### PR TITLE
feat: add syslog and OpenTelemetry log export

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ For a full guide on writing your own plugin, see [Plugin Development](docs/plugi
 
 Modelship exposes Prometheus metrics (Ray cluster, Ray Serve, vLLM, and custom `modelship:*` metrics) through a single scrape endpoint on port 8079. Metrics are **enabled by default** — set `MSHIP_METRICS=false` to disable. A pre-built Grafana dashboard is included.
 
-Logging supports structured JSON output (`MSHIP_LOG_FORMAT=json`) and request ID correlation across Ray actor boundaries. Set `MSHIP_LOG_LEVEL` to `DEBUG` for request bodies or `TRACE` to include library internals.
+Logging supports structured JSON output (`MSHIP_LOG_FORMAT=json`) and request ID correlation across Ray actor boundaries. Logs can be shipped to a remote syslog server (`--log-target syslog://host:514`) or an OpenTelemetry collector (`--otel-endpoint http://collector:4317`). Set `MSHIP_LOG_LEVEL` to `DEBUG` for request bodies or `TRACE` to include library internals.
 
 See [Monitoring & Logging](docs/monitoring.md) for full details.
 
@@ -165,7 +165,7 @@ See the full [Production Readiness Plan](docs/production-readiness.md) for detai
 |------------------------------|-------|----------|
 | Architecture & Design        | 8/10  | Add K8s manifests, improve health checks |
 | Monitoring (metrics)         | 9/10  | Excellent — Prometheus + Grafana ready |
-| Monitoring (alerting + logs) | 7/10  | Structured logging + request correlation done; alerting rules still needed |
+| Monitoring (alerting + logs) | 8/10  | Syslog + OTel log export done; alerting rules still needed |
 | Security                     | 4/10  | No rate limiting, open CORS, no plugin sandboxing |
 | Resilience                   | 5/10  | Good shutdown, weak self-healing |
 | Testing                      | 3/10  | Config tests only, no integration/API tests |

--- a/docs/model-configuration.md
+++ b/docs/model-configuration.md
@@ -17,6 +17,8 @@ Models are configured in a YAML file (default: `config/models.yaml`). Each entry
 | `--cache-dir` | `MSHIP_CACHE_DIR` | `/modelship/.cache/models` | Model cache directory |
 | `--log-level` | `MSHIP_LOG_LEVEL` | `INFO` | Log level |
 | `--log-format` | `MSHIP_LOG_FORMAT` | `text` | Log format (`text` or `json`) |
+| `--log-target` | `MSHIP_LOG_TARGET` | `console` | Log target: `console` or syslog URI (e.g. `syslog://host:514`, `syslog+tcp://host:514`) |
+| `--otel-endpoint` | `OTEL_EXPORTER_OTLP_ENDPOINT` | — | OpenTelemetry OTLP endpoint (e.g. `http://collector:4317`) |
 | `--no-metrics` | `MSHIP_METRICS` | enabled | Disable Prometheus metrics |
 | `--api-keys` | `MSHIP_API_KEYS` | — | Comma-separated API keys |
 | `--max-request-body-bytes` | `MSHIP_MAX_REQUEST_BODY_BYTES` | `52428800` | Max request body size in bytes |
@@ -245,6 +247,8 @@ In this example, requests to model `kokoro` are distributed across three backend
 | `MSHIP_CACHE_DIR` | Model cache directory (HuggingFace + plugins) | `/modelship/.cache/models` |
 | `MSHIP_GATEWAY_NAME` | Name for the API gateway app | `modelship api` |
 | `MSHIP_MAX_REQUEST_BODY_BYTES` | Maximum allowed request body size in bytes | `52428800` (50 MB) |
+| `MSHIP_LOG_TARGET` | Log target: `console` or syslog URI (e.g. `syslog://host:514`, `syslog+tcp://host:514`) | `console` |
+| `OTEL_EXPORTER_OTLP_ENDPOINT` | OpenTelemetry OTLP endpoint for log export (e.g. `http://collector:4317`). Requires `uv sync --extra otel`. | — |
 | `CUDA_DEVICE_ORDER` | GPU enumeration order; set to `PCI_BUS_ID` for deterministic ordering in multi-GPU systems | `PCI_BUS_ID` |
 | `RAY_REDIS_PORT` | Ray GCS server port | `6379` |
 | `RAY_DASHBOARD_PORT` | Ray dashboard port | `8265` |

--- a/docs/monitoring.md
+++ b/docs/monitoring.md
@@ -12,6 +12,8 @@ Modelship uses a centralized logging system with structured output and request c
 |---|---|---|
 | `MSHIP_LOG_LEVEL` | `INFO` | App log level. Set to `DEBUG` for full request/response bodies. Set to `TRACE` to also enable library debug logs. |
 | `MSHIP_LOG_FORMAT` | `text` | `text` for human-readable output, `json` for structured JSON lines (for log aggregation with ELK/Loki/Splunk). |
+| `MSHIP_LOG_TARGET` | `console` | Log target. `console` writes to stderr; syslog URIs ship logs to a remote syslog server (see below). |
+| `OTEL_EXPORTER_OTLP_ENDPOINT` | — | When set, logs are also exported to an OpenTelemetry collector via OTLP (see below). |
 
 ### Log Levels
 
@@ -49,6 +51,59 @@ JSON format example:
 | `modelship.infer.diffusers` | Diffusers inference backend |
 | `modelship.infer.custom` | Custom/plugin inference backend |
 | `modelship.plugin.<name>` | Individual plugins (kokoro, bark, orpheus) |
+
+### Syslog
+
+Ship logs to a remote syslog server instead of stderr. Useful for centralized logging on bare-metal or Unraid setups without extra infrastructure.
+
+```bash
+# UDP (default)
+python start.py --log-target syslog://192.168.1.50:514
+
+# TCP (reliable delivery)
+python start.py --log-target syslog+tcp://192.168.1.50:514
+
+# Via environment variable
+MSHIP_LOG_TARGET=syslog://192.168.1.50:514 python start.py
+```
+
+Supported URI formats:
+
+| URI | Protocol | Notes |
+|---|---|---|
+| `syslog://host:port` | UDP | Default, fire-and-forget |
+| `syslog+tcp://host:port` | TCP | Reliable delivery |
+| `syslog://host` | UDP | Port defaults to 514 |
+
+The syslog target replaces the console handler — logs go to the syslog server only. The `--log-format` setting still applies (text or JSON).
+
+### OpenTelemetry
+
+Export logs to an OpenTelemetry collector via OTLP. Unlike syslog, OTel is additive — logs still go to the console (or syslog) handler, and are also shipped to the collector.
+
+First, install the optional dependencies:
+
+```bash
+uv sync --extra otel
+```
+
+Then configure the endpoint:
+
+```bash
+# Via CLI
+python start.py --otel-endpoint http://collector:4317
+
+# Via environment variable
+OTEL_EXPORTER_OTLP_ENDPOINT=http://collector:4317 python start.py
+```
+
+When OTel is enabled:
+- Logs are exported via `BatchLogRecordProcessor` with `OTLPLogExporter` (gRPC)
+- The service name is set to `modelship`
+- `RAY_TRACING_ENABLED=1` is set automatically so Ray workers also export traces
+- HTTPS endpoints are detected from the URI scheme; all others use insecure connections
+
+If the `opentelemetry-sdk` and `opentelemetry-exporter-otlp` packages are not installed, a warning is logged and OTel is skipped.
 
 ## Architecture
 

--- a/docs/production-readiness.md
+++ b/docs/production-readiness.md
@@ -44,6 +44,8 @@ Future development priorities for making Modelship production-ready, organized b
 - [x] **Structured logging (JSON)** — `MSHIP_LOG_FORMAT=json` for log aggregation (ELK/Loki/Splunk)
 - [x] **Request-ID correlation** — trace a request from gateway through Ray actor boundaries via `contextvars`
 - [x] **Log level configuration** — `MSHIP_LOG_LEVEL` controls app logs; `TRACE` enables library debug logs
+- [x] **Syslog support** — `--log-target syslog://host:port` ships logs to a remote syslog server (UDP or TCP)
+- [x] **OpenTelemetry log export** — `--otel-endpoint` ships logs (and enables Ray traces) via OTLP to any OTel collector
 
 ### Resilience
 
@@ -95,7 +97,7 @@ Future development priorities for making Modelship production-ready, organized b
 |------------------------------|---------|--------|
 | Architecture & Design        | 8/10    | 9/10   |
 | Monitoring (metrics)         | 9/10    | 9/10   |
-| Monitoring (alerting + logs) | 7/10    | 8/10   |
+| Monitoring (alerting + logs) | 8/10    | 9/10   |
 | Security                     | 4/10    | 8/10   |
 | Resilience                   | 5/10    | 8/10   |
 | Testing                      | 3/10    | 7/10   |

--- a/modelship/logging.py
+++ b/modelship/logging.py
@@ -124,6 +124,7 @@ def configure_logging() -> None:
         os.environ.setdefault(env_var, lib_level_name)
 
 
+# pyright: reportMissingImports=false
 def _setup_otel(root_logger: logging.Logger, endpoint: str, level: int) -> None:
     """Attach an OpenTelemetry log exporter to *root_logger*.
 
@@ -132,11 +133,11 @@ def _setup_otel(root_logger: logging.Logger, endpoint: str, level: int) -> None:
     """
     try:
         from opentelemetry.exporter.otlp.proto.grpc.log_exporter import (
-            OTLPLogExporter,  # pyright: ignore[reportMissingImports]
+            OTLPLogExporter,
         )
-        from opentelemetry.sdk._logs import LoggerProvider, LoggingHandler  # pyright: ignore[reportMissingImports]
-        from opentelemetry.sdk._logs.export import BatchLogRecordProcessor  # pyright: ignore[reportMissingImports]
-        from opentelemetry.sdk.resources import SERVICE_NAME, Resource  # pyright: ignore[reportMissingImports]
+        from opentelemetry.sdk._logs import LoggerProvider, LoggingHandler
+        from opentelemetry.sdk._logs.export import BatchLogRecordProcessor
+        from opentelemetry.sdk.resources import SERVICE_NAME, Resource
     except ImportError:
         root_logger.warning(
             "OTEL_EXPORTER_OTLP_ENDPOINT is set but opentelemetry packages are not installed. "

--- a/modelship/logging.py
+++ b/modelship/logging.py
@@ -2,6 +2,9 @@ import contextvars
 import json
 import logging
 import os
+import socket
+from logging.handlers import SysLogHandler
+from urllib.parse import urlparse
 
 request_id_var: contextvars.ContextVar[str | None] = contextvars.ContextVar("request_id", default=None)
 
@@ -57,6 +60,23 @@ _LIB_ENV_VARS = {
 }
 
 
+def _parse_syslog_target(target: str) -> SysLogHandler:
+    """Parse a syslog URI and return a configured SysLogHandler.
+
+    Supported formats:
+        syslog://host:port       — UDP (default)
+        syslog+tcp://host:port   — TCP
+        syslog://host            — UDP, port 514
+    """
+    tcp = target.startswith("syslog+tcp://")
+    url = target.replace("syslog+tcp://", "syslog://", 1)
+    parsed = urlparse(url)
+    host = parsed.hostname or "localhost"
+    port = parsed.port or 514
+    socktype = socket.SOCK_STREAM if tcp else socket.SOCK_DGRAM
+    return SysLogHandler(address=(host, port), socktype=socktype)
+
+
 def configure_logging() -> None:
     global _configured
     if _configured:
@@ -65,6 +85,7 @@ def configure_logging() -> None:
 
     level_name = os.environ.get("MSHIP_LOG_LEVEL", "INFO").upper()
     log_format = os.environ.get("MSHIP_LOG_FORMAT", "text").lower()
+    log_target = os.environ.get("MSHIP_LOG_TARGET", "console").lower()
 
     trace_mode = level_name == "TRACE"
     app_level = logging.DEBUG if trace_mode else getattr(logging, level_name, logging.INFO)
@@ -78,7 +99,7 @@ def configure_logging() -> None:
     if root_logger.handlers:
         return
 
-    handler = logging.StreamHandler()
+    handler = _parse_syslog_target(log_target) if log_target.startswith("syslog") else logging.StreamHandler()
     handler.setLevel(app_level)
 
     if log_format == "json":
@@ -89,6 +110,11 @@ def configure_logging() -> None:
     handler.addFilter(RequestIdFilter())
     root_logger.addHandler(handler)
 
+    # OpenTelemetry: add an OTLP log exporter as a second handler when configured.
+    otel_endpoint = os.environ.get("OTEL_EXPORTER_OTLP_ENDPOINT")
+    if otel_endpoint:
+        _setup_otel(root_logger, otel_endpoint, app_level)
+
     # Set library log levels via both the Python logger (immediate effect) and
     # the library's native env var (so the level sticks when the library
     # re-configures its own loggers later, e.g. vLLM's init_logger).
@@ -96,6 +122,38 @@ def configure_logging() -> None:
         logging.getLogger(name).setLevel(lib_level)
     for env_var in _LIB_ENV_VARS:
         os.environ.setdefault(env_var, lib_level_name)
+
+
+def _setup_otel(root_logger: logging.Logger, endpoint: str, level: int) -> None:
+    """Attach an OpenTelemetry log exporter to *root_logger*.
+
+    Requires the ``opentelemetry-sdk`` and ``opentelemetry-exporter-otlp``
+    packages (install via ``uv sync --extra otel``).
+    """
+    try:
+        from opentelemetry.exporter.otlp.proto.grpc.log_exporter import (
+            OTLPLogExporter,  # pyright: ignore[reportMissingImports]
+        )
+        from opentelemetry.sdk._logs import LoggerProvider, LoggingHandler  # pyright: ignore[reportMissingImports]
+        from opentelemetry.sdk._logs.export import BatchLogRecordProcessor  # pyright: ignore[reportMissingImports]
+        from opentelemetry.sdk.resources import SERVICE_NAME, Resource  # pyright: ignore[reportMissingImports]
+    except ImportError:
+        root_logger.warning(
+            "OTEL_EXPORTER_OTLP_ENDPOINT is set but opentelemetry packages are not installed. "
+            "Install with: uv sync --extra otel"
+        )
+        return
+
+    resource = Resource.create({SERVICE_NAME: "modelship"})
+    provider = LoggerProvider(resource=resource)
+    exporter = OTLPLogExporter(endpoint=endpoint, insecure=not endpoint.startswith("https"))
+    provider.add_log_record_processor(BatchLogRecordProcessor(exporter))
+
+    otel_handler = LoggingHandler(level=level, logger_provider=provider)
+    root_logger.addHandler(otel_handler)
+
+    # Enable Ray's native OTel tracing so spans from Ray workers are exported too.
+    os.environ.setdefault("RAY_TRACING_ENABLED", "1")
 
 
 def get_logger(name: str) -> logging.Logger:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,10 @@ dependencies = [
 kokoro = ["kokoro"]
 bark = ["bark"]
 orpheus = ["orpheus"]
+otel = [
+    "opentelemetry-sdk>=1.20.0",
+    "opentelemetry-exporter-otlp>=1.20.0",
+]
 dev = [
     "ruff>=0.11.0",
     "pyright>=1.1.400",

--- a/start.py
+++ b/start.py
@@ -57,6 +57,14 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         help="Log level (env: MSHIP_LOG_LEVEL)",
     )
     parser.add_argument("--log-format", choices=["text", "json"], help="Log format (env: MSHIP_LOG_FORMAT)")
+    parser.add_argument(
+        "--log-target",
+        help="Log target: 'console' (default) or syslog URI e.g. syslog://host:514, syslog+tcp://host:514 (env: MSHIP_LOG_TARGET)",
+    )
+    parser.add_argument(
+        "--otel-endpoint",
+        help="OpenTelemetry OTLP endpoint e.g. http://collector:4317 (env: OTEL_EXPORTER_OTLP_ENDPOINT)",
+    )
     parser.add_argument("--no-metrics", action="store_true", default=None, help="Disable metrics (env: MSHIP_METRICS)")
     parser.add_argument("--api-keys", help="Comma-separated API keys (env: MSHIP_API_KEYS)")
     parser.add_argument(
@@ -79,6 +87,8 @@ def _apply_args_to_env(args: argparse.Namespace) -> None:
         "cache_dir": "MSHIP_CACHE_DIR",
         "log_level": "MSHIP_LOG_LEVEL",
         "log_format": "MSHIP_LOG_FORMAT",
+        "log_target": "MSHIP_LOG_TARGET",
+        "otel_endpoint": "OTEL_EXPORTER_OTLP_ENDPOINT",
         "api_keys": "MSHIP_API_KEYS",
         "gateway_name": "MSHIP_GATEWAY_NAME",
     }

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -3,6 +3,8 @@
 import json
 import logging
 import os
+import socket
+from logging.handlers import SysLogHandler
 from unittest.mock import patch
 
 import pytest
@@ -13,6 +15,8 @@ from modelship.logging import (
     ModelshipJsonFormatter,
     ModelshipTextFormatter,
     RequestIdFilter,
+    _parse_syslog_target,
+    _setup_otel,
     configure_logging,
     get_logger,
     request_id_var,
@@ -215,3 +219,75 @@ class TestEndToEnd:
         parsed = json.loads(captured.err)
         assert parsed["request_id"] == "json-test-id"
         assert parsed["message"] == "json test"
+
+
+class TestParseSyslogTarget:
+    def test_udp_default(self):
+        handler = _parse_syslog_target("syslog://192.168.1.50:514")
+        assert handler.address == ("192.168.1.50", 514)
+        assert handler.socktype == socket.SOCK_DGRAM
+
+    @patch("modelship.logging.SysLogHandler.createSocket")
+    def test_tcp(self, _mock_create):
+        handler = _parse_syslog_target("syslog+tcp://127.0.0.1:1514")
+        assert handler.address == ("127.0.0.1", 1514)
+        assert handler.socktype == socket.SOCK_STREAM
+
+    def test_default_port(self):
+        handler = _parse_syslog_target("syslog://127.0.0.1")
+        assert handler.address == ("127.0.0.1", 514)
+        assert handler.socktype == socket.SOCK_DGRAM
+
+    def test_default_host(self):
+        handler = _parse_syslog_target("syslog://")
+        assert handler.address == ("localhost", 514)
+
+
+class TestSyslogLogTarget:
+    @patch.dict(os.environ, {"MSHIP_LOG_TARGET": "syslog://127.0.0.1:5140"})
+    def test_configure_creates_syslog_handler(self):
+        configure_logging()
+        root = logging.getLogger("modelship")
+        assert len(root.handlers) == 1
+        assert isinstance(root.handlers[0], SysLogHandler)
+
+    def test_console_default(self):
+        configure_logging()
+        root = logging.getLogger("modelship")
+        assert len(root.handlers) == 1
+        assert isinstance(root.handlers[0], logging.StreamHandler)
+        assert not isinstance(root.handlers[0], SysLogHandler)
+
+
+class TestOtelSetup:
+    def test_warns_when_packages_missing(self, capsys):
+        """When otel packages aren't installed, _setup_otel logs a warning and adds no handler."""
+        root = logging.getLogger("modelship")
+        root.handlers.clear()
+        sh = logging.StreamHandler()
+        root.addHandler(sh)
+        root.setLevel(logging.DEBUG)
+
+        _setup_otel(root, "http://localhost:4317", logging.INFO)
+
+        captured = capsys.readouterr()
+        assert "opentelemetry packages are not installed" in captured.err
+        assert len(root.handlers) == 1
+
+    @patch.dict(os.environ, {"OTEL_EXPORTER_OTLP_ENDPOINT": "http://collector:4317"})
+    @patch("modelship.logging._setup_otel")
+    def test_configure_calls_setup_otel(self, mock_setup):
+        configure_logging()
+        mock_setup.assert_called_once_with(
+            logging.getLogger("modelship"),
+            "http://collector:4317",
+            logging.INFO,
+        )
+
+    @patch.dict(os.environ, {}, clear=False)
+    def test_configure_skips_otel_when_not_set(self):
+        os.environ.pop("OTEL_EXPORTER_OTLP_ENDPOINT", None)
+        configure_logging()
+        root = logging.getLogger("modelship")
+        assert len(root.handlers) == 1
+        assert isinstance(root.handlers[0], logging.StreamHandler)


### PR DESCRIPTION
Add --log-target for shipping logs to a remote syslog server (UDP/TCP) and --otel-endpoint for exporting logs to an OpenTelemetry collector via OTLP. Syslog replaces the console handler; OTel is additive. OTel deps are optional (uv sync --extra otel).


