### PR TITLE
full CPU/GPU inference support via HuggingFace Transformers

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Modelship
 
-Self-hosted, multi-model AI inference server. Runs LLMs alongside specialized models (TTS, speech-to-text, embeddings, image generation) on one or more GPUs, exposing an OpenAI-compatible API. Built on [vLLM](https://github.com/vllm-project/vllm) and [Ray](https://github.com/ray-project/ray).
+Self-hosted, multi-model AI inference server. Runs LLMs alongside specialized models (TTS, speech-to-text, embeddings, image generation) on GPU or CPU, exposing an OpenAI-compatible API. Built on [Ray Serve](https://docs.ray.io/en/latest/serve/index.html) with pluggable inference backends: [vLLM](https://github.com/vllm-project/vllm) for high-throughput GPU inference, [HuggingFace Transformers](https://github.com/huggingface/transformers) for CPU and lightweight GPU workloads, [Diffusers](https://github.com/huggingface/diffusers) for image generation, and a plugin system for custom backends.
 
 ## Architecture
 
@@ -15,33 +15,51 @@ graph TD
     API -->|round-robin| TTS
     API -->|round-robin| STT
     API -->|round-robin| EMB
+    API -->|round-robin| IMG
 
-    subgraph GPU0["GPU 0"]
+    subgraph GPU0["GPU 0 — vLLM"]
         LLM_GPU["LLM Deployment<br/>e.g. Llama 3.1 8B<br/>70% GPU"]
         TTS["TTS Deployment<br/>e.g. Kokoro 82M<br/>5% GPU"]
     end
 
-    subgraph GPU1["GPU 1"]
-        STT["STT Deployment<br/>e.g. Whisper<br/>50% GPU"]
+    subgraph GPU1["GPU 1 — Mixed backends"]
+        STT["STT Deployment (vLLM)<br/>e.g. Whisper Large<br/>50% GPU"]
         EMB["Embedding Deployment<br/>e.g. Nomic Embed<br/>50% GPU"]
     end
 
-    subgraph CPU["CPU-only"]
-        LLM_CPU["LLM Deployment<br/>e.g. Llama 3.1 8B<br/>CPU-only replica"]
+    subgraph CPU["CPU — Transformers"]
+        LLM_CPU["LLM Deployment<br/>e.g. Qwen3-0.6B<br/>CPU-only"]
+        STT_CPU["STT Deployment<br/>e.g. Whisper Small<br/>CPU-only"]
+    end
+
+    subgraph GPU2["GPU 2 — Diffusers"]
+        IMG["Image Generation<br/>e.g. SDXL Turbo<br/>35% GPU"]
     end
 ```
 
-Each model runs as an isolated [Ray Serve](https://docs.ray.io/en/latest/serve/index.html) deployment with its own lifecycle, health checks, and resource budget. Models can be deployed across multiple GPUs, run on CPU-only, or both — multiple deployments of the same model (e.g. one on GPU, one on CPU) are load-balanced with round-robin routing. Each deployment can also scale horizontally with `num_replicas`.
+Each model runs as an isolated [Ray Serve](https://docs.ray.io/en/latest/serve/index.html) deployment with its own lifecycle, health checks, and resource budget. Four inference backends are available:
+
+| Backend | Best for | GPU required |
+|---|---|---|
+| **vLLM** | High-throughput chat, embeddings, transcription | Yes |
+| **Transformers** | Chat, embeddings, transcription, TTS on CPU or lightweight GPU | No |
+| **Diffusers** | Image generation | Yes |
+| **Custom (plugins)** | TTS backends (Kokoro, Bark, Orpheus) | No |
+
+Models can be deployed across multiple GPUs, run on CPU-only, or both — multiple deployments of the same model (e.g. one on GPU via vLLM, one on CPU via Transformers) are load-balanced with round-robin routing. Each deployment can also scale horizontally with `num_replicas`.
 
 ## Requirements
 
-- **NVIDIA GPU** — 16 GB+ VRAM recommended for a full stack (LLM + TTS + STT + embeddings); 8 GB is sufficient for lighter setups
-- **Docker** with [NVIDIA Container Toolkit](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/install-guide.html)
+- **Docker** (or Python 3.12+ with `uv` for local development)
+- **NVIDIA GPU** (optional) — 16 GB+ VRAM recommended for a full stack (LLM + TTS + STT + embeddings) via vLLM; 8 GB is sufficient for lighter setups. Not required when using the Transformers backend on CPU
+- **[NVIDIA Container Toolkit](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/install-guide.html)** — required only when running GPU models in Docker
 - **HuggingFace token** for gated models
 
 ## Features
 
-- **Multi-model, multi-GPU** — run chat, embedding, STT, TTS, and image generation models simultaneously across one or more GPUs with tunable per-model GPU memory allocation; models can also run on CPU-only
+- **Multi-model, multi-GPU** — run chat, embedding, STT, TTS, and image generation models simultaneously across one or more GPUs with tunable per-model GPU memory allocation
+- **CPU-only support** — run models without a GPU using the Transformers backend (chat, embeddings, transcription, TTS). Useful for development, testing, or small models that don't need GPU acceleration
+- **Multiple inference backends** — vLLM for high-throughput GPU inference, HuggingFace Transformers for CPU and lightweight GPU workloads, Diffusers for image generation, and a plugin system for custom backends
 - **Per-model isolated deployments** — each model runs in its own Ray Serve deployment with independent lifecycle, health checks, failure isolation, and configurable replica count
 - **OpenAI-compatible API** — drop-in replacement for any OpenAI SDK client
 - **Streaming** — SSE streaming for chat completions and TTS audio
@@ -153,7 +171,7 @@ For a full guide on writing your own plugin, see [Plugin Development](docs/plugi
 
 Modelship exposes Prometheus metrics (Ray cluster, Ray Serve, vLLM, and custom `modelship:*` metrics) through a single scrape endpoint on port 8079. Metrics are **enabled by default** — set `MSHIP_METRICS=false` to disable. A pre-built Grafana dashboard is included.
 
-Logging supports structured JSON output (`MSHIP_LOG_FORMAT=json`) and request ID correlation across Ray actor boundaries. Logs can be shipped to a remote syslog server (`--log-target syslog://host:514`) or an OpenTelemetry collector (`--otel-endpoint http://collector:4317`). Set `MSHIP_LOG_LEVEL` to `DEBUG` for request bodies or `TRACE` to include library internals.
+Logging supports structured JSON output (`MSHIP_LOG_FORMAT=json`) and request ID correlation across Ray actor boundaries. Logs can be shipped to a remote syslog server (`--log-target syslog://host:514`) or an OpenTelemetry collector (`--otel-endpoint http://collector:4317`). Set `MSHIP_LOG_LEVEL` to `TRACE` for full request/response payloads, or `DEBUG` for detailed diagnostics without payloads.
 
 See [Monitoring & Logging](docs/monitoring.md) for full details.
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -2,18 +2,19 @@
 
 ## Overview
 
-Modelship is built on two core technologies:
-- **[Ray Serve](https://docs.ray.io/en/latest/serve/)** — manages model deployments as isolated actors with independent scaling and failure handling
-- **[vLLM](https://github.com/vllm-project/vllm)** — high-throughput LLM inference engine with continuous batching and PagedAttention
+Modelship is built on [Ray Serve](https://docs.ray.io/en/latest/serve/) for deployment orchestration and a **FastAPI gateway** that exposes an OpenAI-compatible API. Multiple inference backends are supported:
 
-A **FastAPI gateway** sits in front, exposing an OpenAI-compatible API that routes requests to the appropriate model deployment.
+- **[vLLM](https://github.com/vllm-project/vllm)** — high-throughput GPU inference with continuous batching and PagedAttention
+- **[HuggingFace Transformers](https://github.com/huggingface/transformers)** — CPU and lightweight GPU inference for chat, embeddings, transcription, and TTS
+- **[HuggingFace Diffusers](https://github.com/huggingface/diffusers)** — image generation via `AutoPipelineForText2Image`
+- **Plugin system** — custom TTS backends (Kokoro, Bark, Orpheus)
 
 ## Request Lifecycle
 
 1. Client sends a request to the FastAPI gateway (e.g. `POST /v1/chat/completions`)
 2. The gateway identifies the target model from the request body
 3. A `RequestWatcher` begins monitoring the client connection for disconnects
-4. The request is forwarded to the model's Ray Serve deployment via a `DisconnectProxy` (serializable headers + cancellation event)
+4. The request is forwarded to the model's Ray Serve deployment via a `RawRequestProxy` (serializable headers + cancellation event)
 5. The model deployment runs inference (vLLM, transformers, or plugin)
 6. Response streams back as JSON or SSE
 7. If the client disconnects mid-inference, the watcher fires the cancellation event, freeing GPU resources immediately
@@ -33,12 +34,14 @@ Each model in `models.yaml` becomes an isolated Ray Serve deployment (`ModelDepl
 
 Each deployment uses one of three loaders:
 
-| Loader | Backend | Use cases |
-|--------|---------|-----------|
-| `vllm` | vLLM engine | Chat/generation, embeddings, transcription, translation |
-| `transformers` | PyTorch + HuggingFace | Custom model implementations |
-| `diffusers` | HuggingFace Diffusers | Image generation (any `AutoPipelineForText2Image` model) |
-| `custom` | Plugin system | TTS backends (Kokoro, Bark, Orpheus) |
+| Loader | Backend | Use cases | GPU required |
+|--------|---------|-----------|--------------|
+| `vllm` | vLLM engine | Chat/generation, embeddings, transcription, translation | Yes |
+| `transformers` | PyTorch + HuggingFace | Chat/generation, embeddings, transcription, translation, TTS | No — runs on CPU or GPU |
+| `diffusers` | HuggingFace Diffusers | Image generation (any `AutoPipelineForText2Image` model) | Yes |
+| `custom` | Plugin system | TTS backends (Kokoro, Bark, Orpheus) | No |
+
+The `transformers` loader is ideal for CPU-only deployments, smaller models, or development/testing without a GPU. It uses HuggingFace `pipeline()` under the hood and handles audio resampling automatically for speech-to-text models. The `vllm` loader provides higher throughput on GPU with continuous batching and PagedAttention.
 
 ## GPU Allocation
 
@@ -64,6 +67,7 @@ See [Plugin Development](plugins.md) for details.
 | `modelship/infer/model_deployment.py` | Ray Serve deployment actor |
 | `modelship/infer/infer_config.py` | Pydantic config models and protocols |
 | `modelship/infer/vllm/vllm_infer.py` | vLLM engine wrapper |
+| `modelship/infer/transformers/transformers_infer.py` | Transformers pipeline wrapper (CPU/GPU) |
 | `modelship/infer/diffusers/diffusers_infer.py` | Diffusers pipeline wrapper |
 | `modelship/plugins/base_plugin.py` | Plugin base classes |
 | `config/models.yaml` | Model configuration |

--- a/docs/model-configuration.md
+++ b/docs/model-configuration.md
@@ -155,11 +155,60 @@ models:
 
 ## Transformers Loader
 
-The `transformers` loader uses PyTorch with HuggingFace Transformers. Currently supports TTS use cases.
+The `transformers` loader uses PyTorch with HuggingFace Transformers. Supports chat/generation, embeddings, transcription, translation, and TTS. Unlike the vLLM loader, it can run entirely on CPU — making it ideal for smaller models, development, or environments without a GPU.
 
 | Field | Type | Default | Description |
 |---|---|---|---|
-| `device` | string | `cpu` | Device to run on (`cpu` or `cuda:0`) |
+| `device` | string | `cpu` | Device to run on (`cpu`, `cuda`, `cuda:0`, etc.) |
+| `torch_dtype` | string | `auto` | Model dtype (`auto`, `float16`, `bfloat16`, `float32`) |
+| `trust_remote_code` | bool | `false` | Allow remote code execution |
+| `model_kwargs` | object | `{}` | Extra keyword arguments passed to the model constructor |
+| `pipeline_kwargs` | object | `{}` | Extra keyword arguments passed to the pipeline at inference time |
+
+### Chat / Text Generation (CPU)
+
+```yaml
+models:
+  - name: qwen
+    model: Qwen/Qwen3-0.6B
+    usecase: generate
+    loader: transformers
+    num_gpus: 0
+    transformers_config:
+      device: "cpu"
+```
+
+### Speech-to-Text (CPU)
+
+Audio is automatically decoded and resampled to the model's expected sample rate (e.g. 16kHz for Whisper).
+
+```yaml
+models:
+  - name: whisper
+    model: openai/whisper-small
+    usecase: transcription
+    loader: transformers
+    num_gpus: 0
+    transformers_config:
+      device: "cpu"
+```
+
+### Embeddings (CPU)
+
+Uses `sentence-transformers` under the hood.
+
+```yaml
+models:
+  - name: embeddings
+    model: sentence-transformers/all-MiniLM-L6-v2
+    usecase: embed
+    loader: transformers
+    num_gpus: 0
+    transformers_config:
+      device: "cpu"
+```
+
+### TTS (GPU)
 
 ```yaml
 models:

--- a/docs/monitoring.md
+++ b/docs/monitoring.md
@@ -10,18 +10,21 @@ Modelship uses a centralized logging system with structured output and request c
 
 | Env Var | Default | Description |
 |---|---|---|
-| `MSHIP_LOG_LEVEL` | `INFO` | App log level. Set to `DEBUG` for full request/response bodies. Set to `TRACE` to also enable library debug logs. |
+| `MSHIP_LOG_LEVEL` | `INFO` | App log level. Set to `TRACE` for request/response payloads, `DEBUG` for detailed diagnostics. Each level sets library logs to the next level up (e.g. `DEBUG` app → `INFO` libs). |
 | `MSHIP_LOG_FORMAT` | `text` | `text` for human-readable output, `json` for structured JSON lines (for log aggregation with ELK/Loki/Splunk). |
 | `MSHIP_LOG_TARGET` | `console` | Log target. `console` writes to stderr; syslog URIs ship logs to a remote syslog server (see below). |
 | `OTEL_EXPORTER_OTLP_ENDPOINT` | — | When set, logs are also exported to an OpenTelemetry collector via OTLP (see below). |
 
 ### Log Levels
 
-| Level | App logs (`modelship.*`) | Library logs (Ray, vLLM, transformers) |
+Each level sets library logs (Ray, vLLM, transformers) to the next level up:
+
+| Level | App logs (`modelship.*`) | Library logs |
 |---|---|---|
-| `INFO` (default) | Startup, deployment, request summaries | `WARNING` only |
-| `DEBUG` | Full request/response bodies, per-chunk details | `WARNING` only |
-| `TRACE` | Same as `DEBUG` | `DEBUG` — all library internals |
+| `TRACE` | Request/response payloads (audio bytes, transcription text, chat messages, etc.) | `DEBUG` |
+| `DEBUG` | Detailed diagnostics, per-chunk details | `INFO` |
+| `INFO` (default) | Startup, deployment, request summaries | `WARNING` |
+| `WARNING` | Warnings only | `ERROR` |
 
 ### Request Correlation
 
@@ -48,7 +51,12 @@ JSON format example:
 | `modelship.infer.deployment` | Ray Serve model deployment actor |
 | `modelship.infer.vllm` | vLLM inference backend |
 | `modelship.infer.transformers` | Transformers inference backend |
+| `modelship.infer.transformers.transcription` | Transformers speech-to-text/translation |
+| `modelship.infer.transformers.chat` | Transformers chat/generation |
+| `modelship.infer.transformers.embedding` | Transformers embeddings |
+| `modelship.infer.transformers.speech` | Transformers TTS |
 | `modelship.infer.diffusers` | Diffusers inference backend |
+| `modelship.infer.diffusers.image` | Diffusers image generation |
 | `modelship.infer.custom` | Custom/plugin inference backend |
 | `modelship.plugin.<name>` | Individual plugins (kokoro, bark, orpheus) |
 

--- a/modelship/infer/base_infer.py
+++ b/modelship/infer/base_infer.py
@@ -2,7 +2,7 @@ import struct
 from abc import ABC, abstractmethod
 from collections.abc import AsyncGenerator
 
-from modelship.infer.infer_config import DisconnectProxy, ModelshipModelConfig
+from modelship.infer.infer_config import ModelshipModelConfig, RawRequestProxy
 from modelship.logging import get_logger
 from modelship.openai.protocol import (
     ChatCompletionRequest,
@@ -64,6 +64,14 @@ class BaseInfer(ABC):
         logger.info("max_context_length for %s: %s", self.model_config.name, self.max_context_length)
 
     @abstractmethod
+    def shutdown(self) -> None:
+        """Synchronously release resources (engine processes, GPU memory, etc.).
+
+        Called during graceful teardown. Subclasses must implement to clean up
+        loader-specific resources.
+        """
+
+    @abstractmethod
     async def start(self) -> None: ...
 
     @abstractmethod
@@ -76,29 +84,29 @@ class BaseInfer(ABC):
         """
 
     async def create_chat_completion(
-        self, request: ChatCompletionRequest, raw_request: DisconnectProxy
+        self, request: ChatCompletionRequest, raw_request: RawRequestProxy
     ) -> ErrorResponse | ChatCompletionResponse | AsyncGenerator[str, None]:
         return _NOT_SUPPORTED
 
-    async def create_embedding(self, request: EmbeddingRequest, raw_request: DisconnectProxy) -> ErrorResponse:
+    async def create_embedding(self, request: EmbeddingRequest, raw_request: RawRequestProxy) -> ErrorResponse:
         return _NOT_SUPPORTED
 
     async def create_transcription(
-        self, audio_data: bytes, request: TranscriptionRequest, raw_request: DisconnectProxy
+        self, audio_data: bytes, request: TranscriptionRequest, raw_request: RawRequestProxy
     ) -> ErrorResponse | TranscriptionResponse | TranscriptionResponseVerbose | AsyncGenerator[str, None]:
         return _NOT_SUPPORTED
 
     async def create_translation(
-        self, audio_data: bytes, request: TranslationRequest, raw_request: DisconnectProxy
+        self, audio_data: bytes, request: TranslationRequest, raw_request: RawRequestProxy
     ) -> ErrorResponse | TranslationResponse | TranslationResponseVerbose | AsyncGenerator[str, None]:
         return _NOT_SUPPORTED
 
     async def create_speech(
-        self, request: SpeechRequest, raw_request: DisconnectProxy
+        self, request: SpeechRequest, raw_request: RawRequestProxy
     ) -> ErrorResponse | RawSpeechResponse | AsyncGenerator[str, None]:
         return _NOT_SUPPORTED
 
     async def create_image_generation(
-        self, request: ImageGenerationRequest, raw_request: DisconnectProxy
+        self, request: ImageGenerationRequest, raw_request: RawRequestProxy
     ) -> ErrorResponse | ImageGenerationResponse:
         return _NOT_SUPPORTED

--- a/modelship/infer/base_serving.py
+++ b/modelship/infer/base_serving.py
@@ -1,0 +1,21 @@
+import asyncio
+from abc import ABC, abstractmethod
+from collections.abc import Callable
+from typing import Any
+
+from modelship.logging import get_logger
+
+logger = get_logger("infer.base_serving")
+
+
+class OpenAIServing(ABC):
+    request_id_prefix: str = ""
+
+    @abstractmethod
+    async def warmup(self) -> None:
+        """Run a minimal inference pass to warm up the model."""
+
+    @staticmethod
+    async def run_in_executor(fn: Callable[..., Any], *args: Any) -> Any:
+        loop = asyncio.get_event_loop()
+        return await loop.run_in_executor(None, fn, *args)

--- a/modelship/infer/custom/custom_infer.py
+++ b/modelship/infer/custom/custom_infer.py
@@ -2,8 +2,6 @@ import importlib
 from collections.abc import AsyncGenerator
 from typing import cast
 
-from starlette.requests import Request
-
 from modelship.infer.base_infer import BaseInfer
 from modelship.infer.custom.openai.serving_speech import OpenAIServingSpeech
 from modelship.infer.infer_config import ModelshipModelConfig, ModelUsecase, RawRequestProxy
@@ -53,4 +51,4 @@ class CustomInfer(BaseInfer):
     ) -> ErrorResponse | RawSpeechResponse | AsyncGenerator[str, None]:
         if self.serving_speech is None:
             return await super().create_speech(request, raw_request)
-        return await self.serving_speech.create_speech(request, cast("Request", raw_request))
+        return await self.serving_speech.create_speech(request, raw_request)

--- a/modelship/infer/custom/custom_infer.py
+++ b/modelship/infer/custom/custom_infer.py
@@ -6,7 +6,7 @@ from starlette.requests import Request
 
 from modelship.infer.base_infer import BaseInfer
 from modelship.infer.custom.openai.serving_speech import OpenAIServingSpeech
-from modelship.infer.infer_config import DisconnectProxy, ModelshipModelConfig, ModelUsecase
+from modelship.infer.infer_config import ModelshipModelConfig, ModelUsecase, RawRequestProxy
 from modelship.logging import get_logger
 from modelship.openai.protocol import (
     ErrorResponse,
@@ -23,6 +23,9 @@ class CustomInfer(BaseInfer):
         super().__init__(model_config)
         self.custom_engine: BasePlugin | None = None
         self.serving_speech: OpenAIServingSpeech | None = None
+
+    def shutdown(self) -> None:
+        pass
 
     async def start(self):
         plugin = self.model_config.plugin
@@ -46,7 +49,7 @@ class CustomInfer(BaseInfer):
         )
 
     async def create_speech(
-        self, request: SpeechRequest, raw_request: DisconnectProxy
+        self, request: SpeechRequest, raw_request: RawRequestProxy
     ) -> ErrorResponse | RawSpeechResponse | AsyncGenerator[str, None]:
         if self.serving_speech is None:
             return await super().create_speech(request, raw_request)

--- a/modelship/infer/custom/openai/serving_speech.py
+++ b/modelship/infer/custom/openai/serving_speech.py
@@ -1,7 +1,6 @@
 from collections.abc import AsyncGenerator
 
-from fastapi import Request
-
+from modelship.infer.infer_config import RawRequestProxy
 from modelship.logging import get_logger
 from modelship.openai.protocol import ErrorResponse, RawSpeechResponse, SpeechRequest, create_error_response
 from modelship.plugins.base_plugin import BasePlugin
@@ -19,7 +18,7 @@ class OpenAIServingSpeech:
         self.serving_engine = serving_engine
 
     async def create_speech(
-        self, request: SpeechRequest, raw_request: Request
+        self, request: SpeechRequest, raw_request: RawRequestProxy
     ) -> RawSpeechResponse | AsyncGenerator[str, None] | ErrorResponse:
         if self.serving_engine is None:
             return create_error_response("tts model is not yet accessible")

--- a/modelship/infer/diffusers/diffusers_infer.py
+++ b/modelship/infer/diffusers/diffusers_infer.py
@@ -1,11 +1,8 @@
-from typing import cast
-
 import torch
-from starlette.requests import Request
 
 from modelship.infer.base_infer import BaseInfer
 from modelship.infer.diffusers.openai.serving_image import OpenAIServingImage
-from modelship.infer.infer_config import DiffusersConfig, DisconnectProxy, ModelshipModelConfig, ModelUsecase
+from modelship.infer.infer_config import DiffusersConfig, ModelshipModelConfig, ModelUsecase, RawRequestProxy
 from modelship.logging import get_logger
 from modelship.openai.protocol import (
     ErrorResponse,
@@ -30,6 +27,9 @@ class DiffusersInfer(BaseInfer):
         mem_frac = self._get_memory_fraction()
         if torch.cuda.is_available() and mem_frac is not None:
             torch.cuda.set_per_process_memory_fraction(mem_frac)
+
+    def shutdown(self) -> None:
+        pass
 
     def __del__(self):
         try:
@@ -81,12 +81,12 @@ class DiffusersInfer(BaseInfer):
             num_inference_steps=1,
             guidance_scale=0.0,
         )
-        await self.create_image_generation(request, DisconnectProxy(None, {}))
+        await self.create_image_generation(request, RawRequestProxy(None, {}))
         logger.info("Warmup image generation done for %s", self.model_config.name)
 
     async def create_image_generation(
-        self, request: ImageGenerationRequest, raw_request: DisconnectProxy
+        self, request: ImageGenerationRequest, raw_request: RawRequestProxy
     ) -> ErrorResponse | ImageGenerationResponse:
         if self.serving_image is None:
             return await super().create_image_generation(request, raw_request)
-        return await self.serving_image.create_image_generation(request, cast("Request", raw_request))
+        return await self.serving_image.create_image_generation(request, raw_request)

--- a/modelship/infer/diffusers/openai/serving_image.py
+++ b/modelship/infer/diffusers/openai/serving_image.py
@@ -4,10 +4,9 @@ import io
 import time
 
 from diffusers.pipelines.auto_pipeline import AutoPipelineForText2Image
-from fastapi import Request
 
-from modelship.infer.infer_config import DiffusersConfig
-from modelship.logging import get_logger
+from modelship.infer.infer_config import DiffusersConfig, RawRequestProxy
+from modelship.logging import TRACE, get_logger
 from modelship.openai.protocol import (
     ErrorResponse,
     ImageGenerationRequest,
@@ -28,11 +27,21 @@ class OpenAIServingImage:
         self.config = config
 
     async def create_image_generation(
-        self, request: ImageGenerationRequest, raw_request: Request
+        self, request: ImageGenerationRequest, raw_request: RawRequestProxy
     ) -> ImageGenerationResponse | ErrorResponse:
         request_id = f"{self.request_id_prefix}-{base_request_id(raw_request)}"
         logger.info(
             "image generation request %s: prompt=%r, n=%d, size=%s", request_id, request.prompt, request.n, request.size
+        )
+        logger.log(
+            TRACE,
+            "image request %s: prompt=%r, n=%d, size=%s, steps=%s, guidance=%s",
+            request_id,
+            request.prompt,
+            request.n,
+            request.size,
+            request.num_inference_steps,
+            request.guidance_scale,
         )
 
         try:
@@ -65,7 +74,9 @@ class OpenAIServingImage:
             b64 = base64.b64encode(buf.getvalue()).decode("utf-8")
             data.append(ImageObject(b64_json=b64, revised_prompt=request.prompt))
 
-        return ImageGenerationResponse(created=int(time.time()), data=data)
+        response = ImageGenerationResponse(created=int(time.time()), data=data)
+        logger.log(TRACE, "image response %s: num_images=%d", request_id, len(data))
+        return response
 
 
 def _parse_size(size: str) -> tuple[int, int]:

--- a/modelship/infer/infer_config.py
+++ b/modelship/infer/infer_config.py
@@ -47,6 +47,10 @@ class VllmEngineConfig(BaseModel):
 
 class TransformersConfig(BaseModel):
     device: str = "cpu"
+    torch_dtype: str = "auto"
+    trust_remote_code: bool = False
+    model_kwargs: dict[str, Any] = Field(default_factory=dict)
+    pipeline_kwargs: dict[str, Any] = Field(default_factory=dict)
 
 
 class DiffusersConfig(BaseModel):
@@ -60,7 +64,7 @@ class ModelshipModelConfig(BaseModel):
     model: str
     usecase: ModelUsecase
     loader: ModelLoader
-    plugin: str | None = None  # only meaningful for loader='custom', silently ignored otherwise
+    plugin: str | None = None  # only meaningful for loader='custom'
     num_gpus: float = 0
     num_cpus: float = 0.1
     num_replicas: int = 1
@@ -124,14 +128,14 @@ class RequestWatcher:
         return self._event
 
 
-class DisconnectProxy:
+class RawRequestProxy:
     """
     Stands in for a FastAPI Request inside model deployment actors.
 
     The real FastAPI Request cannot cross Ray process boundaries — it holds a live
     TCP socket and ASGI callables that are not serializable. Instead, the gateway
     extracts the serializable parts (headers as a plain dict, disconnect signal via
-    DisconnectEvent Ray actor) and passes those to the model deployment. DisconnectProxy
+    DisconnectEvent Ray actor) and passes those to the model deployment. RawRequestProxy
     reconstructs them into the interface that vllm expects from a raw_request:
 
       - raw_request.headers.get(...)     → Starlette Headers built from the dict
@@ -140,10 +144,11 @@ class DisconnectProxy:
     Any additional attributes vllm reads from raw_request in future should be added here.
     """
 
-    def __init__(self, event, headers: dict):
+    def __init__(self, event, headers: dict, request_id: str | None = None):
         self._event = event
         self.headers = Headers(headers=headers)
         self.state = State()  # vllm writes per-request state here; initialized empty, lives in the actor process
+        self.request_id = request_id
 
     async def is_disconnected(self) -> bool:
         return await self._event.is_set.remote()

--- a/modelship/infer/model_deployment.py
+++ b/modelship/infer/model_deployment.py
@@ -7,7 +7,7 @@ from ray import serve
 from modelship.infer.base_infer import BaseInfer
 from modelship.infer.custom.custom_infer import CustomInfer
 from modelship.infer.diffusers.diffusers_infer import DiffusersInfer
-from modelship.infer.infer_config import DisconnectProxy, ModelLoader, ModelshipModelConfig
+from modelship.infer.infer_config import ModelLoader, ModelshipModelConfig, RawRequestProxy
 from modelship.infer.transformers.transformers_infer import TransformersInfer
 from modelship.infer.vllm.vllm_infer import VllmInfer
 from modelship.logging import configure_logging, get_logger
@@ -59,6 +59,13 @@ class ModelDeployment:
                 time.monotonic() - start, tags={"model": config.name, "loader": config.loader.value}
             )
 
+    def __del__(self):
+        if infer := getattr(self, "infer", None):
+            try:
+                infer.shutdown()
+            except Exception:
+                logger.exception("Failed to shutdown infer for %s", self.config.name)
+
     @staticmethod
     def _set_request_id(request_id: str | None) -> None:
         from modelship.logging import request_id_var
@@ -73,7 +80,7 @@ class ModelDeployment:
         request_id: str | None = None,
     ):
         self._set_request_id(request_id)
-        proxy = DisconnectProxy(disconnect_event, request_headers)
+        proxy = RawRequestProxy(disconnect_event, request_headers, request_id)
         start = time.monotonic()
         result = await self.infer.create_chat_completion(request, proxy)
         GENERATION_DURATION_SECONDS.observe(time.monotonic() - start, tags={"model": self.config.name})
@@ -91,7 +98,7 @@ class ModelDeployment:
         request_id: str | None = None,
     ):
         self._set_request_id(request_id)
-        proxy = DisconnectProxy(disconnect_event, request_headers)
+        proxy = RawRequestProxy(disconnect_event, request_headers, request_id)
         start = time.monotonic()
         result = await self.infer.create_embedding(request, proxy)
         EMBEDDING_DURATION_SECONDS.observe(time.monotonic() - start, tags={"model": self.config.name})
@@ -110,7 +117,7 @@ class ModelDeployment:
         request_id: str | None = None,
     ):
         self._set_request_id(request_id)
-        proxy = DisconnectProxy(disconnect_event, request_headers)
+        proxy = RawRequestProxy(disconnect_event, request_headers, request_id)
         start = time.monotonic()
         result = await self.infer.create_transcription(audio_data, request, proxy)
         TRANSCRIPTION_DURATION_SECONDS.observe(time.monotonic() - start, tags={"model": self.config.name})
@@ -129,7 +136,7 @@ class ModelDeployment:
         request_id: str | None = None,
     ):
         self._set_request_id(request_id)
-        proxy = DisconnectProxy(disconnect_event, request_headers)
+        proxy = RawRequestProxy(disconnect_event, request_headers, request_id)
         start = time.monotonic()
         result = await self.infer.create_translation(audio_data, request, proxy)
         TRANSCRIPTION_DURATION_SECONDS.observe(time.monotonic() - start, tags={"model": self.config.name})
@@ -147,7 +154,7 @@ class ModelDeployment:
         request_id: str | None = None,
     ):
         self._set_request_id(request_id)
-        proxy = DisconnectProxy(disconnect_event, request_headers)
+        proxy = RawRequestProxy(disconnect_event, request_headers, request_id)
         start = time.monotonic()
         result = await self.infer.create_speech(request, proxy)
         TTS_GENERATION_DURATION_SECONDS.observe(time.monotonic() - start, tags={"model": self.config.name})
@@ -165,7 +172,7 @@ class ModelDeployment:
         request_id: str | None = None,
     ):
         self._set_request_id(request_id)
-        proxy = DisconnectProxy(disconnect_event, request_headers)
+        proxy = RawRequestProxy(disconnect_event, request_headers, request_id)
         start = time.monotonic()
         result = await self.infer.create_image_generation(request, proxy)
         IMAGE_GENERATION_DURATION_SECONDS.observe(time.monotonic() - start, tags={"model": self.config.name})

--- a/modelship/infer/transformers/openai/serving_chat.py
+++ b/modelship/infer/transformers/openai/serving_chat.py
@@ -48,7 +48,7 @@ class OpenAIServingChat(OpenAIServing):
             TRACE, "chat request %s: messages=%s, max_tokens=%s", request_id, request.messages, request.max_tokens
         )
 
-        messages = [{"role": m["role"], "content": m["content"]} for m in request.messages]
+        messages = [{"role": m["role"], "content": m["content"]} for m in request.messages]  # type: ignore[index]
 
         if request.stream:
             return self._stream(request_id, messages, request.max_tokens)
@@ -107,10 +107,10 @@ class OpenAIServingChat(OpenAIServing):
         from vllm.entrypoints.openai.chat_completion.protocol import (
             ChatCompletionResponseStreamChoice,
             ChatCompletionStreamResponse,
-            DeltaMessage,
         )
+        from vllm.entrypoints.openai.engine.protocol import DeltaMessage
 
-        streamer = TextIteratorStreamer(self.tokenizer, skip_prompt=True, skip_special_tokens=True)
+        streamer = TextIteratorStreamer(self.tokenizer, skip_prompt=True, skip_special_tokens=True)  # type: ignore[arg-type]
 
         kwargs = {**self.config.pipeline_kwargs}
         if max_tokens is not None:

--- a/modelship/infer/transformers/openai/serving_chat.py
+++ b/modelship/infer/transformers/openai/serving_chat.py
@@ -1,0 +1,163 @@
+import asyncio
+import json
+import time
+from collections.abc import AsyncGenerator
+from threading import Thread
+
+from transformers import Pipeline, PreTrainedTokenizerBase, TextIteratorStreamer
+
+from modelship.infer.base_serving import OpenAIServing
+from modelship.infer.infer_config import RawRequestProxy, TransformersConfig
+from modelship.logging import TRACE, get_logger
+from modelship.openai.protocol import (
+    ChatCompletionRequest,
+    ChatCompletionResponse,
+    ErrorResponse,
+    create_error_response,
+)
+from modelship.utils import base_request_id
+
+logger = get_logger("infer.transformers.chat")
+
+
+class OpenAIServingChat(OpenAIServing):
+    request_id_prefix = "chat"
+
+    def __init__(self, pipeline: Pipeline, model_name: str, config: TransformersConfig):
+        self.pipeline = pipeline
+        self.model_name = model_name
+        self.config = config
+        assert pipeline.tokenizer is not None, "text-generation pipeline must have a tokenizer"
+        self.tokenizer: PreTrainedTokenizerBase = pipeline.tokenizer
+
+    async def warmup(self) -> None:
+        logger.info("Warming up chat model: %s", self.model_name)
+        await self.run_in_executor(
+            self._run,
+            [{"role": "user", "content": "warmup"}],
+            1,
+        )
+        logger.info("Warmup chat done for %s", self.model_name)
+
+    async def create_chat_completion(
+        self, request: ChatCompletionRequest, raw_request: RawRequestProxy
+    ) -> ChatCompletionResponse | AsyncGenerator[str, None] | ErrorResponse:
+        request_id = f"{self.request_id_prefix}-{base_request_id(raw_request)}"
+        logger.info("chat completion request %s: stream=%s", request_id, request.stream)
+        logger.log(
+            TRACE, "chat request %s: messages=%s, max_tokens=%s", request_id, request.messages, request.max_tokens
+        )
+
+        messages = [{"role": m["role"], "content": m["content"]} for m in request.messages]
+
+        if request.stream:
+            return self._stream(request_id, messages, request.max_tokens)
+
+        try:
+            result = await self.run_in_executor(self._run, messages, request.max_tokens)
+        except Exception:
+            logger.exception("chat completion inference failed for %s", request_id)
+            return create_error_response("chat completion inference failed")
+
+        prompt_tokens = len(self.tokenizer.apply_chat_template(messages))
+        generated = result[0]["generated_text"]
+        completion_text = generated[-1]["content"] if isinstance(generated, list) else generated
+        completion_tokens = len(self.tokenizer.encode(completion_text))
+
+        from vllm.entrypoints.openai.chat_completion.protocol import (
+            ChatCompletionResponseChoice,
+            ChatMessage,
+        )
+        from vllm.entrypoints.openai.engine.protocol import UsageInfo
+
+        response = ChatCompletionResponse(
+            id=request_id,
+            model=self.model_name,
+            choices=[
+                ChatCompletionResponseChoice(
+                    index=0,
+                    message=ChatMessage(role="assistant", content=completion_text),
+                    finish_reason="stop",
+                )
+            ],
+            usage=UsageInfo(
+                prompt_tokens=prompt_tokens,
+                completion_tokens=completion_tokens,
+                total_tokens=prompt_tokens + completion_tokens,
+            ),
+            created=int(time.time()),
+        )
+        logger.log(
+            TRACE,
+            "chat response %s: text=%r, prompt_tokens=%d, completion_tokens=%d",
+            request_id,
+            completion_text,
+            prompt_tokens,
+            completion_tokens,
+        )
+        return response
+
+    def _run(self, messages: list[dict], max_tokens: int | None) -> list:
+        kwargs = {**self.config.pipeline_kwargs}
+        if max_tokens is not None:
+            kwargs["max_new_tokens"] = max_tokens
+        return self.pipeline(messages, return_full_text=False, **kwargs)  # type: ignore[return-value]
+
+    async def _stream(self, request_id: str, messages: list[dict], max_tokens: int | None) -> AsyncGenerator[str, None]:
+        from vllm.entrypoints.openai.chat_completion.protocol import (
+            ChatCompletionResponseStreamChoice,
+            ChatCompletionStreamResponse,
+            DeltaMessage,
+        )
+
+        streamer = TextIteratorStreamer(self.tokenizer, skip_prompt=True, skip_special_tokens=True)
+
+        kwargs = {**self.config.pipeline_kwargs}
+        if max_tokens is not None:
+            kwargs["max_new_tokens"] = max_tokens
+
+        thread = Thread(
+            target=self.pipeline,
+            args=(messages,),
+            kwargs={
+                "streamer": streamer,
+                "return_full_text": False,
+                **kwargs,
+            },
+        )
+        thread.start()
+
+        try:
+            for text_chunk in streamer:
+                if not text_chunk:
+                    continue
+                chunk = ChatCompletionStreamResponse(
+                    id=request_id,
+                    model=self.model_name,
+                    choices=[
+                        ChatCompletionResponseStreamChoice(
+                            index=0,
+                            delta=DeltaMessage(role="assistant", content=text_chunk),
+                        )
+                    ],
+                    created=int(time.time()),
+                )
+                yield f"data: {json.dumps(chunk.model_dump(mode='json'))}\n\n"
+                await asyncio.sleep(0)
+
+            final_chunk = ChatCompletionStreamResponse(
+                id=request_id,
+                model=self.model_name,
+                choices=[
+                    ChatCompletionResponseStreamChoice(
+                        index=0,
+                        delta=DeltaMessage(),
+                        finish_reason="stop",
+                    )
+                ],
+                created=int(time.time()),
+            )
+            yield f"data: {json.dumps(final_chunk.model_dump(mode='json'))}\n\n"
+            yield "data: [DONE]\n\n"
+        finally:
+            thread.join()

--- a/modelship/infer/transformers/openai/serving_embedding.py
+++ b/modelship/infer/transformers/openai/serving_embedding.py
@@ -1,0 +1,62 @@
+import time
+
+from sentence_transformers import SentenceTransformer
+from vllm.entrypoints.openai.engine.protocol import UsageInfo
+from vllm.entrypoints.pooling.embed.protocol import EmbeddingResponseData
+
+from modelship.infer.base_serving import OpenAIServing
+from modelship.infer.infer_config import RawRequestProxy
+from modelship.logging import TRACE, get_logger
+from modelship.openai.protocol import EmbeddingRequest, EmbeddingResponse, ErrorResponse, create_error_response
+from modelship.utils import base_request_id
+
+logger = get_logger("infer.transformers.embedding")
+
+
+class OpenAIServingEmbedding(OpenAIServing):
+    request_id_prefix = "embd"
+
+    def __init__(self, model: SentenceTransformer, model_name: str):
+        self.model = model
+        self.model_name = model_name
+
+    async def warmup(self) -> None:
+        logger.info("Warming up embedding model: %s", self.model_name)
+        await self.run_in_executor(self._run, ["warmup"])
+        logger.info("Warmup embedding done for %s", self.model_name)
+
+    def _run(self, inputs: list[str]):
+        return self.model.encode(inputs)
+
+    async def create_embedding(
+        self, request: EmbeddingRequest, raw_request: RawRequestProxy
+    ) -> EmbeddingResponse | ErrorResponse:
+        request_id = f"{self.request_id_prefix}-{base_request_id(raw_request)}"
+        logger.info("embedding request %s", request_id)
+        logger.log(TRACE, "embedding request %s: input=%s", request_id, request.input)
+
+        inputs = request.input
+        if isinstance(inputs, str):
+            inputs = [inputs]
+
+        try:
+            embeddings = await self.run_in_executor(self._run, inputs)
+        except Exception:
+            logger.exception("embedding inference failed for %s", request_id)
+            return create_error_response("embedding inference failed")
+
+        tokenized = self.model.tokenize(inputs)
+        prompt_tokens = sum(len(ids) for ids in tokenized["input_ids"])
+
+        data = [EmbeddingResponseData(index=i, embedding=emb.tolist()) for i, emb in enumerate(embeddings)]
+
+        response = EmbeddingResponse(
+            model=self.model_name,
+            data=data,
+            usage=UsageInfo(prompt_tokens=prompt_tokens, total_tokens=prompt_tokens),
+            created=int(time.time()),
+        )
+        logger.log(
+            TRACE, "embedding response %s: num_embeddings=%d, prompt_tokens=%d", request_id, len(data), prompt_tokens
+        )
+        return response

--- a/modelship/infer/transformers/openai/serving_embedding.py
+++ b/modelship/infer/transformers/openai/serving_embedding.py
@@ -33,9 +33,9 @@ class OpenAIServingEmbedding(OpenAIServing):
     ) -> EmbeddingResponse | ErrorResponse:
         request_id = f"{self.request_id_prefix}-{base_request_id(raw_request)}"
         logger.info("embedding request %s", request_id)
-        logger.log(TRACE, "embedding request %s: input=%s", request_id, request.input)
+        logger.log(TRACE, "embedding request %s: input=%s", request_id, request.input)  # type: ignore[union-attr]
 
-        inputs = request.input
+        inputs = request.input  # type: ignore[union-attr]
         if isinstance(inputs, str):
             inputs = [inputs]
 
@@ -45,7 +45,7 @@ class OpenAIServingEmbedding(OpenAIServing):
             logger.exception("embedding inference failed for %s", request_id)
             return create_error_response("embedding inference failed")
 
-        tokenized = self.model.tokenize(inputs)
+        tokenized = self.model.tokenize(inputs)  # type: ignore[arg-type]
         prompt_tokens = sum(len(ids) for ids in tokenized["input_ids"])
 
         data = [EmbeddingResponseData(index=i, embedding=emb.tolist()) for i, emb in enumerate(embeddings)]

--- a/modelship/infer/transformers/openai/serving_speech.py
+++ b/modelship/infer/transformers/openai/serving_speech.py
@@ -1,29 +1,85 @@
-from collections.abc import AsyncGenerator
+import struct
 
-from fastapi import Request
+import numpy as np
+from transformers import Pipeline
 
-from modelship.logging import get_logger
-from modelship.openai.protocol import ErrorResponse, RawSpeechResponse, SpeechRequest, create_error_response
-from modelship.plugins.base_plugin import BasePluginTransformers
+from modelship.infer.base_serving import OpenAIServing
+from modelship.infer.infer_config import RawRequestProxy, TransformersConfig
+from modelship.logging import TRACE, get_logger
+from modelship.openai.protocol import (
+    ErrorResponse,
+    RawSpeechResponse,
+    SpeechRequest,
+    create_error_response,
+)
 from modelship.utils import base_request_id
 
 logger = get_logger("infer.transformers.speech")
 
 
-class OpenAIServingSpeech:
+def _audio_to_wav(audio: np.ndarray, sampling_rate: int) -> bytes:
+    """Convert a float32 numpy audio array to WAV bytes."""
+    if audio.ndim > 1:
+        audio = audio.squeeze()
+
+    pcm = (audio * 32767).astype(np.int16)
+    data_bytes = pcm.tobytes()
+
+    header = struct.pack(
+        "<4sI4s4sIHHIIHH4sI",
+        b"RIFF",
+        36 + len(data_bytes),
+        b"WAVE",
+        b"fmt ",
+        16,
+        1,  # PCM
+        1,  # mono
+        sampling_rate,
+        sampling_rate * 2,  # byte rate
+        2,  # block align
+        16,  # bits per sample
+        b"data",
+        len(data_bytes),
+    )
+
+    return header + data_bytes
+
+
+class OpenAIServingSpeech(OpenAIServing):
     request_id_prefix = "tts"
 
-    """Handles speech requests"""
+    def __init__(self, pipeline: Pipeline, model_name: str, config: TransformersConfig):
+        self.pipeline = pipeline
+        self.model_name = model_name
+        self.config = config
 
-    def __init__(self, speech_model: BasePluginTransformers | None):
-        self.speech_model = speech_model
+    async def warmup(self) -> None:
+        logger.info("Warming up TTS model: %s", self.model_name)
+        await self.run_in_executor(self._run, "warmup")
+        logger.info("Warmup TTS done for %s", self.model_name)
 
     async def create_speech(
-        self, request: SpeechRequest, raw_request: Request
-    ) -> RawSpeechResponse | AsyncGenerator[str, None] | ErrorResponse:
-        if self.speech_model is None:
-            return create_error_response("tts model is not yet accessible")
-
+        self, request: SpeechRequest, raw_request: RawRequestProxy
+    ) -> RawSpeechResponse | ErrorResponse:
         request_id = f"{self.request_id_prefix}-{base_request_id(raw_request)}"
+        logger.info("speech request %s", request_id)
+        logger.log(TRACE, "speech request %s: input=%r", request_id, request.input)
 
-        return await self.speech_model.generate(request.input, request.voice, request_id, request.stream_format)
+        try:
+            result = await self.run_in_executor(self._run, request.input)
+        except Exception:
+            logger.exception("speech inference failed for %s", request_id)
+            return create_error_response("speech inference failed")
+
+        wav_bytes = _audio_to_wav(result["audio"], result["sampling_rate"])
+        logger.log(
+            TRACE,
+            "speech response %s: audio_bytes=%d, sample_rate=%d",
+            request_id,
+            len(wav_bytes),
+            result["sampling_rate"],
+        )
+        return RawSpeechResponse(audio=wav_bytes)
+
+    def _run(self, text: str) -> dict:
+        return self.pipeline(text, **self.config.pipeline_kwargs)  # type: ignore[return-value]

--- a/modelship/infer/transformers/openai/serving_transcription.py
+++ b/modelship/infer/transformers/openai/serving_transcription.py
@@ -1,0 +1,135 @@
+import io
+
+import librosa
+import numpy as np
+import soundfile as sf
+from transformers import Pipeline
+
+from modelship.infer.base_infer import MINIMAL_WAV
+from modelship.infer.base_serving import OpenAIServing
+from modelship.infer.infer_config import RawRequestProxy, TransformersConfig
+from modelship.logging import TRACE, get_logger
+from modelship.openai.protocol import (
+    ErrorResponse,
+    TranscriptionRequest,
+    TranscriptionResponse,
+    TranscriptionResponseVerbose,
+    TranslationRequest,
+    TranslationResponse,
+    TranslationResponseVerbose,
+    create_error_response,
+)
+from modelship.utils import base_request_id
+
+logger = get_logger("infer.transformers.transcription")
+
+
+def _decode_audio(audio_data: bytes, target_sr: int) -> tuple[dict, int]:
+    """Decode audio bytes and resample to *target_sr*.
+
+    Returns the pipeline input dict and the duration in whole seconds.
+    """
+    samples, source_sr = sf.read(io.BytesIO(audio_data), dtype="float32")
+    if samples.ndim > 1:
+        samples = np.mean(samples, axis=1)
+    duration_seconds = int(len(samples) / source_sr)
+    if source_sr != target_sr:
+        samples = librosa.resample(samples, orig_sr=source_sr, target_sr=target_sr)
+    return {"raw": samples, "sampling_rate": target_sr}, duration_seconds
+
+
+class OpenAIServingTranscription(OpenAIServing):
+    request_id_prefix = "asr"
+
+    def __init__(self, pipeline: Pipeline, model_name: str, config: TransformersConfig):
+        self.pipeline = pipeline
+        self.model_name = model_name
+        self.config = config
+
+    @property
+    def _target_sr(self) -> int:
+        return self.pipeline.feature_extractor.sampling_rate
+
+    async def warmup(self) -> None:
+        logger.info("Warming up transcription model: %s", self.model_name)
+        audio_input, _ = _decode_audio(MINIMAL_WAV, self._target_sr)
+        await self.run_in_executor(self._run, audio_input, None)
+        logger.info("Warmup transcription done for %s", self.model_name)
+
+    async def create_transcription(
+        self, audio_data: bytes, request: TranscriptionRequest, raw_request: RawRequestProxy
+    ) -> TranscriptionResponse | TranscriptionResponseVerbose | ErrorResponse:
+        request_id = f"{self.request_id_prefix}-{base_request_id(raw_request)}"
+        language = request.language if hasattr(request, "language") else None
+        logger.info("transcription request %s", request_id)
+        logger.log(
+            TRACE, "transcription request %s: language=%s, audio_bytes=%d", request_id, language, len(audio_data)
+        )
+
+        try:
+            audio_input, duration_seconds = _decode_audio(audio_data, self._target_sr)
+            result = await self.run_in_executor(self._run, audio_input, language)
+        except Exception:
+            logger.exception("transcription inference failed for %s", request_id)
+            return create_error_response("transcription inference failed")
+
+        text = result["text"].strip()
+        logger.log(TRACE, "transcription response %s: text=%r, duration=%ds", request_id, text, duration_seconds)
+
+        from vllm.entrypoints.openai.speech_to_text.protocol import TranscriptionUsageAudio
+
+        return TranscriptionResponse(
+            text=text,
+            usage=TranscriptionUsageAudio(seconds=duration_seconds),
+        )
+
+    def _run(self, audio_input: dict, language: str | None = None) -> dict:
+        kwargs = {**self.config.pipeline_kwargs}
+        if language:
+            kwargs.setdefault("generate_kwargs", {})
+            kwargs["generate_kwargs"]["language"] = language
+        return self.pipeline(audio_input, **kwargs)  # type: ignore[return-value]
+
+
+class OpenAIServingTranslation(OpenAIServing):
+    request_id_prefix = "translate"
+
+    def __init__(self, pipeline: Pipeline, model_name: str, config: TransformersConfig):
+        self.pipeline = pipeline
+        self.model_name = model_name
+        self.config = config
+
+    @property
+    def _target_sr(self) -> int:
+        return self.pipeline.feature_extractor.sampling_rate
+
+    async def warmup(self) -> None:
+        logger.info("Warming up translation model: %s", self.model_name)
+        audio_input, _ = _decode_audio(MINIMAL_WAV, self._target_sr)
+        await self.run_in_executor(self._run, audio_input)
+        logger.info("Warmup translation done for %s", self.model_name)
+
+    async def create_translation(
+        self, audio_data: bytes, request: TranslationRequest, raw_request: RawRequestProxy
+    ) -> TranslationResponse | TranslationResponseVerbose | ErrorResponse:
+        request_id = f"{self.request_id_prefix}-{base_request_id(raw_request)}"
+        logger.info("translation request %s", request_id)
+        logger.log(TRACE, "translation request %s: audio_bytes=%d", request_id, len(audio_data))
+
+        try:
+            audio_input, _ = _decode_audio(audio_data, self._target_sr)
+            result = await self.run_in_executor(self._run, audio_input)
+        except Exception:
+            logger.exception("translation inference failed for %s", request_id)
+            return create_error_response("translation inference failed")
+
+        text = result["text"].strip()
+        logger.log(TRACE, "translation response %s: text=%r", request_id, text)
+
+        return TranslationResponse(text=text)
+
+    def _run(self, audio_input: dict) -> dict:
+        kwargs = {**self.config.pipeline_kwargs}
+        kwargs.setdefault("generate_kwargs", {})
+        kwargs["generate_kwargs"]["task"] = "translate"
+        return self.pipeline(audio_input, **kwargs)  # type: ignore[return-value]

--- a/modelship/infer/transformers/openai/serving_transcription.py
+++ b/modelship/infer/transformers/openai/serving_transcription.py
@@ -48,7 +48,7 @@ class OpenAIServingTranscription(OpenAIServing):
 
     @property
     def _target_sr(self) -> int:
-        return self.pipeline.feature_extractor.sampling_rate
+        return self.pipeline.feature_extractor.sampling_rate  # type: ignore[union-attr]
 
     async def warmup(self) -> None:
         logger.info("Warming up transcription model: %s", self.model_name)
@@ -101,7 +101,7 @@ class OpenAIServingTranslation(OpenAIServing):
 
     @property
     def _target_sr(self) -> int:
-        return self.pipeline.feature_extractor.sampling_rate
+        return self.pipeline.feature_extractor.sampling_rate  # type: ignore[union-attr]
 
     async def warmup(self) -> None:
         logger.info("Warming up translation model: %s", self.model_name)

--- a/modelship/infer/transformers/transformers_infer.py
+++ b/modelship/infer/transformers/transformers_infer.py
@@ -1,39 +1,56 @@
-import importlib
 from collections.abc import AsyncGenerator
-from typing import ClassVar, cast
 
 import torch
-from starlette.requests import Request
 
 from modelship.infer.base_infer import BaseInfer
-from modelship.infer.infer_config import DisconnectProxy, ModelshipModelConfig, ModelUsecase
-from modelship.infer.transformers.openai.serving_speech import OpenAIServingSpeech
+from modelship.infer.base_serving import OpenAIServing
+from modelship.infer.infer_config import ModelshipModelConfig, ModelUsecase, RawRequestProxy, TransformersConfig
 from modelship.logging import get_logger
 from modelship.openai.protocol import (
+    ChatCompletionRequest,
+    ChatCompletionResponse,
+    EmbeddingRequest,
+    EmbeddingResponse,
     ErrorResponse,
     RawSpeechResponse,
     SpeechRequest,
+    TranscriptionRequest,
+    TranscriptionResponse,
+    TranscriptionResponseVerbose,
+    TranslationRequest,
+    TranslationResponse,
+    TranslationResponseVerbose,
 )
-from modelship.plugins.base_plugin import BasePluginTransformers, PluginProtoTransformers
 
 logger = get_logger("infer.transformers")
 
+_TORCH_DTYPES = {
+    "float16": torch.float16,
+    "float32": torch.float32,
+    "bfloat16": torch.bfloat16,
+}
+
 
 class TransformersInfer(BaseInfer):
-    _transformers_usecases: ClassVar[list[ModelUsecase]] = [ModelUsecase.tts]
-
     def __init__(self, model_config: ModelshipModelConfig):
         super().__init__(model_config)
-        self.device = "cuda:0" if torch.cuda.is_available() else "cpu"
+        self.config = model_config.transformers_config or TransformersConfig()
+        self.device = self.config.device
+        self.torch_dtype = _TORCH_DTYPES.get(self.config.torch_dtype) if self.config.torch_dtype != "auto" else "auto"
 
         mem_frac = self._get_memory_fraction()
         if torch.cuda.is_available() and mem_frac is not None:
             torch.cuda.set_per_process_memory_fraction(mem_frac)
 
+        self._serving: list[OpenAIServing] = []
+
+    def shutdown(self) -> None:
+        pass
+
     def __del__(self):
         try:
-            if serving_speech := getattr(self, "serving_speech", None):
-                del serving_speech
+            for serving in getattr(self, "_serving", []):
+                del serving
             if torch.cuda.is_available():
                 torch.cuda.empty_cache()
         except Exception:
@@ -42,37 +59,115 @@ class TransformersInfer(BaseInfer):
             RESOURCE_CLEANUP_ERRORS_TOTAL.inc(tags={"model": self.model_config.name, "component": "transformers_model"})
 
     async def start(self):
-        self.serving_speech = await self.init_serving_speech()
-        if self.serving_speech and self.serving_speech.speech_model:
-            self._set_max_context_length(self.serving_speech.speech_model.max_context_length())
+        usecase = self.model_config.usecase
+        model_name = self.model_config.model
 
-    async def init_serving_speech(self) -> OpenAIServingSpeech | None:
-        logger.info("init serving speech with model: %s", self.model_config.name)
+        if usecase is ModelUsecase.generate:
+            from transformers import pipeline
 
-        speech_model: BasePluginTransformers | None = None
-        plugin = self.model_config.plugin
-        if plugin is not None:
-            logger.info("Loading plugin: %s", plugin)
-            module = cast("PluginProtoTransformers", importlib.import_module(plugin))
-            assert self.model_config.model is not None
-            speech_model = module.ModelPlugin(model_name=self.model_config.model, device=self.device)
+            from modelship.infer.transformers.openai.serving_chat import OpenAIServingChat
 
-        return OpenAIServingSpeech(speech_model=speech_model) if self.model_config.usecase is ModelUsecase.tts else None
+            pipe = pipeline(
+                "text-generation",
+                model=model_name,
+                device=self.device,
+                torch_dtype=self.torch_dtype,
+                trust_remote_code=self.config.trust_remote_code,
+                model_kwargs=self.config.model_kwargs,
+            )
+            self.serving_chat = OpenAIServingChat(pipe, self.model_config.name, self.config)
+            self._serving.append(self.serving_chat)
+
+        elif usecase is ModelUsecase.embed:
+            from sentence_transformers import SentenceTransformer
+
+            from modelship.infer.transformers.openai.serving_embedding import OpenAIServingEmbedding
+
+            model = SentenceTransformer(
+                model_name,
+                device=self.device,
+                trust_remote_code=self.config.trust_remote_code,
+                model_kwargs=self.config.model_kwargs,
+            )
+            self.serving_embedding = OpenAIServingEmbedding(model, self.model_config.name)
+            self._serving.append(self.serving_embedding)
+
+        elif usecase in (ModelUsecase.transcription, ModelUsecase.translation):
+            from transformers import pipeline
+
+            from modelship.infer.transformers.openai.serving_transcription import (
+                OpenAIServingTranscription,
+                OpenAIServingTranslation,
+            )
+
+            pipe = pipeline(
+                "automatic-speech-recognition",
+                model=model_name,
+                device=self.device,
+                torch_dtype=self.torch_dtype,
+                trust_remote_code=self.config.trust_remote_code,
+                model_kwargs=self.config.model_kwargs,
+            )
+            self.serving_transcription = OpenAIServingTranscription(pipe, self.model_config.name, self.config)
+            self.serving_translation = OpenAIServingTranslation(pipe, self.model_config.name, self.config)
+            self._serving.append(self.serving_transcription)
+            self._serving.append(self.serving_translation)
+
+        elif usecase is ModelUsecase.tts:
+            from transformers import pipeline
+
+            from modelship.infer.transformers.openai.serving_speech import OpenAIServingSpeech
+
+            pipe = pipeline(
+                "text-to-audio",
+                model=model_name,
+                device=self.device,
+                torch_dtype=self.torch_dtype,
+                trust_remote_code=self.config.trust_remote_code,
+                model_kwargs=self.config.model_kwargs,
+            )
+            self.serving_speech = OpenAIServingSpeech(pipe, self.model_config.name, self.config)
+            self._serving.append(self.serving_speech)
+
+        logger.info(
+            "TransformersInfer started for %s (usecase=%s, device=%s)", self.model_config.name, usecase, self.device
+        )
 
     async def warmup(self) -> None:
-        if self.serving_speech is None:
-            return
-        logger.info("Warming up transformers TTS model: %s", self.model_config.name)
-        request = SpeechRequest(model=self.model_config.name, input="warmup", voice="default")
-        result = await self.create_speech(request, DisconnectProxy(None, {}))
-        if isinstance(result, AsyncGenerator):
-            async for _ in result:
-                pass
-        logger.info("Warmup TTS done for %s", self.model_config.name)
+        for serving in self._serving:
+            await serving.warmup()
+
+    async def create_chat_completion(
+        self, request: ChatCompletionRequest, raw_request: RawRequestProxy
+    ) -> ErrorResponse | ChatCompletionResponse | AsyncGenerator[str, None]:
+        if not hasattr(self, "serving_chat"):
+            return await super().create_chat_completion(request, raw_request)
+        return await self.serving_chat.create_chat_completion(request, raw_request)
+
+    async def create_embedding(
+        self, request: EmbeddingRequest, raw_request: RawRequestProxy
+    ) -> EmbeddingResponse | ErrorResponse:
+        if not hasattr(self, "serving_embedding"):
+            return await super().create_embedding(request, raw_request)
+        return await self.serving_embedding.create_embedding(request, raw_request)
+
+    async def create_transcription(
+        self, audio_data: bytes, request: TranscriptionRequest, raw_request: RawRequestProxy
+    ) -> ErrorResponse | TranscriptionResponse | TranscriptionResponseVerbose | AsyncGenerator[str, None]:
+        if not hasattr(self, "serving_transcription"):
+            return await super().create_transcription(audio_data, request, raw_request)
+        return await self.serving_transcription.create_transcription(audio_data, request, raw_request)
+
+    async def create_translation(
+        self, audio_data: bytes, request: TranslationRequest, raw_request: RawRequestProxy
+    ) -> ErrorResponse | TranslationResponse | TranslationResponseVerbose | AsyncGenerator[str, None]:
+        if not hasattr(self, "serving_translation"):
+            return await super().create_translation(audio_data, request, raw_request)
+        return await self.serving_translation.create_translation(audio_data, request, raw_request)
 
     async def create_speech(
-        self, request: SpeechRequest, raw_request: DisconnectProxy
+        self, request: SpeechRequest, raw_request: RawRequestProxy
     ) -> ErrorResponse | RawSpeechResponse | AsyncGenerator[str, None]:
-        if self.serving_speech is None:
+        if not hasattr(self, "serving_speech"):
             return await super().create_speech(request, raw_request)
-        return await self.serving_speech.create_speech(request, cast("Request", raw_request))
+        return await self.serving_speech.create_speech(request, raw_request)

--- a/modelship/infer/vllm/vllm_infer.py
+++ b/modelship/infer/vllm/vllm_infer.py
@@ -19,7 +19,7 @@ from vllm.usage.usage_lib import UsageContext
 from vllm.v1.engine.async_llm import AsyncLLM
 
 from modelship.infer.base_infer import MINIMAL_WAV, BaseInfer
-from modelship.infer.infer_config import DisconnectProxy, ModelshipModelConfig, ModelUsecase, VllmEngineConfig
+from modelship.infer.infer_config import ModelshipModelConfig, ModelUsecase, RawRequestProxy, VllmEngineConfig
 from modelship.logging import get_logger
 from modelship.metrics import _ENABLED as _METRICS_ENABLED
 from modelship.openai.protocol import (
@@ -94,14 +94,19 @@ class VllmInfer(BaseInfer):
             stat_loggers=stat_loggers,
         )
 
-    def __del__(self):
+    def shutdown(self) -> None:
         try:
             if engine := getattr(self, "engine", None):
+                logger.info("Shutting down vllm engine for %s", self.model_config.name)
                 engine.shutdown()
         except Exception:
             from modelship.metrics import RESOURCE_CLEANUP_ERRORS_TOTAL
 
             RESOURCE_CLEANUP_ERRORS_TOTAL.inc(tags={"model": self.model_config.name, "component": "vllm_engine"})
+            logger.exception("Failed to shutdown vllm engine for %s", self.model_config.name)
+
+    def __del__(self):
+        self.shutdown()
 
     async def start(self):
         logger.info("Start vllm infer for model: %s", self.model_config)
@@ -117,7 +122,7 @@ class VllmInfer(BaseInfer):
 
     async def warmup(self) -> None:
         logger.info("Warming up vllm model: %s", self.model_config.name)
-        dummy_proxy = DisconnectProxy(None, {})
+        dummy_proxy = RawRequestProxy(None, {})
 
         if self.serving_chat is not None:
             request = ChatCompletionRequest(
@@ -254,21 +259,21 @@ class VllmInfer(BaseInfer):
         )
 
     async def create_chat_completion(
-        self, request: ChatCompletionRequest, raw_request: DisconnectProxy
+        self, request: ChatCompletionRequest, raw_request: RawRequestProxy
     ) -> ErrorResponse | ChatCompletionResponse | AsyncGenerator[str, None]:
         if self.serving_chat is None:
             return await super().create_chat_completion(request, raw_request)
         return await self.serving_chat.create_chat_completion(request, cast("Request", raw_request))
 
     async def create_embedding(
-        self, request: EmbeddingRequest, raw_request: DisconnectProxy
+        self, request: EmbeddingRequest, raw_request: RawRequestProxy
     ) -> ErrorResponse | Response:
         if self.serving_embedding is None:
             return await super().create_embedding(request, raw_request)
         return await self.serving_embedding(request, cast("Request", raw_request))
 
     async def create_transcription(
-        self, audio_data: bytes, request: TranscriptionRequest, raw_request: DisconnectProxy
+        self, audio_data: bytes, request: TranscriptionRequest, raw_request: RawRequestProxy
     ) -> ErrorResponse | TranscriptionResponse | TranscriptionResponseVerbose | AsyncGenerator[str, None]:
         if self.serving_transcription is None:
             return await super().create_transcription(audio_data, request, raw_request)
@@ -276,7 +281,7 @@ class VllmInfer(BaseInfer):
         return await self.serving_transcription.create_transcription(audio_data, request, cast("Request", raw_request))
 
     async def create_translation(
-        self, audio_data: bytes, request: TranslationRequest, raw_request: DisconnectProxy
+        self, audio_data: bytes, request: TranslationRequest, raw_request: RawRequestProxy
     ) -> ErrorResponse | TranslationResponse | TranslationResponseVerbose | AsyncGenerator[str, None]:
         if self.serving_translation is None:
             return await super().create_translation(audio_data, request, raw_request)

--- a/modelship/logging.py
+++ b/modelship/logging.py
@@ -87,9 +87,9 @@ def configure_logging() -> None:
     log_format = os.environ.get("MSHIP_LOG_FORMAT", "text").lower()
     log_target = os.environ.get("MSHIP_LOG_TARGET", "console").lower()
 
-    trace_mode = level_name == "TRACE"
-    app_level = logging.DEBUG if trace_mode else getattr(logging, level_name, logging.INFO)
-    lib_level = logging.DEBUG if trace_mode else logging.WARNING
+    levels = [TRACE, logging.DEBUG, logging.INFO, logging.WARNING, logging.ERROR, logging.CRITICAL]
+    app_level = TRACE if level_name == "TRACE" else getattr(logging, level_name, logging.INFO)
+    lib_level = next((lv for lv in levels if lv > app_level), logging.CRITICAL)
     lib_level_name = logging.getLevelName(lib_level)
 
     root_logger = logging.getLogger("modelship")

--- a/modelship/plugins/base_plugin.py
+++ b/modelship/plugins/base_plugin.py
@@ -2,41 +2,8 @@ from abc import ABC, abstractmethod
 from collections.abc import AsyncGenerator
 from typing import Literal, Protocol
 
-from vllm.config.model import ModelConfig
-from vllm.engine.protocol import EngineClient
-
 from modelship.infer.infer_config import ModelshipModelConfig
 from modelship.openai.protocol import ErrorResponse, RawSpeechResponse
-
-
-class BasePluginVllm(ABC):
-    @abstractmethod
-    def __init__(self, engine_client: EngineClient, model_config: ModelConfig):
-        pass
-
-    @abstractmethod
-    async def generate(
-        self, input: str, voice: str, request_id: str, stream_format: Literal["sse", "audio"]
-    ) -> RawSpeechResponse | AsyncGenerator[str, None] | ErrorResponse:
-        pass
-
-    def max_context_length(self) -> int | None:
-        return None
-
-
-class BasePluginTransformers(ABC):
-    @abstractmethod
-    def __init__(self, model_name: str, device: str):
-        pass
-
-    @abstractmethod
-    async def generate(
-        self, input: str, voice: str, request_id: str, stream_format: Literal["sse", "audio"]
-    ) -> RawSpeechResponse | AsyncGenerator[str, None] | ErrorResponse:
-        pass
-
-    def max_context_length(self) -> int | None:
-        return None
 
 
 class BasePlugin(ABC):
@@ -56,14 +23,6 @@ class BasePlugin(ABC):
 
     def max_context_length(self) -> int | None:
         return None
-
-
-class PluginProtoVllm(Protocol):
-    ModelPlugin: type[BasePluginVllm]
-
-
-class PluginProtoTransformers(Protocol):
-    ModelPlugin: type[BasePluginTransformers]
 
 
 class PluginProto(Protocol):

--- a/modelship/utils/__init__.py
+++ b/modelship/utils/__init__.py
@@ -2,18 +2,19 @@ import os
 import uuid
 
 import requests
-from fastapi import Request
+
+from modelship.infer.infer_config import RawRequestProxy
 
 
 def random_uuid() -> str:
     return str(uuid.uuid4().hex)
 
 
-def base_request_id(raw_request: Request | None, default: str | None = None) -> str | None:
-    """Pulls the request id to use from a header, if provided"""
-    default = default or random_uuid()
-    if raw_request is None:
-        return default
+def base_request_id(raw_request: RawRequestProxy | None = None) -> str:
+    """Return the request ID from a RawRequestProxy, or generate a new one."""
+    if raw_request is not None and raw_request.request_id is not None:
+        return raw_request.request_id
+    return random_uuid()
 
 
 def download(url: str, file_path: str, overwrite: bool = False):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,8 @@ dependencies = [
     "pydantic-yaml>=1.6.0",
     "python-multipart>=0.0.20",
     "ray[data,default,serve-grpc]>=2.51.1",
-    "scipy>=1.16.1",
+    "librosa>=0.11.0",
+    "soundfile>=0.13.0",
     "torch>=2.10.0",
     "torchvision>=0.25.0",
     "transformers>=4.57.5",
@@ -36,6 +37,7 @@ dependencies = [
     "requests>=2.32.5",
     "accelerate>=1.6.0",
     "diffusers>=0.31.0",
+    "sentence-transformers>=3.0.0",
 ]
 
 [project.optional-dependencies]

--- a/start.py
+++ b/start.py
@@ -141,6 +141,11 @@ def build_actor_options(config: ModelshipModelConfig) -> dict:
 
     env_vars = _build_cache_env_vars()
 
+    for log_var in ("MSHIP_LOG_LEVEL", "MSHIP_LOG_FORMAT", "MSHIP_LOG_TARGET"):
+        val = os.environ.get(log_var)
+        if val is not None:
+            env_vars[log_var] = val
+
     if tp > 1 and tp_backend != "mp" and config.num_gpus > 0:
         # ray backend: set per-worker GPU fraction so vLLM worker actors claim the
         # right amount. Only override when num_gpus is explicitly set; otherwise
@@ -238,7 +243,7 @@ def main(argv: list[str] | None = None):
     deployed_this_run: dict[str, str] = {}
 
     def _cleanup(sig, frame):
-        logger.info("Interrupted (signal %s), cleaning up deployments from this run...", sig)
+        logger.info("Shutting down (signal %s), cleaning up deployments from this run...", sig)
         for name in reversed(deployed_this_run):
             try:
                 logger.info("Deleting deployment: %s", name)
@@ -247,7 +252,7 @@ def main(argv: list[str] | None = None):
                 logger.exception("Failed to delete deployment: %s", name)
         if fresh_install:
             _shutdown_ray()
-        sys.exit(1)
+        sys.exit(0)
 
     signal.signal(signal.SIGINT, _cleanup)
     signal.signal(signal.SIGTERM, _cleanup)
@@ -297,8 +302,11 @@ def main(argv: list[str] | None = None):
 
         if fresh_install:
             # On fresh install, stay alive as the operator process.
-            signal.signal(signal.SIGINT, lambda s, f: (_shutdown_ray(), sys.exit(0)))
-            signal.signal(signal.SIGTERM, lambda s, f: (_shutdown_ray(), sys.exit(0)))
+            # Reuse _cleanup which gracefully deletes each deployment (letting actors
+            # run __del__ and clean up child processes like vllm EngineCore) before
+            # tearing down Ray.
+            signal.signal(signal.SIGINT, _cleanup)
+            signal.signal(signal.SIGTERM, _cleanup)
             signal.pause()
 
     except BaseException as e:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -8,6 +8,7 @@ from modelship.infer.infer_config import (
     ModelshipConfig,
     ModelshipModelConfig,
     ModelUsecase,
+    TransformersConfig,
     VllmEngineConfig,
 )
 
@@ -172,6 +173,83 @@ class TestModelshipConfig:
         )
         assert len(config.models) == 2
         assert config.models[0].name == config.models[1].name == "kokoro"
+
+
+class TestTransformersConfig:
+    def test_defaults(self):
+        config = TransformersConfig()
+        assert config.device == "cpu"
+        assert config.torch_dtype == "auto"
+        assert config.trust_remote_code is False
+        assert config.model_kwargs == {}
+        assert config.pipeline_kwargs == {}
+
+    def test_custom_values(self):
+        config = TransformersConfig(
+            device="cuda:0",
+            torch_dtype="float16",
+            trust_remote_code=True,
+            model_kwargs={"attn_implementation": "flash_attention_2"},
+        )
+        assert config.device == "cuda:0"
+        assert config.torch_dtype == "float16"
+        assert config.trust_remote_code is True
+        assert config.model_kwargs == {"attn_implementation": "flash_attention_2"}
+
+    def test_transformers_generate_model(self):
+        config = ModelshipModelConfig(
+            name="llm-cpu",
+            model="meta-llama/Llama-3.2-1B-Instruct",
+            usecase=ModelUsecase.generate,
+            loader=ModelLoader.transformers,
+            num_cpus=4,
+            transformers_config=TransformersConfig(torch_dtype="float32"),
+        )
+        assert config.loader == ModelLoader.transformers
+        assert config.usecase == ModelUsecase.generate
+        assert config.transformers_config.torch_dtype == "float32"
+
+    def test_transformers_embed_model(self):
+        config = ModelshipModelConfig(
+            name="embed",
+            model="nomic-ai/nomic-embed-text-v1.5",
+            usecase=ModelUsecase.embed,
+            loader=ModelLoader.transformers,
+            num_cpus=2,
+            transformers_config=TransformersConfig(trust_remote_code=True),
+        )
+        assert config.usecase == ModelUsecase.embed
+        assert config.transformers_config.trust_remote_code is True
+
+    def test_transformers_transcription_model(self):
+        config = ModelshipModelConfig(
+            name="whisper-cpu",
+            model="openai/whisper-base",
+            usecase=ModelUsecase.transcription,
+            loader=ModelLoader.transformers,
+            num_cpus=2,
+        )
+        assert config.usecase == ModelUsecase.transcription
+        assert config.transformers_config is None
+
+    def test_transformers_tts_model(self):
+        config = ModelshipModelConfig(
+            name="tts",
+            model="microsoft/speecht5_tts",
+            usecase=ModelUsecase.tts,
+            loader=ModelLoader.transformers,
+            num_cpus=1,
+        )
+        assert config.usecase == ModelUsecase.tts
+
+    def test_transformers_config_not_required(self):
+        config = ModelshipModelConfig(
+            name="test",
+            model="some-model",
+            usecase=ModelUsecase.generate,
+            loader=ModelLoader.transformers,
+        )
+        assert config.transformers_config is None
 
 
 class TestNumReplicas:

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -87,16 +87,18 @@ class TestConfigureLogging:
             assert os.environ.get(env_var) == "WARNING"
 
     @patch.dict(os.environ, {"MSHIP_LOG_LEVEL": "DEBUG"})
-    def test_lib_loggers_stay_warning_at_debug(self):
+    def test_lib_loggers_info_at_debug(self):
         configure_logging()
         assert logging.getLogger("modelship").level == logging.DEBUG
         for name in _LIB_LOGGERS:
-            assert logging.getLogger(name).level == logging.WARNING
+            assert logging.getLogger(name).level == logging.INFO
 
     @patch.dict(os.environ, {"MSHIP_LOG_LEVEL": "TRACE"})
-    def test_trace_mode_enables_all_debug(self):
+    def test_trace_mode_sets_trace_app_debug_libs(self):
+        from modelship.logging import TRACE
+
         configure_logging()
-        assert logging.getLogger("modelship").level == logging.DEBUG
+        assert logging.getLogger("modelship").level == TRACE
         for name in _LIB_LOGGERS:
             assert logging.getLogger(name).level == logging.DEBUG
         for env_var in _LIB_ENV_VARS:

--- a/uv.lock
+++ b/uv.lock
@@ -1441,13 +1441,15 @@ dependencies = [
     { name = "fastapi" },
     { name = "flashinfer-python" },
     { name = "httpx" },
+    { name = "librosa" },
     { name = "numpy" },
     { name = "pydantic" },
     { name = "pydantic-yaml" },
     { name = "python-multipart" },
     { name = "ray", extra = ["data", "default", "serve-grpc"] },
     { name = "requests" },
-    { name = "scipy" },
+    { name = "sentence-transformers" },
+    { name = "soundfile" },
     { name = "torch" },
     { name = "torchvision" },
     { name = "transformers" },
@@ -1487,6 +1489,7 @@ requires-dist = [
     { name = "flashinfer-python", specifier = ">=0.6.1" },
     { name = "httpx", specifier = ">=0.28.1" },
     { name = "kokoro", marker = "extra == 'kokoro'", editable = "plugins/kokoro" },
+    { name = "librosa", specifier = ">=0.11.0" },
     { name = "numpy", specifier = ">=2.2.6" },
     { name = "opentelemetry-exporter-otlp", marker = "extra == 'otel'", specifier = ">=1.20.0" },
     { name = "opentelemetry-sdk", marker = "extra == 'otel'", specifier = ">=1.20.0" },
@@ -1501,7 +1504,8 @@ requires-dist = [
     { name = "ray", extras = ["data", "default", "serve-grpc"], specifier = ">=2.51.1" },
     { name = "requests", specifier = ">=2.32.5" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.11.0" },
-    { name = "scipy", specifier = ">=1.16.1" },
+    { name = "sentence-transformers", specifier = ">=3.0.0" },
+    { name = "soundfile", specifier = ">=0.13.0" },
     { name = "torch", specifier = ">=2.10.0" },
     { name = "torchvision", specifier = ">=0.25.0" },
     { name = "transformers", specifier = ">=4.57.5" },
@@ -3075,6 +3079,25 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/9b/4c/25e499df952528004ff3f7f8e1e63d20773ed30141ed17c285adb5446f55/segments-2.3.0.tar.gz", hash = "sha256:381143f66f59eaf45398f5bb57f899d6501be011048ec5f92754c9b24b181615", size = 18193, upload-time = "2025-02-20T07:55:42.273Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/11/18/cb614939ccd46d336013cab705f1e11540ec9c68b08ecbb854ab893fc480/segments-2.3.0-py2.py3-none-any.whl", hash = "sha256:30a5656787071430cd22422e04713b2a9beabe1a97d2ebf37f716a56f90577a3", size = 15705, upload-time = "2025-02-20T07:55:39.755Z" },
+]
+
+[[package]]
+name = "sentence-transformers"
+version = "5.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "huggingface-hub" },
+    { name = "numpy" },
+    { name = "scikit-learn" },
+    { name = "scipy" },
+    { name = "torch" },
+    { name = "tqdm" },
+    { name = "transformers" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/19/b0/fcc810aa1747e96eb2e342e16173dbebbff85b8ccd079f35b32874c5f6ce/sentence_transformers-5.4.0.tar.gz", hash = "sha256:ef0c129d653f736df5fd74d46af11a2234328a32cddb1d91a1975c5f6cccc194", size = 428330, upload-time = "2026-04-09T13:34:12.642Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5a/d4/58f3e1308c8d15cae83407bd651542b62155a2b3248e0290a724e80fd124/sentence_transformers-5.4.0-py3-none-any.whl", hash = "sha256:4e5ac9a19244153f3f4074d898e664990408d7b077fb1d1d0dc9cb8a9316feac", size = 570836, upload-time = "2026-04-09T13:34:11.298Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Add full CPU/GPU inference support via HuggingFace Transformers for chat,
embeddings, transcription, translation, and TTS use cases. Fix TRACE log
level to actually emit level-5 messages and add request/response payload
logging across all serving modules. Fix Whisper hallucination bug caused
by missing audio resampling -- decode audio with librosa and resample to
the model expected sample rate. Forward MSHIP_LOG_LEVEL to Ray worker
processes via runtime_env. Update docs with new backend comparison,
architecture diagram, and Transformers loader examples.
