### PR TITLE
refactor: centralize OpenAI protocol imports into yasha.openai.protocol

### DIFF
--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -47,8 +47,8 @@ from collections.abc import AsyncGenerator
 from typing import Literal
 
 from yasha.plugins.base_plugin import BasePlugin
-from yasha.infer.infer_config import RawSpeechResponse, YashaModelConfig
-from vllm.entrypoints.openai.engine.protocol import ErrorResponse
+from yasha.infer.infer_config import YashaModelConfig
+from yasha.openai.protocol import ErrorResponse, RawSpeechResponse
 
 
 class ModelPlugin(BasePlugin):

--- a/plugins/bark/bark/bark.py
+++ b/plugins/bark/bark/bark.py
@@ -33,10 +33,9 @@ from typing import Literal
 import torch
 from scipy.io.wavfile import write as write_wav
 from transformers import BarkModel, BarkProcessor
-from vllm.entrypoints.openai.engine.protocol import ErrorResponse
-from vllm.entrypoints.utils import create_error_response
 
-from yasha.infer.infer_config import RawSpeechResponse, YashaModelConfig
+from yasha.infer.infer_config import YashaModelConfig
+from yasha.openai.protocol import ErrorResponse, RawSpeechResponse, create_error_response
 from yasha.plugins.base_plugin import BasePlugin
 
 logger = logging.getLogger("ray")

--- a/plugins/kokoro/kokoro/kokoro.py
+++ b/plugins/kokoro/kokoro/kokoro.py
@@ -35,9 +35,9 @@ import onnxruntime as ort  # type: ignore[import-unresolved]
 from kokoro_onnx import Kokoro  # type: ignore[import-unresolved]
 from scipy.io.wavfile import write as write_wav
 from scipy.signal import resample_poly
-from vllm.entrypoints.openai.engine.protocol import ErrorResponse
 
-from yasha.infer.infer_config import RawSpeechResponse, SpeechResponse, YashaModelConfig
+from yasha.infer.infer_config import YashaModelConfig
+from yasha.openai.protocol import ErrorResponse, RawSpeechResponse, SpeechResponse
 from yasha.plugins.base_plugin import BasePlugin
 from yasha.utils import cache_dir, download
 

--- a/plugins/orpheus/orpheus/orpheus.py
+++ b/plugins/orpheus/orpheus/orpheus.py
@@ -43,11 +43,11 @@ from snac import SNAC  # type: ignore[import-unresolved]
 from transformers import AutoTokenizer
 from vllm import SamplingParams
 from vllm.engine.arg_utils import AsyncEngineArgs
-from vllm.entrypoints.openai.engine.protocol import ErrorResponse
 from vllm.usage.usage_lib import UsageContext
 from vllm.v1.engine.async_llm import AsyncLLM
 
-from yasha.infer.infer_config import RawSpeechResponse, SpeechResponse, YashaModelConfig
+from yasha.infer.infer_config import YashaModelConfig
+from yasha.openai.protocol import ErrorResponse, RawSpeechResponse, SpeechResponse
 from yasha.plugins.base_plugin import BasePlugin
 
 logger = logging.getLogger("ray")

--- a/yasha/infer/custom/custom_infer.py
+++ b/yasha/infer/custom/custom_infer.py
@@ -4,13 +4,19 @@ from collections.abc import AsyncGenerator
 from typing import cast
 
 from starlette.requests import Request
-from vllm.entrypoints.openai.chat_completion.protocol import ChatCompletionRequest
-from vllm.entrypoints.openai.engine.protocol import ErrorInfo, ErrorResponse
-from vllm.entrypoints.openai.speech_to_text.protocol import TranscriptionRequest, TranslationRequest
-from vllm.entrypoints.pooling.embed.protocol import EmbeddingRequest
 
 from yasha.infer.custom.openai.serving_speech import OpenAIServingSpeech
