### PR TITLE
feat: add API key authentication middleware

### DIFF
--- a/docs/grafana-dashboard.json
+++ b/docs/grafana-dashboard.json
@@ -59,7 +59,7 @@
     {
       "title": "In-Flight Requests",
       "type": "timeseries",
-      "gridPos": { "h": 8, "w": 4, "x": 16, "y": 1 },
+      "gridPos": { "h": 4, "w": 4, "x": 16, "y": 1 },
       "id": 3,
       "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
       "targets": [
@@ -80,6 +80,22 @@
           "expr": "ray_yasha_models_loaded"
         }
       ]
+    },
+    {
+      "title": "Auth Failures",
+      "type": "timeseries",
+      "gridPos": { "h": 4, "w": 4, "x": 16, "y": 5 },
+      "id": 6,
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "targets": [
+        {
+          "expr": "sum(rate(ray_yasha_auth_failures_total[5m])) by (reason)",
+          "legendFormat": "{{ reason }}"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": { "unit": "reqps" }
+      }
     },
     {
       "title": "Client Disconnects",

--- a/docs/production-readiness.md
+++ b/docs/production-readiness.md
@@ -6,7 +6,7 @@ Future development priorities for making Yasha production-ready, organized by se
 
 ### Security
 
-- [ ] **API authentication layer** — API key or OAuth/JWT-based auth at the gateway level (currently zero auth, relies on network isolation)
+- [x] **API authentication layer** — API key auth at the gateway level via `YASHA_API_KEYS` env var; OpenAI-compatible `Authorization: Bearer <key>` header
 - [ ] **Rate limiting** — per-user/IP/model throttling to prevent GPU resource monopolization
 - [ ] **Input size limits** — max prompt length and max_tokens enforcement at the gateway to prevent GPU OOM
 - [ ] **Lock down CORS** — replace wildcard `*` origins with environment-specific allowed origins

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,0 +1,126 @@
+"""Tests for API key authentication middleware."""
+
+import os
+from unittest.mock import patch
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from starlette.requests import Request
+from starlette.responses import JSONResponse
+
+from yasha.openai.auth import ApiKeyMiddleware, get_api_keys
+
+
+def _make_app(api_keys: set[str]) -> FastAPI:
+    """Build a minimal FastAPI app with the auth middleware for testing."""
+    app = FastAPI()
+    app.add_middleware(ApiKeyMiddleware, api_keys=api_keys)
+
+    @app.get("/health")
+    async def health():
+        return {"status": "ok"}
+
+    @app.get("/v1/models")
+    async def models():
+        return {"object": "list", "data": []}
+
+    @app.post("/v1/chat/completions")
+    async def chat(request: Request):
+        return JSONResponse({"id": "test"})
+
+    return app
+
+
+VALID_KEY = "sk-test-key-123"
+OTHER_KEY = "sk-other-key-456"
+KEYS = {VALID_KEY, OTHER_KEY}
+
+
+class TestApiKeyMiddleware:
+    def test_valid_key_allows_request(self):
+        client = TestClient(_make_app(KEYS))
+        resp = client.get("/v1/models", headers={"Authorization": f"Bearer {VALID_KEY}"})
+        assert resp.status_code == 200
+
+    def test_other_valid_key_allows_request(self):
+        client = TestClient(_make_app(KEYS))
+        resp = client.get("/v1/models", headers={"Authorization": f"Bearer {OTHER_KEY}"})
+        assert resp.status_code == 200
+
+    def test_missing_auth_header_returns_401(self):
+        client = TestClient(_make_app(KEYS))
+        resp = client.get("/v1/models")
+        assert resp.status_code == 401
+        assert "Missing API key" in resp.json()["error"]["message"]
+
+    def test_empty_bearer_returns_401(self):
+        client = TestClient(_make_app(KEYS))
+        resp = client.get("/v1/models", headers={"Authorization": "Bearer "})
+        assert resp.status_code == 401
+        assert "Missing API key" in resp.json()["error"]["message"]
+
+    def test_invalid_key_returns_401(self):
+        client = TestClient(_make_app(KEYS))
+        resp = client.get("/v1/models", headers={"Authorization": "Bearer wrong-key"})
+        assert resp.status_code == 401
+        assert "Invalid API key" in resp.json()["error"]["message"]
+
+    def test_non_bearer_auth_returns_401(self):
+        client = TestClient(_make_app(KEYS))
+        resp = client.get("/v1/models", headers={"Authorization": f"Basic {VALID_KEY}"})
+        assert resp.status_code == 401
+
+    def test_health_endpoint_bypasses_auth(self):
+        client = TestClient(_make_app(KEYS))
+        resp = client.get("/health")
+        assert resp.status_code == 200
+        assert resp.json() == {"status": "ok"}
+
+    def test_post_endpoint_requires_auth(self):
+        client = TestClient(_make_app(KEYS))
+        resp = client.post("/v1/chat/completions", json={})
+        assert resp.status_code == 401
+
+    def test_post_endpoint_with_valid_key(self):
+        client = TestClient(_make_app(KEYS))
+        resp = client.post(
+            "/v1/chat/completions",
+            json={},
+            headers={"Authorization": f"Bearer {VALID_KEY}"},
+        )
+        assert resp.status_code == 200
+
+    def test_error_response_format(self):
+        client = TestClient(_make_app(KEYS))
+        resp = client.get("/v1/models")
+        body = resp.json()
+        assert "error" in body
+        assert body["error"]["type"] == "auth_error"
+        assert body["error"]["code"] == 401
+
+
+class TestGetApiKeys:
+    def test_returns_keys_from_env(self):
+        with patch.dict(os.environ, {"YASHA_API_KEYS": "sk-a,sk-b,sk-c"}):
+            keys = get_api_keys()
+        assert keys == {"sk-a", "sk-b", "sk-c"}
+
+    def test_strips_whitespace(self):
+        with patch.dict(os.environ, {"YASHA_API_KEYS": " sk-a , sk-b "}):
+            keys = get_api_keys()
+        assert keys == {"sk-a", "sk-b"}
+
+    def test_empty_env_returns_empty_set(self):
+        with patch.dict(os.environ, {"YASHA_API_KEYS": ""}):
+            keys = get_api_keys()
+        assert keys == set()
+
+    def test_unset_env_returns_empty_set(self):
+        with patch.dict(os.environ, {}, clear=True):
+            keys = get_api_keys()
+        assert keys == set()
+
+    def test_ignores_empty_entries(self):
+        with patch.dict(os.environ, {"YASHA_API_KEYS": "sk-a,,,,sk-b,"}):
+            keys = get_api_keys()
+        assert keys == {"sk-a", "sk-b"}

--- a/yasha/metrics.py
+++ b/yasha/metrics.py
@@ -71,6 +71,7 @@ def _build_metrics():
             "embedding_duration_seconds": _NoOpHistogram(),
             # Resource cleanup
             "resource_cleanup_errors_total": _NoOpCounter(),
+            "auth_failures_total": _NoOpCounter(),
         }
 
     from ray.serve.metrics import Counter, Gauge, Histogram
@@ -157,6 +158,12 @@ def _build_metrics():
             boundaries=_REQUEST_LATENCY_BOUNDARIES,
             tag_keys=("model",),
         ),
