### PR TITLE
refactor: decouple OpenAI protocol models from vLLM

### DIFF
--- a/modelship/infer/infer_config.py
+++ b/modelship/infer/infer_config.py
@@ -1,12 +1,13 @@
 import asyncio
 from enum import StrEnum
-from typing import Any
+from typing import Any, Literal
 
 import ray
 from fastapi import Request
 from pydantic import BaseModel, Field, model_validator
 from starlette.datastructures import Headers, State
-from vllm.entrypoints.chat_utils import ChatTemplateContentFormatOption
+
+ChatTemplateContentFormatOption = Literal["auto", "string", "openai"]
 
 
 class ModelUsecase(StrEnum):

--- a/modelship/infer/transformers/openai/serving_chat.py
+++ b/modelship/infer/transformers/openai/serving_chat.py
@@ -12,7 +12,13 @@ from modelship.logging import TRACE, get_logger
 from modelship.openai.protocol import (
     ChatCompletionRequest,
     ChatCompletionResponse,
+    ChatCompletionResponseChoice,
+    ChatCompletionResponseStreamChoice,
+    ChatCompletionStreamResponse,
+    ChatMessage,
+    DeltaMessage,
     ErrorResponse,
+    UsageInfo,
     create_error_response,
 )
 from modelship.utils import base_request_id
@@ -64,12 +70,6 @@ class OpenAIServingChat(OpenAIServing):
         completion_text = generated[-1]["content"] if isinstance(generated, list) else generated
         completion_tokens = len(self.tokenizer.encode(completion_text))
 