-from yasha.infer.infer_config import DisconnectProxy, ModelUsecase, RawSpeechResponse, SpeechRequest, YashaModelConfig
+from yasha.infer.infer_config import DisconnectProxy, ModelUsecase, YashaModelConfig
+from yasha.openai.protocol import (
+    ChatCompletionRequest,
+    EmbeddingRequest,
+    ErrorInfo,
+    ErrorResponse,
+    RawSpeechResponse,
+    SpeechRequest,
+    TranscriptionRequest,
+    TranslationRequest,
+)
 from yasha.plugins.base_plugin import BasePlugin, PluginProto
 
 logger = logging.getLogger("ray")

--- a/yasha/infer/custom/openai/serving_speech.py
+++ b/yasha/infer/custom/openai/serving_speech.py
@@ -2,13 +2,8 @@ import logging
 from collections.abc import AsyncGenerator
 
 from fastapi import Request
-from vllm.entrypoints.openai.engine.protocol import ErrorResponse
-from vllm.entrypoints.utils import create_error_response
 
-from yasha.infer.infer_config import (
-    RawSpeechResponse,
-    SpeechRequest,
-)
+from yasha.openai.protocol import ErrorResponse, RawSpeechResponse, SpeechRequest, create_error_response
 from yasha.plugins.base_plugin import BasePlugin
 from yasha.utils import base_request_id
 

--- a/yasha/infer/infer_config.py
+++ b/yasha/infer/infer_config.py
@@ -1,13 +1,12 @@
 import asyncio
 from enum import StrEnum
-from typing import Any, Literal
+from typing import Any
 
 import ray
 from fastapi import Request
 from pydantic import BaseModel, Field, model_validator
 from starlette.datastructures import Headers, State
 from vllm.entrypoints.chat_utils import ChatTemplateContentFormatOption
-from vllm.entrypoints.openai.engine.protocol import OpenAIBaseModel
 
 
 class ModelUsecase(StrEnum):
@@ -154,42 +153,3 @@ class DisconnectProxy:
 
     async def is_disconnected(self) -> bool:
         return await self._event.is_set.remote()
-
-
-class SpeechRequest(OpenAIBaseModel):
-    input: str = Field(..., description="The text to generate audio for")
-    model: str = Field(
-        ...,
-        description="The model to use for generation.",
-    )
-    voice: str = Field(
-        ...,
-        description="The voice to use for generation.",
-    )
-    response_format: Literal["mp3", "opus", "aac", "flac", "wav", "pcm"] = Field(
-        default="mp3",
-        description="The format to return audio in.",
-    )
-    speed: float = Field(
-        default=1.0,
-        ge=0.25,
-        le=4.0,
-        description="The speed of the generated audio. Select a value from 0.25 to 4.0.",
-    )
-    stream_format: Literal["sse", "audio"] = Field(
-        default="audio",
-        description="The stream format to return the audio in.",
-    )
-
-
-class SpeechResponse(OpenAIBaseModel):
-    audio: str | None = Field(default=None, description="The generated audio data encoded in base 64")
-    type: Literal["speech.audio.delta", "speech.audio.done"] = Field(
-        ...,
-        description="Type of audio chunk",
-    )
-
-
-class RawSpeechResponse(BaseModel):
-    audio: bytes = Field(..., description="full audio file bytes")
-    media_type: Literal["audio/wav"] = Field(default="audio/wav", description="audio bytes media type")

--- a/yasha/infer/model_deployment.py
+++ b/yasha/infer/model_deployment.py
@@ -3,14 +3,18 @@ from collections.abc import AsyncGenerator
 from typing import Any
 
 from ray import serve
-from vllm.entrypoints.openai.chat_completion.protocol import ChatCompletionRequest
-from vllm.entrypoints.openai.speech_to_text.protocol import TranscriptionRequest, TranslationRequest
-from vllm.entrypoints.pooling.embed.protocol import EmbeddingRequest
 
 from yasha.infer.custom.custom_infer import CustomInfer
-from yasha.infer.infer_config import DisconnectProxy, ModelLoader, SpeechRequest, YashaModelConfig
+from yasha.infer.infer_config import DisconnectProxy, ModelLoader, YashaModelConfig
 from yasha.infer.transformers.transformers_infer import TransformersInfer
 from yasha.infer.vllm.vllm_infer import VllmInfer
