### PR TITLE
feat: add llama_cpp loader for cpu-only gguf inference

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![Python 3.12+](https://img.shields.io/badge/python-3.12+-blue.svg)](https://www.python.org/downloads/)
 
-Self-hosted, multi-model AI inference server. Runs LLMs alongside specialized models (TTS, speech-to-text, embeddings, image generation) on GPU or CPU, exposing an OpenAI-compatible API. Built on [Ray Serve](https://docs.ray.io/en/latest/serve/index.html) with pluggable inference backends: [vLLM](https://github.com/vllm-project/vllm) for high-throughput GPU inference, [HuggingFace Transformers](https://github.com/huggingface/transformers) for CPU and lightweight GPU workloads, [Diffusers](https://github.com/huggingface/diffusers) for image generation, and a plugin system for custom backends.
+Self-hosted, multi-model AI inference server. Runs LLMs alongside specialized models (TTS, speech-to-text, embeddings, image generation) on GPU or CPU, exposing an OpenAI-compatible API. Built on [Ray Serve](https://docs.ray.io/en/latest/serve/index.html) with pluggable inference backends: [vLLM](https://github.com/vllm-project/vllm) for high-throughput GPU inference, [HuggingFace Transformers](https://github.com/huggingface/transformers) for CPU and lightweight GPU workloads, [llama.cpp](https://github.com/abetlen/llama-cpp-python) for high-efficiency GGUF models on CPU, [Diffusers](https://github.com/huggingface/diffusers) for image generation, and a plugin system for custom backends.
 
 ## Why Modelship?
 
@@ -12,7 +12,7 @@ Most self-hosted inference tools focus on running a single model. Modelship is f
 
 - **One server, many models** — run a full AI stack (chat + TTS + STT + embeddings + image gen) on a single machine instead of juggling separate services
 - **GPU memory control** — allocate exact GPU fractions per model (e.g. 70% for the LLM, 5% for TTS) so everything fits on your hardware
-- **Mix and match backends** — use vLLM for high-throughput GPU inference, Transformers for CPU-only workloads, Diffusers for images, and plugins for custom backends — in the same deployment
+- **Mix and match backends** — use vLLM for high-throughput GPU inference, Transformers or llama.cpp for CPU-only workloads, Diffusers for images, and plugins for custom backends — in the same deployment
 - **Drop-in OpenAI replacement** — any OpenAI SDK client works out of the box, making it easy to integrate with existing apps and tools like [Home Assistant](docs/home-assistant.md)
 
 ## Architecture
@@ -40,7 +40,7 @@ graph TD
         EMB["Embedding Deployment<br/>e.g. Nomic Embed<br/>50% GPU"]
     end
 
-    subgraph CPU["CPU — Transformers"]
+    subgraph CPU["CPU — Transformers / llama.cpp"]
         LLM_CPU["LLM Deployment<br/>e.g. Qwen3-0.6B<br/>CPU-only"]
         STT_CPU["STT Deployment<br/>e.g. Whisper Small<br/>CPU-only"]
     end
@@ -50,16 +50,18 @@ graph TD
     end
 ```
 
-Each model runs as an isolated [Ray Serve](https://docs.ray.io/en/latest/serve/index.html) deployment with its own lifecycle, health checks, and resource budget. Four inference backends are available:
+Each model runs as an isolated [Ray Serve](https://docs.ray.io/en/latest/serve/index.html) deployment with its own lifecycle, health checks, and resource budget. Five inference backends are available:
 
 | Backend | Best for | GPU required |
 |---|---|---|
 | **vLLM** | High-throughput chat, embeddings, transcription | Yes |
+| **llama.cpp** | High-efficiency quantized GGUF models (chat, embeddings) | No |
 | **Transformers** | Chat, embeddings, transcription, TTS on CPU or lightweight GPU | No |
 | **Diffusers** | Image generation | Yes |
 | **Custom (plugins)** | TTS backends (Kokoro, Bark, Orpheus) | No |
 
 Models can be deployed across multiple GPUs, run on CPU-only, or both — multiple deployments of the same model (e.g. one on GPU via vLLM, one on CPU via Transformers) are load-balanced with round-robin routing. Each deployment can also scale horizontally with `num_replicas`.
+...
 
 ## Requirements
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -32,16 +32,17 @@ Each model in `models.yaml` becomes an isolated Ray Serve deployment (`ModelDepl
 
 ### Inference Loaders
 
-Each deployment uses one of three loaders:
+Each deployment uses one of the following loaders:
 
 | Loader | Backend | Use cases | GPU required |
 |--------|---------|-----------|--------------|
 | `vllm` | vLLM engine | Chat/generation, embeddings, transcription, translation | Yes |
+| `llama_cpp` | llama-cpp-python | Chat/generation, embeddings (GGUF models) | No — currently CPU-only |
 | `transformers` | PyTorch + HuggingFace | Chat/generation, embeddings, transcription, translation, TTS | No — runs on CPU or GPU |
 | `diffusers` | HuggingFace Diffusers | Image generation (any `AutoPipelineForText2Image` model) | Yes |
 | `custom` | Plugin system | TTS backends (Kokoro, Bark, Orpheus) | No |
 
-The `transformers` loader is ideal for CPU-only deployments, smaller models, or development/testing without a GPU. It uses HuggingFace `pipeline()` under the hood and handles audio resampling automatically for speech-to-text models. The `vllm` loader provides higher throughput on GPU with continuous batching and PagedAttention.
+The `transformers` loader is ideal for CPU-only deployments, smaller models, or development/testing without a GPU. It uses HuggingFace `pipeline()` under the hood and handles audio resampling automatically for speech-to-text models. The `llama_cpp` loader provides high-efficiency inference for quantized GGUF models on CPU. The `vllm` loader provides higher throughput on GPU with continuous batching and PagedAttention.
 
 ## GPU Allocation
 

--- a/docs/model-configuration.md
+++ b/docs/model-configuration.md
@@ -67,7 +67,7 @@ python start.py --config config/tts.yaml --gateway-name "tts-api"
 | `name` | string | Model identifier used in API requests |
 | `model` | string | HuggingFace model ID |
 | `usecase` | string | `generate`, `embed`, `transcription`, `translation`, `tts`, or `image` |
-| `loader` | string | `vllm`, `transformers`, `diffusers`, or `custom` |
+| `loader` | string | `vllm`, `transformers`, `diffusers`, `llama_cpp`, or `custom` |
 | `plugin` | string | Plugin module name (required when `loader: custom`); must be installed via `uv sync --extra <plugin>` |
 | `num_gpus` | float | Fraction of a GPU to allocate (0.0-1.0); also sets vLLM `gpu_memory_utilization` |
 | `num_cpus` | float | CPU units to allocate (default `0.1`) |
@@ -75,6 +75,7 @@ python start.py --config config/tts.yaml --gateway-name "tts-api"
 | `vllm_engine_kwargs` | object | Passed directly to the vLLM engine (see below) |
 | `transformers_config` | object | Transformers loader options (see below) |
 | `diffusers_config` | object | Diffusers pipeline options (see below) |
+| `llama_cpp_config` | object | llama.cpp loader options (see below) |
 | `plugin_config` | object | Plugin-specific options passed through to the plugin |
 
 ## vLLM Loader
@@ -251,6 +252,46 @@ models:
       torch_dtype: "float16"
       num_inference_steps: 4
       guidance_scale: 0.0
+```
+
+## llama.cpp Loader
+
+The `llama_cpp` loader uses [llama-cpp-python](https://github.com/abetlen/llama-cpp-python) to run GGUF models. It currently supports **CPU-only inference** — any `num_gpus` configuration is ignored. This loader is ideal for running quantized models efficiently on hardware without dedicated GPUs.
+
+| Field | Type | Default | Description |
+|---|---|---|---|
+| `n_ctx` | int | `2048` | Maximum sequence length |
+| `n_batch` | int | `512` | Batch size for prompt processing |
+| `chat_format` | string | — | Chat template format (e.g. `llama-3`) |
+| `hf_filename` | string | — | Specific GGUF filename to download from the HF repo (supports glob patterns) |
+| `model_kwargs` | object | `{}` | Extra keyword arguments passed to the `Llama` constructor |
+
+> **Note:** Setting `MSHIP_LOG_LEVEL` to `TRACE` will enable `verbose` mode in the underlying llama.cpp engine.
+
+### Chat / Text Generation (GGUF)
+
+```yaml
+models:
+  - name: llama-3
+    model: meta-llama/Llama-3-8B-Instruct-GGUF
+    usecase: generate
+    loader: llama_cpp
+    num_cpus: 4
+    llama_cpp_config:
+      hf_filename: "*Q4_K_M.gguf"
+      n_ctx: 4096
+```
+
+### Embeddings (GGUF)
+
+```yaml
+models:
+  - name: nomic-embed
+    model: nomic-ai/nomic-embed-text-v1.5-GGUF
+    usecase: embed
+    loader: llama_cpp
+    llama_cpp_config:
+      hf_filename: "nomic-embed-text-v1.5.Q4_K_M.gguf"
 ```
 
 ## Custom Loader (Plugins)

--- a/modelship/infer/infer_config.py
+++ b/modelship/infer/infer_config.py
@@ -23,6 +23,7 @@ class ModelLoader(StrEnum):
     vllm = "vllm"
     transformers = "transformers"
     diffusers = "diffusers"
+    llama_cpp = "llama_cpp"
     custom = "custom"
 
 
@@ -60,6 +61,15 @@ class DiffusersConfig(BaseModel):
     guidance_scale: float = 7.5
 
 
+class LlamaCppConfig(BaseModel):
+    n_gpu_layers: int = -1
+    n_ctx: int = 2048
+    n_batch: int = 512
+    chat_format: str | None = None
+    hf_filename: str | None = None
+    model_kwargs: dict[str, Any] = Field(default_factory=dict)
+
+
 class ModelshipModelConfig(BaseModel):
     name: str
     model: str
@@ -72,6 +82,7 @@ class ModelshipModelConfig(BaseModel):
     vllm_engine_kwargs: VllmEngineConfig = Field(default_factory=VllmEngineConfig)
     transformers_config: TransformersConfig | None = None
     diffusers_config: DiffusersConfig | None = None
+    llama_cpp_config: LlamaCppConfig | None = None
     plugin_config: dict[str, Any] | None = None  # plugin devs parse this themselves
 
     @model_validator(mode="after")

--- a/modelship/infer/llama_cpp/llama_cpp_infer.py
+++ b/modelship/infer/llama_cpp/llama_cpp_infer.py
@@ -1,0 +1,188 @@
+import asyncio
+import inspect
+import json
+import os
+from collections.abc import AsyncGenerator
+
+from llama_cpp import Llama
+
+from modelship.infer.base_infer import BaseInfer
+from modelship.infer.infer_config import LlamaCppConfig, ModelshipModelConfig, ModelUsecase, RawRequestProxy
+from modelship.logging import get_logger
+from modelship.openai.protocol import (
+    ChatCompletionRequest,
+    ChatCompletionResponse,
+    EmbeddingRequest,
+    EmbeddingResponse,
+    ErrorResponse,
+)
+
+logger = get_logger("infer.llama_cpp")
+
+
+class LlamaCppInfer(BaseInfer):
+    def __init__(self, model_config: ModelshipModelConfig):
+        super().__init__(model_config)
+        self.config = model_config.llama_cpp_config or LlamaCppConfig()
+
+        # Automatically enable verbose mode if MSHIP_LOG_LEVEL is TRACE.
+        # Other log levels are handled via the 'llama_cpp' Python logger (configured in logging.py).
+        mship_log_level = os.environ.get("MSHIP_LOG_LEVEL", "INFO").upper()
+        self._verbose = mship_log_level == "TRACE"
+
+        # Force CPU-only as llama_cpp is currently compiled without GPU support in this environment.
+        if self.config.n_gpu_layers != 0:
+            logger.warning(
+                "n_gpu_layers=%s is ignored for model '%s': llama_cpp currently only supports CPU.",
+                self.config.n_gpu_layers,
+                self.model_config.name,
+            )
+        self._n_gpu_layers = 0
+
+        self.llamacpp: Llama | None = None
+        self._chat_params: set[str] = set()
+        self._embed_params: set[str] = set()
+        logger.info(
+            "initialising llama.cpp engine (verbose=%s) with config: %s",
+            self._verbose,
+            self.config.model_dump(),
+        )
+
+    def shutdown(self) -> None:
+        if self.llamacpp:
+            logger.info("Shutting down llama.cpp engine for %s", self.model_config.name)
+            # llama-cpp-python relies on __del__ for resource cleanup.
+            del self.llamacpp
+            self.llamacpp = None
+
+    def __del__(self):
+        self.shutdown()
+
+    async def start(self) -> None:
+        logger.info("Start llama.cpp infer for model: %s", self.model_config)
+        loop = asyncio.get_event_loop()
+
+        # Initialize Llama in a thread pool as it can be slow/blocking
+        if self.config.hf_filename:
+            logger.info(
+                "Loading llama.cpp model from Hugging Face: repo=%s, file=%s",
+                self.model_config.model,
+                self.config.hf_filename,
+            )
+            self.llamacpp = await loop.run_in_executor(
+                None,
+                lambda: Llama.from_pretrained(
+                    repo_id=self.model_config.model,
+                    filename=self.config.hf_filename,
+                    n_gpu_layers=self._n_gpu_layers,
+                    n_ctx=self.config.n_ctx,
+                    n_batch=self.config.n_batch,
+                    chat_format=self.config.chat_format,
+                    verbose=self._verbose,
+                    embedding=self.model_config.usecase == ModelUsecase.embed,
+                    **self.config.model_kwargs,
+                ),
+            )
+        else:
+            self.llamacpp = await loop.run_in_executor(
+                None,
+                lambda: Llama(
+                    model_path=self.model_config.model,
+                    n_gpu_layers=self._n_gpu_layers,
+                    n_ctx=self.config.n_ctx,
+                    n_batch=self.config.n_batch,
+                    chat_format=self.config.chat_format,
+                    verbose=self._verbose,
+                    embedding=self.model_config.usecase == ModelUsecase.embed,
+                    **self.config.model_kwargs,
+                ),
+            )
+        self._set_max_context_length(self.config.n_ctx)
+
+        # Inspect and cache parameter lists once
+        if self.llamacpp:
+            self._chat_params = set(inspect.signature(self.llamacpp.create_chat_completion).parameters.keys())
+            self._embed_params = set(inspect.signature(self.llamacpp.create_embedding).parameters.keys())
+
+    async def warmup(self) -> None:
+        if not self.llamacpp:
+            return
+
+        logger.info("Warming up llama.cpp model: %s", self.model_config.name)
+        dummy_proxy = RawRequestProxy(None, {})
+
+        if self.model_config.usecase == ModelUsecase.generate:
+            request = ChatCompletionRequest(
+                model=self.model_config.name,
+                messages=[{"role": "user", "content": "warmup"}],
+                max_tokens=1,
+            )
+            await self.create_chat_completion(request, dummy_proxy)
+            logger.info("Warmup chat completion done for %s", self.model_config.name)
+        elif self.model_config.usecase == ModelUsecase.embed:
+            request = EmbeddingRequest(
+                model=self.model_config.name,
+                input="warmup",
+            )
+            await self.create_embedding(request, dummy_proxy)
+            logger.info("Warmup embedding done for %s", self.model_config.name)
+
+    async def create_chat_completion(
+        self, request: ChatCompletionRequest, raw_request: RawRequestProxy
+    ) -> ErrorResponse | ChatCompletionResponse | AsyncGenerator[str, None]:
+        if not self.llamacpp or self.model_config.usecase != ModelUsecase.generate:
+            return await super().create_chat_completion(request, raw_request)
+
+        request_id = raw_request.request_id
+        logger.info("chat completion request %s: stream=%s", request_id, request.stream)
+
+        loop = asyncio.get_event_loop()
+        llamacpp = self.llamacpp
+        assert llamacpp is not None
+
+        all_params = request.model_dump(exclude_none=True)
+        # Handle 'max_completion_tokens' mapping to 'max_tokens' if needed.
+        if "max_tokens" not in all_params and "max_completion_tokens" in all_params:
+            all_params["max_tokens"] = all_params["max_completion_tokens"]
+
+        kwargs = {k: v for k, v in all_params.items() if k in self._chat_params and k != "stream"}
+
+        if request.stream:
+
+            async def stream_generator() -> AsyncGenerator[str, None]:
+                # Run the synchronous generator in a thread
+                iterator = await loop.run_in_executor(
+                    None,
+                    lambda: llamacpp.create_chat_completion(**kwargs, stream=True),  # type: ignore
+                )
+                for chunk in iterator:
+                    yield f"data: {json.dumps(chunk)}\n\n"
+                    await asyncio.sleep(0)
+                yield "data: [DONE]\n\n"
+
+            return stream_generator()
+        else:
+            result = await loop.run_in_executor(
+                None,
+                lambda: llamacpp.create_chat_completion(**kwargs, stream=False),  # type: ignore
+            )
+            return ChatCompletionResponse.model_validate(result)
+
+    async def create_embedding(
+        self, request: EmbeddingRequest, raw_request: RawRequestProxy
+    ) -> ErrorResponse | EmbeddingResponse:
+        if not self.llamacpp or self.model_config.usecase != ModelUsecase.embed:
+            return await super().create_embedding(request, raw_request)
+
+        request_id = raw_request.request_id
+        logger.info("embedding request %s", request_id)
+
+        loop = asyncio.get_event_loop()
+        llamacpp = self.llamacpp
+        assert llamacpp is not None
+
+        all_params = request.model_dump(exclude_none=True)
+        kwargs = {k: v for k, v in all_params.items() if k in self._embed_params}
+
+        result = await loop.run_in_executor(None, lambda: llamacpp.create_embedding(**kwargs))
+        return EmbeddingResponse.model_validate(result)

--- a/modelship/infer/model_deployment.py
+++ b/modelship/infer/model_deployment.py
@@ -48,6 +48,10 @@ class ModelDeployment:
                 from modelship.infer.diffusers.diffusers_infer import DiffusersInfer
 
                 self.infer = DiffusersInfer(config)
+            elif config.loader == ModelLoader.llama_cpp:
+                from modelship.infer.llama_cpp.llama_cpp_infer import LlamaCppInfer
+
+                self.infer = LlamaCppInfer(config)
             else:
                 from modelship.infer.custom.custom_infer import CustomInfer
 

--- a/modelship/logging.py
+++ b/modelship/logging.py
@@ -48,7 +48,7 @@ class ModelshipTextFormatter(logging.Formatter):
 TRACE = 5
 logging.addLevelName(TRACE, "TRACE")
 
-_LIB_LOGGERS = ("ray", "ray.serve", "vllm", "transformers", "diffusers")
+_LIB_LOGGERS = ("ray", "ray.serve", "vllm", "transformers", "diffusers", "llama_cpp")
 
 # Env vars that libraries check internally when creating their own loggers.
 # Setting these ensures the level sticks even when a library re-configures

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,12 +42,14 @@ gpu = [
     "vllm[audio]==0.18.0",
     "accelerate>=1.6.0",
     "diffusers>=0.31.0",
+    "llama-cpp-python>=0.3.6",
 ]
 cpu = [
     "torch>=2.10.0",
     "torchvision>=0.25.0",
     "transformers>=4.57.5",
     "sentence-transformers>=3.0.0",
+    "llama-cpp-python>=0.3.6",
 ]
 kokoro = ["kokoro"]
 bark = ["bark"]

--- a/start.py
+++ b/start.py
@@ -115,34 +115,42 @@ def _apply_args_to_env(args: argparse.Namespace) -> None:
 
 
 def build_actor_options(config: ModelshipModelConfig) -> dict:
-    tp = config.vllm_engine_kwargs.tensor_parallel_size if config.vllm_engine_kwargs else 1
-
-    tp_backend = config.vllm_engine_kwargs.distributed_executor_backend if config.vllm_engine_kwargs else None
-
-    if config.num_gpus == 0:
-        num_gpus = 0
-    elif tp > 1 and tp_backend == "mp":
-        # mp backend: the main actor forks TP worker subprocesses, each owning one
-        # physical GPU. Allocate tp whole units so Ray exposes all devices via
-        # CUDA_VISIBLE_DEVICES. num_gpus is not used for Ray allocation in this path —
-        # gpu_memory_utilization is passed directly to vLLM instead.
+    if config.loader == ModelLoader.llama_cpp:
         if config.num_gpus > 0:
             logger.warning(
-                "num_gpus=%s is ignored for model '%s': with vllm mp backend and "
-                "tensor_parallel_size=%d, Ray GPU allocation is determined by tp.",
+                "num_gpus=%s is ignored for model '%s': llama_cpp loader currently only supports CPU.",
                 config.num_gpus,
                 config.name,
-                tp,
             )
-        num_gpus = float(tp)
-    elif tp > 1:
-        # ray backend: vLLM spawns tp worker Ray actors that each claim their own
-        # fractional GPU. The outer actor is a coordinator only and needs no GPU
-        # units. VLLM_RAY_PER_WORKER_GPUS tells vLLM what fraction each worker
-        # actor should request.
         num_gpus = 0
     else:
-        num_gpus = config.num_gpus
+        tp = config.vllm_engine_kwargs.tensor_parallel_size if config.vllm_engine_kwargs else 1
+        tp_backend = config.vllm_engine_kwargs.distributed_executor_backend if config.vllm_engine_kwargs else None
+
+        if config.num_gpus == 0:
+            num_gpus = 0
+        elif tp > 1 and tp_backend == "mp":
+            # mp backend: the main actor forks TP worker subprocesses, each owning one
+            # physical GPU. Allocate tp whole units so Ray exposes all devices via
+            # CUDA_VISIBLE_DEVICES. num_gpus is not used for Ray allocation in this path —
+            # gpu_memory_utilization is passed directly to vLLM instead.
+            if config.num_gpus > 0:
+                logger.warning(
+                    "num_gpus=%s is ignored for model '%s': with vllm mp backend and "
+                    "tensor_parallel_size=%d, Ray GPU allocation is determined by tp.",
+                    config.num_gpus,
+                    config.name,
+                    tp,
+                )
+            num_gpus = float(tp)
+        elif tp > 1:
+            # ray backend: vLLM spawns tp worker Ray actors that each claim their own
+            # fractional GPU. The outer actor is a coordinator only and needs no GPU
+            # units. VLLM_RAY_PER_WORKER_GPUS tells vLLM what fraction each worker
+            # actor should request.
+            num_gpus = 0
+        else:
+            num_gpus = config.num_gpus
 
     options: dict = {"num_gpus": num_gpus, "num_cpus": config.num_cpus}
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -4,6 +4,7 @@ import pytest
 from pydantic import ValidationError
 
 from modelship.infer.infer_config import (
+    LlamaCppConfig,
     ModelLoader,
     ModelshipConfig,
     ModelshipModelConfig,
@@ -11,6 +12,44 @@ from modelship.infer.infer_config import (
     TransformersConfig,
     VllmEngineConfig,
 )
+
+
+class TestLlamaCppConfig:
+    def test_defaults(self):
+        config = LlamaCppConfig()
+        assert config.n_gpu_layers == -1
+        assert config.n_ctx == 2048
+        assert config.n_batch == 512
+        assert config.chat_format is None
+        assert config.hf_filename is None
+        assert config.model_kwargs == {}
+
+    def test_custom_values(self):
+        config = LlamaCppConfig(
+            n_gpu_layers=33,
+            n_ctx=4096,
+            n_batch=1024,
+            chat_format="llama-3",
+            hf_filename="model.gguf",
+            model_kwargs={"seed": 42},
+        )
+        assert config.n_gpu_layers == 33
+        assert config.n_ctx == 4096
+        assert config.n_batch == 1024
+        assert config.chat_format == "llama-3"
+        assert config.hf_filename == "model.gguf"
+        assert config.model_kwargs == {"seed": 42}
+
+    def test_llama_cpp_model_config(self):
+        config = ModelshipModelConfig(
+            name="llama-3",
+            model="meta-llama/Llama-3-8B-Instruct-GGUF",
+            usecase=ModelUsecase.generate,
+            loader=ModelLoader.llama_cpp,
+            llama_cpp_config=LlamaCppConfig(hf_filename="*Q4_K_M.gguf"),
+        )
+        assert config.loader == ModelLoader.llama_cpp
+        assert config.llama_cpp_config.hf_filename == "*Q4_K_M.gguf"
 
 
 class TestModelshipModelConfig:

--- a/uv.lock
+++ b/uv.lock
@@ -1343,6 +1343,18 @@ wheels = [
 ]
 
 [[package]]
+name = "llama-cpp-python"
+version = "0.3.20"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "diskcache" },
+    { name = "jinja2" },
+    { name = "numpy" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/45/95/c69c47c9c8dda97f712f5864688d13a22b0159aa9adae91a69067a728532/llama_cpp_python-0.3.20.tar.gz", hash = "sha256:70f01b7d915d31c617dc66610a332cb2d51cde84c8b152d09a352206323616f5", size = 59323017, upload-time = "2026-04-03T06:56:32.455Z" }
+
+[[package]]
 name = "llguidance"
 version = "1.3.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1533,6 +1545,7 @@ bark = [
     { name = "bark" },
 ]
 cpu = [
+    { name = "llama-cpp-python" },
     { name = "sentence-transformers" },
     { name = "torch", version = "2.11.0", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "(sys_platform == 'darwin' and extra == 'extra-9-modelship-cpu') or (extra == 'extra-9-modelship-cpu' and extra == 'extra-9-modelship-gpu')" },
     { name = "torch", version = "2.11.0+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "(sys_platform != 'darwin' and extra == 'extra-9-modelship-cpu') or (extra == 'extra-9-modelship-cpu' and extra == 'extra-9-modelship-gpu')" },
@@ -1551,6 +1564,7 @@ gpu = [
     { name = "accelerate" },
     { name = "diffusers" },
     { name = "flashinfer-python" },
+    { name = "llama-cpp-python" },
     { name = "sentence-transformers" },
     { name = "torch", version = "2.10.0+cu128", source = { registry = "https://download.pytorch.org/whl/cu128" } },
     { name = "torchvision", version = "0.25.0+cu128", source = { registry = "https://download.pytorch.org/whl/cu128" } },
@@ -1580,6 +1594,8 @@ requires-dist = [
     { name = "httpx", specifier = ">=0.28.1" },
     { name = "kokoro", marker = "extra == 'kokoro'", editable = "plugins/kokoro" },
     { name = "librosa", specifier = ">=0.11.0" },
+    { name = "llama-cpp-python", marker = "extra == 'cpu'", specifier = ">=0.3.6" },
+    { name = "llama-cpp-python", marker = "extra == 'gpu'", specifier = ">=0.3.6" },
     { name = "numpy", specifier = ">=2.2.6" },
     { name = "opentelemetry-exporter-otlp", marker = "extra == 'otel'", specifier = ">=1.20.0" },
     { name = "opentelemetry-sdk", marker = "extra == 'otel'", specifier = ">=1.20.0" },


### PR DESCRIPTION
Adds a new `llama_cpp` loader utilizing `llama-cpp-python` for highly efficient CPU inference of quantized GGUF models.
- Forces `n_gpu_layers=0` regardless of configuration as it only supports CPU right now.
- Enables verbose logging automatically when `MSHIP_LOG_LEVEL` is set to `TRACE`.
- Adds `LlamaCppConfig` with `n_ctx`, `n_batch`, and `hf_filename` support.
- Updates documentation and architecture guides to include the new loader.


