### PR TITLE
feat: add --openai-api-port flag and run container as non-root user

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,7 +3,11 @@
   "build": {
     "dockerfile": "../Dockerfile",
     "target": "dev",
-    "context": ".."
+    "context": "..",
+    "args": {
+      "UID": "${localEnv:UID:1000}",
+      "GID": "${localEnv:GID:1000}"
+    }
   },
   "features": {
     "ghcr.io/devcontainers/features/node:1": {
@@ -25,12 +29,13 @@
     "8265": { "label": "Ray Dashboard" }
   },
   "mounts": [
-    "source=${localEnv:HOME}/.claude,target=/root/.claude,type=bind"
+    "source=${localEnv:HOME}/.claude,target=/home/modelship/.claude,type=bind"
   ],
   "postCreateCommand": "npm install -g @anthropic-ai/claude-code",
   "containerEnv": {
-    "CLAUDE_CONFIG_DIR": "/root/.claude"
+    "CLAUDE_CONFIG_DIR": "/home/modelship/.claude"
   },
+  "remoteUser": "modelship",
   "remoteEnv": {
     "HF_TOKEN": "${localEnv:HF_TOKEN}",
     "MSHIP_PLUGINS": "${localEnv:MSHIP_PLUGINS}",

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,8 @@ FROM ubuntu:24.04 AS base
 
 ARG CUDA_VERSION
 ARG PYTHON_VERSION
+ARG UID=1000
+ARG GID=1000
 
 RUN apt-get update -y && \
     apt-get install -y --no-install-recommends ca-certificates curl gnupg && \
@@ -32,6 +34,13 @@ RUN CUDA_VERSION_DASH=$(echo $CUDA_VERSION | cut -d. -f1,2 | tr '.' '-') && CUDA
         libcublas-${CUDA_VERSION_DASH} \
         cudnn9-cuda-${CUDA_MAJOR_VERSION}
 
+# Create non-root user matching host UID/GID
+# If a group with the target GID already exists (e.g. ubuntu:1000), reuse it;
+# if a user with the target UID already exists, reuse and rename it.
+RUN if ! getent group $GID >/dev/null; then groupadd -g $GID modelship; fi && \
+    if ! getent passwd $UID >/dev/null; then useradd -m -u $UID -g $GID modelship; \
+    else existing=$(getent passwd $UID | cut -d: -f1) && usermod -l modelship -d /home/modelship -m "$existing"; fi
+
 # Install uv
 COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /bin/
 ENV UV_LINK_MODE=copy
@@ -56,23 +65,26 @@ ENV MSHIP_METRICS=true
 ENV RAY_METRICS_EXPORT_PORT=8079
 ENV MSHIP_LOG_LEVEL=INFO
 ENV MSHIP_LOG_FORMAT=text
+ARG PYTHON_VERSION
+ENV UV_PYTHON_INSTALL_DIR=/usr/local/uv/python
+RUN uv python install ${PYTHON_VERSION}
 RUN uv venv
 
-ARG PYTHON_VERSION
-RUN uv python install ${PYTHON_VERSION}
-
 ENV PATH="$UV_PROJECT_ENVIRONMENT/bin:$PATH"
+
+RUN chown -R $UID:$GID /modelship $UV_PROJECT_ENVIRONMENT
 
 # ---------------------------------------------------------------------------
 # Development target
 # ---------------------------------------------------------------------------
 FROM base AS dev
 
-RUN --mount=type=cache,target=/root/.cache/uv \
+USER modelship
+
+RUN --mount=type=cache,target=/home/modelship/.cache/uv,uid=$UID,gid=$GID \
     uv sync --locked --no-install-project --extra dev
 
-ADD ./scripts/start_ray.sh /modelship/scripts/start_ray.sh
-RUN chmod +x /modelship/scripts/start_ray.sh
+ADD --chown=$UID:$GID ./scripts/start_ray.sh /modelship/scripts/start_ray.sh
 
 CMD ["/bin/bash"]
 
@@ -81,13 +93,13 @@ CMD ["/bin/bash"]
 # ---------------------------------------------------------------------------
 FROM base AS prod
 
-ADD ./start.py start.py
-ADD ./modelship modelship
-ADD ./scripts scripts
+ADD --chown=$UID:$GID ./start.py start.py
+ADD --chown=$UID:$GID ./modelship modelship
+ADD --chown=$UID:$GID ./scripts scripts
 
-RUN --mount=type=cache,target=/root/.cache/uv \
+USER modelship
+
+RUN --mount=type=cache,target=/home/modelship/.cache/uv,uid=$UID,gid=$GID \
     uv sync --locked --no-install-project
-
-RUN chmod +x /modelship/scripts/start_ray.sh /modelship/scripts/start.sh
 
 CMD ["uv", "run", "--active", "bash", "/modelship/scripts/start.sh"]

--- a/start.py
+++ b/start.py
@@ -71,6 +71,11 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         "--max-request-body-bytes", type=int, help="Max request body size in bytes (env: MSHIP_MAX_REQUEST_BODY_BYTES)"
     )
     parser.add_argument(
+        "--openai-api-port",
+        type=int,
+        help="Port for the OpenAI-compatible API (env: MSHIP_OPENAI_API_PORT, default: 8000)",
+    )
+    parser.add_argument(
         "--redeploy",
         action="store_true",
         default=False,
@@ -105,6 +110,9 @@ def _apply_args_to_env(args: argparse.Namespace) -> None:
 
     if args.max_request_body_bytes is not None:
         os.environ["MSHIP_MAX_REQUEST_BODY_BYTES"] = str(args.max_request_body_bytes)
+
+    if args.openai_api_port is not None:
+        os.environ["MSHIP_OPENAI_API_PORT"] = str(args.openai_api_port)
 
 
 def build_actor_options(config: ModelshipModelConfig) -> dict:
@@ -202,7 +210,8 @@ def main(argv: list[str] | None = None):
 
     ray_address = f"{ray_cluster_address}:{ray_redis_port}" if use_existing_cluster else "auto"
     ray.init(address=ray_address, ignore_reinit_error=True)
-    serve.start(http_options=HTTPOptions(host="0.0.0.0"))
+    openai_api_port = int(os.environ.get("MSHIP_OPENAI_API_PORT", "8000"))
+    serve.start(http_options=HTTPOptions(host="0.0.0.0", port=openai_api_port))
 
     existing_apps = set() if args.redeploy else _get_existing_apps()
     fresh_install = gateway_name not in existing_apps


### PR DESCRIPTION
Add MSHIP_OPENAI_API_PORT env var and --openai-api-port CLI flag to configure the OpenAI-compatible API port (default: 8000).

Also switch Dockerfile and devcontainer to run as a non-root "modelship" user with configurable UID/GID for better security.