+from yasha.openai.protocol import (
+    ChatCompletionRequest,
+    EmbeddingRequest,
+    SpeechRequest,
+    TranscriptionRequest,
+    TranslationRequest,
+)
 
 logger = logging.getLogger("ray.serve")
 

--- a/yasha/infer/transformers/openai/serving_speech.py
+++ b/yasha/infer/transformers/openai/serving_speech.py
@@ -2,13 +2,8 @@ import logging
 from collections.abc import AsyncGenerator
 
 from fastapi import Request
-from vllm.entrypoints.openai.engine.protocol import ErrorResponse
-from vllm.entrypoints.utils import create_error_response
 
-from yasha.infer.infer_config import (
-    RawSpeechResponse,
-    SpeechRequest,
-)
+from yasha.openai.protocol import ErrorResponse, RawSpeechResponse, SpeechRequest, create_error_response
 from yasha.plugins.base_plugin import BasePluginTransformers
 from yasha.utils import base_request_id
 

--- a/yasha/infer/transformers/transformers_infer.py
+++ b/yasha/infer/transformers/transformers_infer.py
@@ -5,13 +5,19 @@ from typing import ClassVar, cast
 
 import torch
 from starlette.requests import Request
-from vllm.entrypoints.openai.chat_completion.protocol import ChatCompletionRequest
-from vllm.entrypoints.openai.engine.protocol import ErrorInfo, ErrorResponse
-from vllm.entrypoints.openai.speech_to_text.protocol import TranscriptionRequest, TranslationRequest
-from vllm.entrypoints.pooling.embed.protocol import EmbeddingRequest
 
-from yasha.infer.infer_config import DisconnectProxy, ModelUsecase, RawSpeechResponse, SpeechRequest, YashaModelConfig
+from yasha.infer.infer_config import DisconnectProxy, ModelUsecase, YashaModelConfig
 from yasha.infer.transformers.openai.serving_speech import OpenAIServingSpeech
+from yasha.openai.protocol import (
+    ChatCompletionRequest,
+    EmbeddingRequest,
+    ErrorInfo,
+    ErrorResponse,
+    RawSpeechResponse,
+    SpeechRequest,
+    TranscriptionRequest,
+    TranslationRequest,
+)
 from yasha.plugins.base_plugin import BasePluginTransformers, PluginProtoTransformers
 
 logger = logging.getLogger("ray")

--- a/yasha/infer/vllm/openai/serving_speech.py
+++ b/yasha/infer/vllm/openai/serving_speech.py
@@ -7,12 +7,10 @@ from fastapi import Request
 from vllm.config.model import ModelConfig
 from vllm.engine.protocol import EngineClient
 from vllm.entrypoints.logger import RequestLogger
-from vllm.entrypoints.openai.engine.protocol import ErrorResponse
 from vllm.entrypoints.openai.engine.serving import OpenAIServing
 from vllm.entrypoints.openai.models.serving import OpenAIServingModels
-from vllm.entrypoints.utils import create_error_response
 
-from yasha.infer.infer_config import RawSpeechResponse, SpeechRequest
+from yasha.openai.protocol import ErrorResponse, RawSpeechResponse, SpeechRequest, create_error_response
 from yasha.plugins.base_plugin import PluginProtoVllm
 
 

--- a/yasha/infer/vllm/vllm_infer.py
+++ b/yasha/infer/vllm/vllm_infer.py
@@ -8,12 +8,25 @@ from vllm.config.model import ModelDType
 from vllm.config.parallel import DistributedExecutorBackend
 from vllm.engine.arg_utils import AsyncEngineArgs
 from vllm.entrypoints.logger import RequestLogger
-from vllm.entrypoints.openai.chat_completion.protocol import ChatCompletionRequest, ChatCompletionResponse
 from vllm.entrypoints.openai.chat_completion.serving import OpenAIServingChat
-from vllm.entrypoints.openai.engine.protocol import ErrorInfo, ErrorResponse
 from vllm.entrypoints.openai.models.protocol import BaseModelPath
 from vllm.entrypoints.openai.models.serving import OpenAIServingModels