+        # -- Authentication --
+        "auth_failures_total": Counter(
+            "yasha_auth_failures_total",
+            description="Total rejected requests due to invalid/missing API key.",
+            tag_keys=("reason",),
+        ),
         # -- Resource cleanup --
         "resource_cleanup_errors_total": Counter(
             "yasha_resource_cleanup_errors_total",
@@ -187,6 +194,9 @@ TTS_GENERATION_DURATION_SECONDS = _metrics["tts_generation_duration_seconds"]
 IMAGE_GENERATION_DURATION_SECONDS = _metrics["image_generation_duration_seconds"]
 TRANSCRIPTION_DURATION_SECONDS = _metrics["transcription_duration_seconds"]
 EMBEDDING_DURATION_SECONDS = _metrics["embedding_duration_seconds"]
+
+# -- Authentication --
+AUTH_FAILURES_TOTAL = _metrics["auth_failures_total"]
 
 # -- Resource cleanup --
 RESOURCE_CLEANUP_ERRORS_TOTAL = _metrics["resource_cleanup_errors_total"]

--- a/yasha/openai/api.py
+++ b/yasha/openai/api.py
@@ -19,6 +19,7 @@ from yasha.metrics import (
     REQUEST_TOTAL,
     STREAM_CHUNKS_TOTAL,
 )
+from yasha.openai.auth import ApiKeyMiddleware, get_api_keys
 from yasha.openai.protocol import (
     ChatCompletionRequest,
     ChatCompletionResponse,
@@ -47,6 +48,13 @@ def build_app():
         allow_methods=["*"],
         allow_headers=["*"],
     )
+
+    api_keys = get_api_keys()
+    if api_keys:
+        app.add_middleware(ApiKeyMiddleware, api_keys=api_keys)
+        logger.info("API key authentication enabled (%d key(s))", len(api_keys))
+    else:
+        logger.warning("API key authentication disabled (YASHA_API_KEYS not set)")
 
     @app.exception_handler(HTTPException)
     async def log_http_exception(request: Request, exc: HTTPException):

--- a/yasha/openai/auth.py
+++ b/yasha/openai/auth.py
@@ -1,0 +1,58 @@
+import hmac
+import logging
+import os
+
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.requests import Request
+from starlette.responses import JSONResponse
+
+from yasha.metrics import AUTH_FAILURES_TOTAL
+
+logger = logging.getLogger("ray.serve")
+
+_PUBLIC_PATHS = {"/health"}
+
+
+class ApiKeyMiddleware(BaseHTTPMiddleware):
+    """Validates ``Authorization: Bearer <key>`` against a set of allowed API keys."""
+
+    def __init__(self, app, api_keys: set[str]):
+        super().__init__(app)
+        self.api_keys = api_keys
+
+    async def dispatch(self, request: Request, call_next):
+        if request.url.path in _PUBLIC_PATHS:
+            return await call_next(request)
+
+        auth = request.headers.get("authorization", "")
+        token = auth[7:] if auth.startswith("Bearer ") else ""
+
+        if not token:
+            AUTH_FAILURES_TOTAL.inc(tags={"reason": "missing"})
+            logger.warning("auth failed (missing key): %s %s", request.method, request.url.path)
+            return JSONResponse(
+                status_code=401,
+                content={
+                    "error": {
+                        "message": "Missing API key. Use Authorization: Bearer <key>.",
+                        "type": "auth_error",
+                        "code": 401,
+                    }
+                },
+            )
+
+        if not any(hmac.compare_digest(token, key) for key in self.api_keys):
+            AUTH_FAILURES_TOTAL.inc(tags={"reason": "invalid"})
+            logger.warning("auth failed (invalid key): %s %s", request.method, request.url.path)
+            return JSONResponse(
+                status_code=401,
+                content={"error": {"message": "Invalid API key.", "type": "auth_error", "code": 401}},
+            )
+
+        return await call_next(request)
+
+
+def get_api_keys() -> set[str]:
+    """Read allowed API keys from the ``YASHA_API_KEYS`` environment variable (comma-separated)."""
+    raw = os.environ.get("YASHA_API_KEYS", "")
+    return {k.strip() for k in raw.split(",") if k.strip()}


### PR DESCRIPTION
Add OpenAI-compatible Bearer token auth at the gateway level. Keys are configured via YASHA_API_KEYS env var (comma-separated). Auth is disabled when the env var is unset, preserving backward compatibility. /health is exempt for load balancer probes. Includes yasha_auth_failures_total Prometheus metric, Grafana dashboard panel, and 15 tests.