-        from vllm.entrypoints.openai.chat_completion.protocol import (
-            ChatCompletionResponseChoice,
-            ChatMessage,
-        )
-        from vllm.entrypoints.openai.engine.protocol import UsageInfo
-
         response = ChatCompletionResponse(
             id=request_id,
             model=self.model_name,
@@ -104,12 +104,6 @@ class OpenAIServingChat(OpenAIServing):
         return self.pipeline(messages, return_full_text=False, **kwargs)  # type: ignore[return-value]
 
     async def _stream(self, request_id: str, messages: list[dict], max_tokens: int | None) -> AsyncGenerator[str, None]:
-        from vllm.entrypoints.openai.chat_completion.protocol import (
-            ChatCompletionResponseStreamChoice,
-            ChatCompletionStreamResponse,
-        )
-        from vllm.entrypoints.openai.engine.protocol import DeltaMessage
-
         streamer = TextIteratorStreamer(self.tokenizer, skip_prompt=True, skip_special_tokens=True)  # type: ignore[arg-type]
 
         kwargs = {**self.config.pipeline_kwargs}

--- a/modelship/infer/transformers/openai/serving_embedding.py
+++ b/modelship/infer/transformers/openai/serving_embedding.py
@@ -1,13 +1,18 @@
 import time
 
 from sentence_transformers import SentenceTransformer
-from vllm.entrypoints.openai.engine.protocol import UsageInfo
-from vllm.entrypoints.pooling.embed.protocol import EmbeddingResponseData
 
 from modelship.infer.base_serving import OpenAIServing
 from modelship.infer.infer_config import RawRequestProxy
 from modelship.logging import TRACE, get_logger
-from modelship.openai.protocol import EmbeddingRequest, EmbeddingResponse, ErrorResponse, create_error_response
+from modelship.openai.protocol import (
+    EmbeddingRequest,
+    EmbeddingResponse,
+    EmbeddingResponseData,
+    ErrorResponse,
+    UsageInfo,
+    create_error_response,
+)
 from modelship.utils import base_request_id
 
 logger = get_logger("infer.transformers.embedding")

--- a/modelship/infer/transformers/openai/serving_transcription.py
+++ b/modelship/infer/transformers/openai/serving_transcription.py
@@ -14,6 +14,7 @@ from modelship.openai.protocol import (
     TranscriptionRequest,
     TranscriptionResponse,
     TranscriptionResponseVerbose,
+    TranscriptionUsageAudio,
     TranslationRequest,
     TranslationResponse,
     TranslationResponseVerbose,
@@ -75,8 +76,6 @@ class OpenAIServingTranscription(OpenAIServing):
 
         text = result["text"].strip()
         logger.log(TRACE, "transcription response %s: text=%r, duration=%ds", request_id, text, duration_seconds)
-
-        from vllm.entrypoints.openai.speech_to_text.protocol import TranscriptionUsageAudio
 
         return TranscriptionResponse(
             text=text,

--- a/modelship/infer/vllm/vllm_infer.py
+++ b/modelship/infer/vllm/vllm_infer.py
@@ -9,10 +9,22 @@ from vllm.config.model import ModelDType
 from vllm.config.parallel import DistributedExecutorBackend
 from vllm.engine.arg_utils import AsyncEngineArgs
 from vllm.entrypoints.logger import RequestLogger
+from vllm.entrypoints.openai.chat_completion.protocol import (
+    ChatCompletionRequest as VllmChatCompletionRequest,
+)
 from vllm.entrypoints.openai.chat_completion.serving import OpenAIServingChat
 from vllm.entrypoints.openai.models.protocol import BaseModelPath
 from vllm.entrypoints.openai.models.serving import OpenAIServingModels
+from vllm.entrypoints.openai.speech_to_text.protocol import (
+    TranscriptionRequest as VllmTranscriptionRequest,
+)
+from vllm.entrypoints.openai.speech_to_text.protocol import (
+    TranslationRequest as VllmTranslationRequest,
+)
 from vllm.entrypoints.openai.speech_to_text.serving import OpenAIServingTranscription, OpenAIServingTranslation
+from vllm.entrypoints.pooling.embed.protocol import (
+    EmbeddingCompletionRequest as VllmEmbeddingCompletionRequest,
+)
 from vllm.entrypoints.pooling.embed.serving import ServingEmbedding
 from vllm.entrypoints.serve.render.serving import OpenAIServingRender
 from vllm.usage.usage_lib import UsageContext
@@ -263,26 +275,43 @@ class VllmInfer(BaseInfer):
     ) -> ErrorResponse | ChatCompletionResponse | AsyncGenerator[str, None]:
         if self.serving_chat is None:
             return await super().create_chat_completion(request, raw_request)
-        return await self.serving_chat.create_chat_completion(request, cast("Request", raw_request))
+        vllm_request = VllmChatCompletionRequest(**request.model_dump())
+        result = await self.serving_chat.create_chat_completion(vllm_request, cast("Request", raw_request))
+        return cast("ErrorResponse | ChatCompletionResponse | AsyncGenerator[str, None]", result)
 
     async def create_embedding(
         self, request: EmbeddingRequest, raw_request: RawRequestProxy
     ) -> ErrorResponse | Response:
         if self.serving_embedding is None:
             return await super().create_embedding(request, raw_request)
-        return await self.serving_embedding(request, cast("Request", raw_request))
+        vllm_request = VllmEmbeddingCompletionRequest(**request.model_dump())
+        return cast(
+            "ErrorResponse | Response", await self.serving_embedding(vllm_request, cast("Request", raw_request))
+        )
 
     async def create_transcription(
         self, audio_data: bytes, request: TranscriptionRequest, raw_request: RawRequestProxy
     ) -> ErrorResponse | TranscriptionResponse | TranscriptionResponseVerbose | AsyncGenerator[str, None]:
         if self.serving_transcription is None:
             return await super().create_transcription(audio_data, request, raw_request)
-        request.timestamp_granularities = []
-        return await self.serving_transcription.create_transcription(audio_data, request, cast("Request", raw_request))
+        vllm_request = VllmTranscriptionRequest(**request.model_dump())
+        vllm_request.timestamp_granularities = []
+        result = await self.serving_transcription.create_transcription(
+            audio_data, vllm_request, cast("Request", raw_request)
+        )
+        return cast(
+            "ErrorResponse | TranscriptionResponse | TranscriptionResponseVerbose | AsyncGenerator[str, None]", result
+        )
 
     async def create_translation(
         self, audio_data: bytes, request: TranslationRequest, raw_request: RawRequestProxy
     ) -> ErrorResponse | TranslationResponse | TranslationResponseVerbose | AsyncGenerator[str, None]:
         if self.serving_translation is None:
             return await super().create_translation(audio_data, request, raw_request)
-        return await self.serving_translation.create_translation(audio_data, request, cast("Request", raw_request))
+        vllm_request = VllmTranslationRequest(**request.model_dump())
+        result = await self.serving_translation.create_translation(
+            audio_data, vllm_request, cast("Request", raw_request)
+        )
+        return cast(
+            "ErrorResponse | TranslationResponse | TranslationResponseVerbose | AsyncGenerator[str, None]", result
+        )

--- a/modelship/openai/protocol.py
+++ b/modelship/openai/protocol.py
@@ -1,52 +1,348 @@
 """
-Centralised re-exports of the OpenAI-compatible protocol models used for
-FastAPI request/response validation.
+OpenAI-compatible protocol models for request/response validation.
 
 Every backend (vllm, transformers, custom) and the API gateway import from
-here instead of reaching into vllm internals directly.  If the upstream
-module paths change, or we decide to define our own models, only this file
-needs updating.
+here instead of reaching into framework internals directly.  These are
+standalone Pydantic models following the OpenAI API specification, with no
+dependency on vLLM or any other inference engine.
 """
 
-from typing import Literal
+import time
+import uuid
+from http import HTTPStatus
+from typing import Any, ClassVar, Literal
 
-from pydantic import BaseModel, Field
+from fastapi import UploadFile
+from pydantic import BaseModel, ConfigDict, Field
 
-# -- chat completion --------------------------------------------------------
-from vllm.entrypoints.openai.chat_completion.protocol import (
-    ChatCompletionRequest,
-    ChatCompletionResponse,
-)
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
 
-# -- engine / base ----------------------------------------------------------
-from vllm.entrypoints.openai.engine.protocol import (
-    ErrorInfo,
-    ErrorResponse,
-    OpenAIBaseModel,
-)
-
-# -- speech-to-text ---------------------------------------------------------
-from vllm.entrypoints.openai.speech_to_text.protocol import (
-    TranscriptionRequest,
-    TranscriptionResponse,
-    TranscriptionResponseVerbose,
-    TranslationRequest,
-    TranslationResponse,
-    TranslationResponseVerbose,
-)
-
-# -- embeddings -------------------------------------------------------------
-from vllm.entrypoints.pooling.embed.protocol import (
-    EmbeddingCompletionRequest,
-    EmbeddingRequest,
-    EmbeddingResponse,
-)
-
-# -- utilities --------------------------------------------------------------
-from vllm.entrypoints.utils import create_error_response
+_MASK_64_BITS = (1 << 64) - 1
 
 
-# -- text-to-speech (not yet provided by vllm) ------------------------------
+def random_uuid() -> str:
+    return f"{uuid.uuid4().int & _MASK_64_BITS:016x}"
+
+
+# ---------------------------------------------------------------------------
+# Base
+# ---------------------------------------------------------------------------
+
+
+class OpenAIBaseModel(BaseModel):
+    model_config = ConfigDict(extra="allow")
+
+
+# ---------------------------------------------------------------------------
+# Error
+# ---------------------------------------------------------------------------
+
+
+class ErrorInfo(OpenAIBaseModel):
+    message: str
+    type: str
+    param: str | None = None
+    code: int
+
+
+class ErrorResponse(OpenAIBaseModel):
+    error: ErrorInfo
+
+
+def create_error_response(
+    message: str | Exception,
+    err_type: str = "BadRequestError",
+    status_code: HTTPStatus = HTTPStatus.BAD_REQUEST,
+    param: str | None = None,
+) -> ErrorResponse:
+    if isinstance(message, Exception):
+        exc = message
+        if isinstance(exc, ValueError | TypeError | OverflowError):
+            err_type = "BadRequestError"
+            status_code = HTTPStatus.BAD_REQUEST
+            param = None
+        elif isinstance(exc, NotImplementedError):
+            err_type = "NotImplementedError"
+            status_code = HTTPStatus.NOT_IMPLEMENTED
+            param = None
+        else:
+            err_type = "InternalServerError"
+            status_code = HTTPStatus.INTERNAL_SERVER_ERROR
+            param = None
+        message = str(exc)
+
+    return ErrorResponse(
+        error=ErrorInfo(
+            message=message,
+            type=err_type,
+            code=status_code.value,
+            param=param,
+        )
+    )
+
+
+# ---------------------------------------------------------------------------
+# Usage
+# ---------------------------------------------------------------------------
+
+
+class PromptTokenUsageInfo(OpenAIBaseModel):
+    cached_tokens: int | None = None
+
+
+class UsageInfo(OpenAIBaseModel):
+    prompt_tokens: int = 0
+    total_tokens: int = 0
+    completion_tokens: int | None = 0
+    prompt_tokens_details: PromptTokenUsageInfo | None = None
+
+
+# ---------------------------------------------------------------------------
+# Chat completion — tool calls
+# ---------------------------------------------------------------------------
+
+
+class FunctionCall(OpenAIBaseModel):
+    id: str | None = Field(default=None, exclude=True)
+    name: str
+    arguments: str
+
+
+class ToolCall(OpenAIBaseModel):
+    id: str = Field(default_factory=lambda: f"chatcmpl-tool-{random_uuid()}")
+    type: Literal["function"] = "function"
+    function: FunctionCall
+
+
+class DeltaFunctionCall(BaseModel):
+    name: str | None = None
+    arguments: str | None = None
+
+
+class DeltaToolCall(OpenAIBaseModel):
+    id: str | None = None
+    type: Literal["function"] | None = None
+    index: int
+    function: DeltaFunctionCall | None = None
+
+
+# ---------------------------------------------------------------------------
+# Chat completion — logprobs
+# ---------------------------------------------------------------------------
+
+
+class ChatCompletionLogProb(OpenAIBaseModel):
+    token: str
+    logprob: float = -9999.0
+    bytes: list[int] | None = None
+
+
+class ChatCompletionLogProbsContent(ChatCompletionLogProb):
+    field_names: ClassVar[set[str] | None] = None
+    top_logprobs: list[ChatCompletionLogProb] = Field(default_factory=list)
+
+
+class ChatCompletionLogProbs(OpenAIBaseModel):
+    content: list[ChatCompletionLogProbsContent] | None = None
+
+
+# ---------------------------------------------------------------------------
+# Chat completion — request
+# ---------------------------------------------------------------------------
+
+
+class StreamOptions(OpenAIBaseModel):
+    include_usage: bool | None = False
+    continuous_usage_stats: bool | None = False
+
+
+ChatCompletionMessageParam = dict[str, Any]
+
+
+class ChatCompletionRequest(OpenAIBaseModel):
+    messages: list[ChatCompletionMessageParam]
+    model: str | None = None
+    frequency_penalty: float | None = 0.0
+    logit_bias: dict[str, float] | None = None
+    logprobs: bool | None = False
+    top_logprobs: int | None = 0
+    max_tokens: int | None = None
+    max_completion_tokens: int | None = None
+    n: int | None = 1
+    presence_penalty: float | None = 0.0
+    response_format: dict[str, Any] | None = None
+    seed: int | None = None
+    stop: str | list[str] | None = []
+    stream: bool | None = False
+    stream_options: StreamOptions | None = None
+    temperature: float | None = None
+    top_p: float | None = None
+    tools: list[dict[str, Any]] | None = None
+    tool_choice: str | dict[str, Any] | None = "none"
+    reasoning_effort: Literal["none", "low", "medium", "high"] | None = None
+    parallel_tool_calls: bool | None = True
+    user: str | None = None
+
+
+# ---------------------------------------------------------------------------
+# Chat completion — response
+# ---------------------------------------------------------------------------
+
+
+class ChatMessage(OpenAIBaseModel):
+    role: str
+    content: str | None = None
+    refusal: str | None = None
+    tool_calls: list[ToolCall] = Field(default_factory=list)
+    reasoning: str | None = None
+
+
+class ChatCompletionResponseChoice(OpenAIBaseModel):
+    index: int
+    message: ChatMessage
+    logprobs: ChatCompletionLogProbs | None = None
+    finish_reason: str | None = "stop"
+    stop_reason: int | str | None = None
+
+
+class ChatCompletionResponse(OpenAIBaseModel):
+    id: str = Field(default_factory=lambda: f"chatcmpl-{random_uuid()}")
+    object: Literal["chat.completion"] = "chat.completion"
+    created: int = Field(default_factory=lambda: int(time.time()))
+    model: str
+    choices: list[ChatCompletionResponseChoice]
+    usage: UsageInfo
+
+
+# ---------------------------------------------------------------------------
+# Chat completion — streaming response
+# ---------------------------------------------------------------------------
+
+
+class DeltaMessage(OpenAIBaseModel):
+    role: str | None = None
+    content: str | None = None
+    reasoning: str | None = None
+    tool_calls: list[DeltaToolCall] = Field(default_factory=list)
+
+
+class ChatCompletionResponseStreamChoice(OpenAIBaseModel):
+    index: int
+    delta: DeltaMessage
+    logprobs: ChatCompletionLogProbs | None = None
+    finish_reason: str | None = None
+    stop_reason: int | str | None = None
+
+
+class ChatCompletionStreamResponse(OpenAIBaseModel):
+    id: str = Field(default_factory=lambda: f"chatcmpl-{random_uuid()}")
+    object: Literal["chat.completion.chunk"] = "chat.completion.chunk"
+    created: int = Field(default_factory=lambda: int(time.time()))
+    model: str
+    choices: list[ChatCompletionResponseStreamChoice]
+    usage: UsageInfo | None = Field(default=None)
+
+
+# ---------------------------------------------------------------------------
+# Embeddings
+# ---------------------------------------------------------------------------
+
+
+class EmbeddingCompletionRequest(OpenAIBaseModel):
+    input: list[int] | list[list[int]] | str | list[str]
+    model: str | None = None
+    encoding_format: Literal["float", "base64"] = "float"
+    dimensions: int | None = None
+    user: str | None = None
+
+
+EmbeddingRequest = EmbeddingCompletionRequest
+
+
+class EmbeddingResponseData(OpenAIBaseModel):
+    index: int
+    object: str = "embedding"
+    embedding: list[float] | str
+
+
+class EmbeddingResponse(OpenAIBaseModel):
+    id: str = Field(default_factory=lambda: f"embd-{random_uuid()}")
+    object: str = "list"
+    created: int = Field(default_factory=lambda: int(time.time()))
+    model: str | None = None
+    data: list[EmbeddingResponseData]
+    usage: UsageInfo
+
+
+# ---------------------------------------------------------------------------
+# Speech-to-text (transcription)
+# ---------------------------------------------------------------------------
+
+AudioResponseFormat = Literal["json", "text", "srt", "verbose_json", "vtt"]
+
+
+class TranscriptionUsageAudio(OpenAIBaseModel):
+    type: Literal["duration"] = "duration"
+    seconds: int
+
+
+class TranscriptionRequest(OpenAIBaseModel):
+    file: UploadFile
+    model: str | None = None
+    language: str | None = None
+    prompt: str = Field(default="")
+    response_format: AudioResponseFormat = Field(default="json")
+    timestamp_granularities: list[Literal["word", "segment"]] = Field(alias="timestamp_granularities[]", default=[])
+    stream: bool | None = False
+    temperature: float = Field(default=0.0)
+    seed: int | None = None
+
+
+class TranscriptionResponse(OpenAIBaseModel):
+    text: str
+    usage: TranscriptionUsageAudio
+
+
+class TranscriptionResponseVerbose(OpenAIBaseModel):
+    duration: str
+    language: str
+    text: str
+
+
+# ---------------------------------------------------------------------------
+# Speech-to-text (translation)
+# ---------------------------------------------------------------------------
+
+
+class TranslationRequest(OpenAIBaseModel):
+    file: UploadFile
+    model: str | None = None
+    prompt: str = Field(default="")
+    response_format: AudioResponseFormat = Field(default="json")
+    stream: bool | None = False
+    temperature: float = Field(default=0.0)
+    seed: int | None = None
+    language: str | None = None
+    to_language: str | None = None
+
+
+class TranslationResponse(OpenAIBaseModel):
+    text: str
+
+
+class TranslationResponseVerbose(OpenAIBaseModel):
+    duration: str
+    language: str
+    text: str
+
+
+# ---------------------------------------------------------------------------
+# Text-to-speech
+# ---------------------------------------------------------------------------
+
+
 class SpeechRequest(OpenAIBaseModel):
     input: str = Field(..., description="The text to generate audio for")
     model: str = Field(
@@ -86,7 +382,11 @@ class RawSpeechResponse(BaseModel):
     media_type: Literal["audio/wav"] = Field(default="audio/wav", description="audio bytes media type")
 
 
-# -- image generation (not yet provided by vllm) ---------------------------
+# ---------------------------------------------------------------------------
+# Image generation
+# ---------------------------------------------------------------------------
+
+
 class ImageGenerationRequest(OpenAIBaseModel):
     model: str = Field(..., description="The model to use for image generation.")
     prompt: str = Field(..., description="A text description of the desired image(s).")
@@ -110,26 +410,50 @@ class ImageGenerationResponse(OpenAIBaseModel):
     data: list[ImageObject] = Field(..., description="The list of generated images.")
 
 
+# ---------------------------------------------------------------------------
+# Exports
+# ---------------------------------------------------------------------------
+
 __all__ = [
+    "AudioResponseFormat",
+    "ChatCompletionLogProb",
+    "ChatCompletionLogProbs",
+    "ChatCompletionLogProbsContent",
+    "ChatCompletionMessageParam",
     "ChatCompletionRequest",
     "ChatCompletionResponse",
+    "ChatCompletionResponseChoice",
+    "ChatCompletionResponseStreamChoice",
+    "ChatCompletionStreamResponse",
+    "ChatMessage",
+    "DeltaFunctionCall",
+    "DeltaMessage",
+    "DeltaToolCall",
     "EmbeddingCompletionRequest",
     "EmbeddingRequest",
     "EmbeddingResponse",
+    "EmbeddingResponseData",
     "ErrorInfo",
     "ErrorResponse",
+    "FunctionCall",
     "ImageGenerationRequest",
     "ImageGenerationResponse",
     "ImageObject",
     "OpenAIBaseModel",
+    "PromptTokenUsageInfo",
     "RawSpeechResponse",
     "SpeechRequest",
     "SpeechResponse",
+    "StreamOptions",
+    "ToolCall",
     "TranscriptionRequest",
     "TranscriptionResponse",
     "TranscriptionResponseVerbose",
+    "TranscriptionUsageAudio",
     "TranslationRequest",
     "TranslationResponse",
     "TranslationResponseVerbose",
+    "UsageInfo",
     "create_error_response",
+    "random_uuid",
 ]


### PR DESCRIPTION
Replace vLLM protocol imports with standalone Pydantic models in protocol.py so the core codebase can run without vLLM installed.

- Define own OpenAI-compatible request/response models in protocol.py
- vLLM imports now only exist in modelship/infer/vllm/vllm_infer.py