-from vllm.entrypoints.openai.speech_to_text.protocol import (
+from vllm.entrypoints.openai.speech_to_text.serving import OpenAIServingTranscription, OpenAIServingTranslation
+from vllm.entrypoints.pooling.embed.serving import ServingEmbedding
+from vllm.entrypoints.serve.render.serving import OpenAIServingRender
+from vllm.usage.usage_lib import UsageContext
+from vllm.v1.engine.async_llm import AsyncLLM
+
+from yasha.infer.infer_config import DisconnectProxy, ModelUsecase, VllmEngineConfig, YashaModelConfig
+from yasha.infer.vllm.openai.serving_speech import OpenAIServingSpeech
+from yasha.openai.protocol import (
+    ChatCompletionRequest,
+    ChatCompletionResponse,
+    EmbeddingRequest,
+    ErrorInfo,
+    ErrorResponse,
+    RawSpeechResponse,
+    SpeechRequest,
     TranscriptionRequest,
     TranscriptionResponse,
     TranscriptionResponseVerbose,
@@ -21,22 +34,6 @@ from vllm.entrypoints.openai.speech_to_text.protocol import (
     TranslationResponse,
     TranslationResponseVerbose,
 )
-from vllm.entrypoints.openai.speech_to_text.serving import OpenAIServingTranscription, OpenAIServingTranslation
-from vllm.entrypoints.pooling.embed.protocol import EmbeddingRequest
-from vllm.entrypoints.pooling.embed.serving import ServingEmbedding
-from vllm.entrypoints.serve.render.serving import OpenAIServingRender
-from vllm.usage.usage_lib import UsageContext
-from vllm.v1.engine.async_llm import AsyncLLM
-
-from yasha.infer.infer_config import (
-    DisconnectProxy,
-    ModelUsecase,
-    RawSpeechResponse,
-    SpeechRequest,
-    VllmEngineConfig,
-    YashaModelConfig,
-)
-from yasha.infer.vllm.openai.serving_speech import OpenAIServingSpeech
 
 logger = logging.getLogger("ray")
 

--- a/yasha/openai/api.py
+++ b/yasha/openai/api.py
@@ -9,17 +9,21 @@ from fastapi.responses import JSONResponse, Response, StreamingResponse
 from pydantic import BaseModel, Field
 from ray import serve
 from ray.serve.handle import DeploymentHandle
-from vllm.entrypoints.openai.chat_completion.protocol import ChatCompletionRequest, ChatCompletionResponse
-from vllm.entrypoints.openai.engine.protocol import ErrorResponse
-from vllm.entrypoints.openai.speech_to_text.protocol import (
+
+from yasha.infer.infer_config import ModelUsecase, RequestWatcher
+from yasha.openai.protocol import (
+    ChatCompletionRequest,
+    ChatCompletionResponse,
+    EmbeddingRequest,
+    EmbeddingResponse,
+    ErrorResponse,
+    RawSpeechResponse,
+    SpeechRequest,
     TranscriptionRequest,
     TranscriptionResponse,
     TranslationRequest,
     TranslationResponse,
 )
-from vllm.entrypoints.pooling.embed.protocol import EmbeddingRequest, EmbeddingResponse
-
-from yasha.infer.infer_config import ModelUsecase, RawSpeechResponse, RequestWatcher, SpeechRequest
 
 logger = logging.getLogger("ray.serve")
 

--- a/yasha/openai/protocol.py
+++ b/yasha/openai/protocol.py
@@ -1,0 +1,106 @@
+"""
+Centralised re-exports of the OpenAI-compatible protocol models used for
+FastAPI request/response validation.
+
+Every backend (vllm, transformers, custom) and the API gateway import from
+here instead of reaching into vllm internals directly.  If the upstream
+module paths change, or we decide to define our own models, only this file
+needs updating.
+"""
+
+from typing import Literal
+
+from pydantic import BaseModel, Field
+
+# -- chat completion --------------------------------------------------------
+from vllm.entrypoints.openai.chat_completion.protocol import (
+    ChatCompletionRequest,
+    ChatCompletionResponse,
+)
+
+# -- engine / base ----------------------------------------------------------
+from vllm.entrypoints.openai.engine.protocol import (
+    ErrorInfo,
+    ErrorResponse,
+    OpenAIBaseModel,
+)
+
+# -- speech-to-text ---------------------------------------------------------
+from vllm.entrypoints.openai.speech_to_text.protocol import (
+    TranscriptionRequest,
+    TranscriptionResponse,
+    TranscriptionResponseVerbose,
+    TranslationRequest,
+    TranslationResponse,
+    TranslationResponseVerbose,
+)
+
+# -- embeddings -------------------------------------------------------------
+from vllm.entrypoints.pooling.embed.protocol import (
+    EmbeddingRequest,
+    EmbeddingResponse,
+)
+
+# -- utilities --------------------------------------------------------------
+from vllm.entrypoints.utils import create_error_response
+
+
+# -- text-to-speech (not yet provided by vllm) ------------------------------
+class SpeechRequest(OpenAIBaseModel):
+    input: str = Field(..., description="The text to generate audio for")
+    model: str = Field(
+        ...,
+        description="The model to use for generation.",
+    )
+    voice: str = Field(
+        ...,
+        description="The voice to use for generation.",
+    )
+    response_format: Literal["mp3", "opus", "aac", "flac", "wav", "pcm"] = Field(
+        default="mp3",
+        description="The format to return audio in.",
+    )
+    speed: float = Field(
+        default=1.0,
+        ge=0.25,
+        le=4.0,
+        description="The speed of the generated audio. Select a value from 0.25 to 4.0.",
+    )
+    stream_format: Literal["sse", "audio"] = Field(
+        default="audio",
+        description="The stream format to return the audio in.",
+    )
+
+
+class SpeechResponse(OpenAIBaseModel):
+    audio: str | None = Field(default=None, description="The generated audio data encoded in base 64")
+    type: Literal["speech.audio.delta", "speech.audio.done"] = Field(
+        ...,
+        description="Type of audio chunk",
+    )
+
+
+class RawSpeechResponse(BaseModel):
+    audio: bytes = Field(..., description="full audio file bytes")
+    media_type: Literal["audio/wav"] = Field(default="audio/wav", description="audio bytes media type")
+
+
+__all__ = [
+    "ChatCompletionRequest",
+    "ChatCompletionResponse",
+    "EmbeddingRequest",
+    "EmbeddingResponse",
+    "ErrorInfo",
+    "ErrorResponse",
+    "OpenAIBaseModel",
+    "RawSpeechResponse",
+    "SpeechRequest",
+    "SpeechResponse",
+    "TranscriptionRequest",
+    "TranscriptionResponse",
+    "TranscriptionResponseVerbose",
+    "TranslationRequest",
+    "TranslationResponse",
+    "TranslationResponseVerbose",
+    "create_error_response",
+]

--- a/yasha/plugins/base_plugin.py
+++ b/yasha/plugins/base_plugin.py
@@ -4,9 +4,9 @@ from typing import Literal, Protocol
 
 from vllm.config.model import ModelConfig
 from vllm.engine.protocol import EngineClient
-from vllm.entrypoints.openai.engine.protocol import ErrorResponse
 
-from yasha.infer.infer_config import RawSpeechResponse, YashaModelConfig
+from yasha.infer.infer_config import YashaModelConfig
+from yasha.openai.protocol import ErrorResponse, RawSpeechResponse
 
 
 class BasePluginVllm(ABC):


### PR DESCRIPTION
.## What

All vllm protocol model imports (ChatCompletionRequest, EmbeddingRequest, ErrorResponse, etc.) and custom TTS models (SpeechRequest, SpeechResponse, RawSpeechResponse) now live in a single module.

## Why

 This decouples every backend and plugin from vllm's internal module paths — if upstream paths change or we define our own models, only protocol.py needs updating

## How to Test

Steps to verify the change works as expected.

## Checklist

- [x] `ruff check .` passes
- [x] `ruff format --check .` passes
- [x] `pyright` passes
