### PR TITLE
feat: add whispercpp STT plugin, expand custom plugin system to all u…

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Each model runs as an isolated [Ray Serve](https://docs.ray.io/en/latest/serve/i
 | **llama.cpp** | High-efficiency quantized GGUF models (chat, embeddings) | No |
 | **Transformers** | Chat, embeddings, transcription, TTS on CPU or lightweight GPU | No |
 | **Diffusers** | Image generation | Yes |
-| **Custom (plugins)** | TTS backends (Kokoro, Bark, Orpheus) | No |
+| **Custom (plugins)** | TTS backends (Kokoro ONNX, Bark, Orpheus), STT backends (whisper.cpp) | No |
 
 Models can be deployed across multiple GPUs, run on CPU-only, or both — multiple deployments of the same model (e.g. one on GPU via vLLM, one on CPU via Transformers) are load-balanced with round-robin routing. Each deployment can also scale horizontally with `num_replicas`.
 ...
@@ -79,7 +79,7 @@ Models can be deployed across multiple GPUs, run on CPU-only, or both — multip
 - **OpenAI-compatible API** — drop-in replacement for any OpenAI SDK client
 - **Streaming** — SSE streaming for chat completions and TTS audio
 - **Tool/function calling** — auto tool choice with configurable parsers
-- **Plugin system** — opt-in TTS backends installed as isolated uv workspace packages
+- **Plugin system** — opt-in TTS and STT backends installed as isolated uv workspace packages
 - **Multi-GPU & hybrid routing** — assign models to specific GPUs or run them on CPU-only; deploy the same model on both GPU and CPU and requests are load-balanced via round-robin; full tensor parallelism support for large models spanning multiple GPUs
 - **Client disconnect detection** — cancels in-flight inference when the client disconnects, freeing GPU resources immediately
 - **Prometheus metrics & Grafana dashboard** — built-in observability with custom `modelship:*` metrics, vLLM engine stats, and Ray cluster metrics on a single scrape endpoint; pre-built Grafana dashboard included
@@ -161,19 +161,26 @@ Hitting an error? Check [docs/troubleshooting.md](docs/troubleshooting.md).
 
 ## Plugin Support
 
-Modelship's TTS system is built around a plugin architecture — each TTS backend is an opt-in package with its own isolated dependencies. Plugins ship inside this repo (`plugins/`) or can be installed from PyPI.
+Modelship's TTS and STT systems are built around a plugin architecture — each backend is an opt-in package with its own isolated dependencies. Plugins ship inside this repo (`plugins/`) or can be installed from PyPI.
+
+Built-in plugins:
+
+- [Kokoro ONNX](plugins/kokoroonnx/README.md) — lightweight TTS via ONNX Runtime (CPU or GPU)
+- [Bark](plugins/bark/README.md) — multilingual TTS by Suno (GPU recommended)
+- [Orpheus](plugins/orpheus/README.md) — expressive TTS
+- [whisper.cpp](plugins/whispercpp/README.md) — CPU-only STT via `pywhispercpp`
 
 To enable plugins, pass them as extras at sync time:
 
 ```bash
-uv sync --extra kokoro
-uv sync --extra kokoro --extra orpheus  # multiple plugins
+uv sync --extra kokoroonnx
+uv sync --extra kokoroonnx --extra whispercpp  # multiple plugins
 ```
 
 When using Docker, set the `MSHIP_PLUGINS` environment variable:
 
 ```
-MSHIP_PLUGINS=kokoro,orpheus
+MSHIP_PLUGINS=kokoroonnx,whispercpp
 ```
 
 For a full guide on writing your own plugin, see [Plugin Development](docs/plugins.md).
@@ -183,7 +190,7 @@ For a full guide on writing your own plugin, see [Plugin Development](docs/plugi
 - [Development](docs/development.md) — dev environment setup, building, and running locally
 - [Model Configuration](docs/model-configuration.md) — full `models.yaml` reference, GPU pinning, environment variables
 - [Architecture](docs/architecture.md) — system design, request lifecycle, plugin loading
-- [Plugin Development](docs/plugins.md) — writing custom TTS backends
+- [Plugin Development](docs/plugins.md) — writing custom TTS/STT backends
 - [Home Assistant Integration](docs/home-assistant.md) — Wyoming protocol setup for voice automation
 - [Monitoring & Logging](docs/monitoring.md) — Prometheus metrics, Grafana dashboard, structured logging, health checks
 - [Troubleshooting](docs/troubleshooting.md) — common first-run errors and fixes

--- a/config/examples/README.md
+++ b/config/examples/README.md
@@ -8,8 +8,9 @@ Ready-to-run `models.yaml` configs for common scenarios. Mount one into the cont
 | [transformers-cpu.yaml](transformers-cpu.yaml) | Llama 3.2 1B + Nomic embed + Whisper + MMS-TTS | CPU |
 | [vllm.yaml](vllm.yaml) | High-throughput chat with tool calling, embeddings, Whisper | NVIDIA GPU |
 | [diffusers.yaml](diffusers.yaml) | SDXL Turbo image generation | NVIDIA GPU |
-| [kokoro-tts.yaml](kokoro-tts.yaml) | Kokoro TTS with GPU + CPU fallback replicas | Mixed |
+| [kokoro-tts.yaml](kokoro-tts.yaml) | Kokoro ONNX TTS with GPU + CPU fallback replicas | Mixed |
 | [full-stack.yaml](full-stack.yaml) | LLM + TTS + STT + embeddings on one GPU | NVIDIA GPU |
+| [mini-pc.yaml](mini-pc.yaml) | Low-resource stack: llama.cpp chat + Kokoro ONNX TTS + whisper.cpp STT | CPU (e.g. Intel N100) |
 
 Example:
 

--- a/config/examples/full-stack.yaml
+++ b/config/examples/full-stack.yaml
@@ -1,6 +1,6 @@
 # Full AI stack on a single GPU: chat + TTS + STT + embeddings + image gen.
 # Tune num_gpus fractions to fit your VRAM budget.
-# Plugins (Kokoro) require `MSHIP_PLUGINS=kokoro` or `uv sync --extra kokoro`.
+# Plugins (Kokoro ONNX) require `MSHIP_PLUGINS=kokoroonnx` or `uv sync --extra kokoroonnx`.
 
 models:
   - name: "llm"
@@ -17,7 +17,7 @@ models:
     model: "hexgrad/Kokoro-82M"
     usecase: "tts"
     loader: "custom"
-    plugin: "kokoro"
+    plugin: "kokoroonnx"
     num_gpus: 0.07
     plugin_config:
       onnx_provider: "CUDAExecutionProvider"

--- a/config/examples/kokoro-tts.yaml
+++ b/config/examples/kokoro-tts.yaml
@@ -1,5 +1,5 @@
-# Kokoro TTS plugin — install with `uv sync --extra kokoro`
-# or set MSHIP_PLUGINS=kokoro for Docker.
+# Kokoro ONNX TTS plugin — install with `uv sync --extra kokoroonnx`
+# or set MSHIP_PLUGINS=kokoroonnx for Docker.
 #
 # The same model name can appear twice with different configs; requests are
 # load-balanced round-robin across all matching deployments.
@@ -10,7 +10,7 @@ models:
     model: "hexgrad/Kokoro-82M"
     usecase: "tts"
     loader: "custom"
-    plugin: "kokoro"
+    plugin: "kokoroonnx"
     num_gpus: 0.07
     num_replicas: 3
     plugin_config:
@@ -21,7 +21,7 @@ models:
     model: "hexgrad/Kokoro-82M"
     usecase: "tts"
     loader: "custom"
-    plugin: "kokoro"
+    plugin: "kokoroonnx"
     num_gpus: 0
     num_cpus: 1
     num_replicas: 1

--- a/config/examples/mini-pc.yaml
+++ b/config/examples/mini-pc.yaml
@@ -1,0 +1,38 @@
+# Low-resource home-assistant stack for a mini-PC (e.g. Intel N100, 16 GB RAM).
+# CPU-only: quantized chat via llama.cpp, Kokoro ONNX TTS, whisper.cpp STT.
+# Install plugins: `uv sync --extra kokoroonnx --extra whispercpp`
+# Docker: MSHIP_PLUGINS=kokoroonnx,whispercpp
+# Note: kokoroonnx needs espeak-ng on the host (apt-get install -y espeak-ng).
+
+models:
+  # Chat — 3B Q4 quant, ~2 GB, tool calling works for simple commands.
+  - name: "qwen"
+    model: "lmstudio-community/Qwen2.5-3B-Instruct-GGUF"
+    usecase: "generate"
+    loader: "llama_cpp"
+    num_cpus: 2
+    llama_cpp_config:
+      hf_filename: "*Q4_K_M.gguf"
+      n_ctx: 4096
+
+  # TTS — Kokoro on CPU via ONNX.
+  - name: "kokoro"
+    model: "hexgrad/Kokoro-82M"
+    usecase: "tts"
+    loader: "custom"
+    plugin: "kokoroonnx"
+    num_gpus: 0
+    num_cpus: 1
+    plugin_config:
+      onnx_provider: "CPUExecutionProvider"
+
+  # STT — whisper.cpp base.en (~150 MB). Swap to `base` for multilingual.
+  - name: "whisper"
+    model: "base.en"
+    usecase: "transcription"
+    loader: "custom"
+    plugin: "whispercpp"
+    num_gpus: 0
+    num_cpus: 1
+    plugin_config:
+      n_threads: 2

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -7,7 +7,7 @@ Modelship is built on [Ray Serve](https://docs.ray.io/en/latest/serve/) for depl
 - **[vLLM](https://github.com/vllm-project/vllm)** — high-throughput GPU inference with continuous batching and PagedAttention
 - **[HuggingFace Transformers](https://github.com/huggingface/transformers)** — CPU and lightweight GPU inference for chat, embeddings, transcription, and TTS
 - **[HuggingFace Diffusers](https://github.com/huggingface/diffusers)** — image generation via `AutoPipelineForText2Image`
-- **Plugin system** — custom TTS backends (Kokoro, Bark, Orpheus)
+- **Plugin system** — custom TTS and STT backends (Kokoro ONNX, Bark, Orpheus, whisper.cpp)
 
 ## Request Lifecycle
 
@@ -40,7 +40,7 @@ Each deployment uses one of the following loaders:
 | `llama_cpp` | llama-cpp-python | Chat/generation, embeddings (GGUF models) | No — currently CPU-only |
 | `transformers` | PyTorch + HuggingFace | Chat/generation, embeddings, transcription, translation, TTS | No — runs on CPU or GPU |
 | `diffusers` | HuggingFace Diffusers | Image generation (any `AutoPipelineForText2Image` model) | Yes |
-| `custom` | Plugin system | TTS backends (Kokoro, Bark, Orpheus) | No |
+| `custom` | Plugin system | TTS backends (Kokoro ONNX, Bark, Orpheus), STT backends (whisper.cpp) | No |
 
 The `transformers` loader is ideal for CPU-only deployments, smaller models, or development/testing without a GPU. It uses HuggingFace `pipeline()` under the hood and handles audio resampling automatically for speech-to-text models. The `llama_cpp` loader provides high-efficiency inference for quantized GGUF models on CPU. The `vllm` loader provides higher throughput on GPU with continuous batching and PagedAttention.
 
@@ -50,12 +50,12 @@ Ray automatically schedules model deployments across available GPUs based on the
 
 ## Plugin System
 
-TTS backends are isolated `uv` workspace packages under `plugins/`. Each plugin:
+Custom backends are isolated `uv` workspace packages under `plugins/`. Each plugin:
 
-- Implements `BasePlugin` with `start()` and `generate()` methods
+- Implements `BasePlugin` and overrides the `create_*` method(s) matching its `usecase` (e.g. `create_speech` for TTS, `create_transcription` for STT)
 - Has its own dependencies, isolated from the main project
 - Is opt-in via `uv sync --extra <plugin>` or the `MSHIP_PLUGINS` env var
-- Returns audio as a single response or as an SSE async generator
+- Returns raw, protocol-agnostic outputs; OpenAI-shape adaptation is handled by the serving wrappers in `modelship/infer/custom/openai/`
 
 See [Plugin Development](plugins.md) for details.
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -14,7 +14,7 @@ The recommended way to develop Modelship is with VS Code Dev Containers. The con
 
    ```bash
    export HF_TOKEN=your_token_here
-   export MSHIP_PLUGINS=kokoro  # optional — comma-separated list of plugins to install
+   export MSHIP_PLUGINS=kokoroonnx  # optional — comma-separated list of plugins to install
    ```
 
 2. Open the repo in VS Code and run **Dev Containers: Reopen in Container** from the command palette (`Ctrl+Shift+P` / `Cmd+Shift+P`).
@@ -67,7 +67,7 @@ The following environment variables are set in the dev image with sensible defau
 Plugin packages (e.g. `kokoro_onnx`, `onnxruntime`) are only installed when their extra is enabled. If you're working on a plugin and want full IntelliSense, sync the extras inside the container:
 
 ```bash
-uv sync --extra kokoro --extra dev
+uv sync --extra kokoroonnx --extra dev
 ```
 
 ## Manual setup (without Dev Containers)
@@ -94,7 +94,7 @@ The dev image does not bake in source files. Mount the repo root so changes take
 ```bash
 docker run -it --rm --shm-size=8g --gpus all \
   -e HF_TOKEN=your_token_here \
-  -e MSHIP_PLUGINS=kokoro \
+  -e MSHIP_PLUGINS=kokoroonnx \
   -e RAY_HEAD_GPU_NUM=1 \
   --mount type=bind,src=./,dst=/modelship \
   -v ./models-cache:/.cache \

--- a/docs/model-configuration.md
+++ b/docs/model-configuration.md
@@ -299,9 +299,10 @@ models:
 The `custom` loader delegates to a plugin module. The `plugin` field is required and must match an installed plugin package. Plugin-specific options are passed via `plugin_config`.
 
 See each plugin's README for configuration details:
-- [Kokoro TTS](../plugins/kokoro/README.md)
+- [Kokoro ONNX TTS](../plugins/kokoroonnx/README.md)
 - [Bark TTS](../plugins/bark/README.md)
 - [Orpheus TTS](../plugins/orpheus/README.md)
+- [whisper.cpp STT](../plugins/whispercpp/README.md)
 
 For writing your own plugin, see [Plugin Development](plugins.md).
 
@@ -318,7 +319,7 @@ models:
     model: "hexgrad/Kokoro-82M"
     usecase: "tts"
     loader: "custom"
-    plugin: "kokoro"
+    plugin: "kokoroonnx"
     num_gpus: 0.07
     num_replicas: 2
     plugin_config:
@@ -329,7 +330,7 @@ models:
     model: "hexgrad/Kokoro-82M"
     usecase: "tts"
     loader: "custom"
-    plugin: "kokoro"
+    plugin: "kokoroonnx"
     num_gpus: 0
     plugin_config:
       onnx_provider: "CPUExecutionProvider"
@@ -342,7 +343,7 @@ In this example, requests to model `kokoro` are distributed across three backend
 | Variable | Description | Default |
 |---|---|---|
 | `HF_TOKEN` | HuggingFace access token | — |
-| `MSHIP_PLUGINS` | Comma-separated list of plugins to install at startup (e.g. `kokoro,orpheus`) | — |
+| `MSHIP_PLUGINS` | Comma-separated list of plugins to install at startup (e.g. `kokoroonnx,whispercpp`) | — |
 | `MSHIP_CACHE_DIR` | Model cache directory (HuggingFace + plugins) | `/.cache` |
 | `MSHIP_GATEWAY_NAME` | Name for the API gateway app | `modelship api` |
 | `MSHIP_MAX_REQUEST_BODY_BYTES` | Maximum allowed request body size in bytes | `52428800` (50 MB) |

--- a/docs/monitoring.md
+++ b/docs/monitoring.md
@@ -58,7 +58,7 @@ JSON format example:
 | `modelship.infer.diffusers` | Diffusers inference backend |
 | `modelship.infer.diffusers.image` | Diffusers image generation |
 | `modelship.infer.custom` | Custom/plugin inference backend |
-| `modelship.plugin.<name>` | Individual plugins (kokoro, bark, orpheus) |
+| `modelship.plugin.<name>` | Individual plugins (kokoroonnx, bark, orpheus, whispercpp) |
 
 ### Syslog
 

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -1,18 +1,27 @@
 # Plugin Development
 
-Plugins are Python packages that extend Modelship with new TTS backends. Each plugin is a self-contained uv workspace package with its own dependencies, installed on demand.
+Plugins are Python packages that extend Modelship with custom inference backends. Each plugin is a self-contained uv workspace package with its own dependencies, installed on demand.
+
+Plugins can implement any usecase — TTS, STT, chat, embeddings, translation, image generation — not just speech synthesis.
 
 ## How plugins work
 
 When `loader: custom` is set in `models.yaml`, Modelship imports the module named by `plugin` and expects it to expose a `ModelPlugin` class extending `BasePlugin`.
 
-`BasePlugin` requires three methods:
+A plugin overrides only the `create_*` method(s) matching its `usecase`:
 
-| Method | Description |
-|---|---|
-| `__init__(model_config: ModelshipModelConfig)` | Initialize the plugin; store config and set up state |
-| `async start()` | Load models into memory; called once before the first request |
-| `async generate(input, voice, request_id, stream_format)` | Generate audio; return a `RawSpeechResponse` or an SSE `AsyncGenerator[str, None]` |
+| Usecase | Method to override | Raw return type |
+|---|---|---|
+| `tts` | `create_speech` | `RawSpeechResponse` or `AsyncGenerator[(bytes, int), None]` |
+| `transcription` | `create_transcription` | `RawTranscription` |
+| `translation` | `create_translation` | `RawTranslation` |
+| `generate` | `create_chat_completion` | `RawChatCompletion` or `AsyncGenerator[RawChatDelta, None]` |
+| `embed` | `create_embedding` | `list[list[float]]` |
+| `image` | `create_image_generation` | `list[bytes]` (PNG-encoded) |
+
+Plugins return protocol-agnostic raw outputs. The serving wrappers in `modelship/infer/custom/openai/` translate these into OpenAI-compatible responses, so a different protocol adapter (e.g. Anthropic, gRPC) could be added later without touching any plugin.
+
+Unimplemented methods fall back to a 404 "plugin does not support this action" error.
 
 ## Creating a plugin
 
@@ -33,18 +42,31 @@ plugins/
 [project]
 name = "myplugin"
 version = "0.1.0"
+requires-python = "==3.12.10"
 dependencies = [
     "modelship",
     # your plugin's dependencies
 ]
+
+[build-system]
+requires = ["uv_build"]
+build-backend = "uv_build"
+
+[tool.uv.sources]
+modelship = { workspace = true }
+
+[tool.uv.build-backend]
+module-name = "myplugin"
+module-root = ""
 ```
 
 ### 3. Implement `ModelPlugin`
 
+#### TTS example
+
 ```python
 # plugins/myplugin/myplugin/myplugin.py
 from collections.abc import AsyncGenerator
-from typing import Literal
 
 from modelship.plugins.base_plugin import BasePlugin
 from modelship.infer.infer_config import ModelshipModelConfig
@@ -60,15 +82,43 @@ class ModelPlugin(BasePlugin):
         # load your model here
         pass
 
-    async def generate(
+    async def create_speech(
         self,
         input: str,
-        voice: str,
-        request_id: str,
-        stream_format: Literal["sse", "audio"],
-    ) -> RawSpeechResponse | AsyncGenerator[str, None] | ErrorResponse:
+        voice: str | None = None,
+        speed: float | None = None,
+        stream: bool = False,
+        request_id: str | None = None,
+    ) -> RawSpeechResponse | AsyncGenerator[tuple[bytes, int], None] | ErrorResponse:
         audio_bytes = b"..."  # your synthesis here
         return RawSpeechResponse(audio=audio_bytes)
+```
+
+#### STT example
+
+```python
+from modelship.plugins.base_plugin import BasePlugin
+from modelship.infer.infer_config import ModelshipModelConfig
+from modelship.openai.protocol import ErrorResponse, RawTranscription
+
+
+class ModelPlugin(BasePlugin):
+    def __init__(self, model_config: ModelshipModelConfig):
+        self.model_name = model_config.model
+
+    async def start(self):
+        pass
+
+    async def create_transcription(
+        self,
+        audio_data: bytes,
+        language: str | None = None,
+        prompt: str | None = None,
+        temperature: float | None = None,
+        request_id: str | None = None,
+    ) -> RawTranscription | ErrorResponse:
+        text = "..."  # your transcription here
+        return RawTranscription(text=text, language=language, duration_seconds=0.0)
 ```
 
 ### 4. Export `ModelPlugin` from `__init__.py`
@@ -85,6 +135,9 @@ __all__ = ["ModelPlugin"]
 ```toml
 [project.optional-dependencies]
 myplugin = ["myplugin"]
+
+[tool.uv.sources]
+myplugin = { workspace = true }
 ```
 
 ### 6. Install and configure
@@ -97,29 +150,27 @@ In `models.yaml`:
 
 ```yaml
 - name: myplugin
-  usecase: tts
+  usecase: tts        # or transcription, translation, generate, embed, image
   loader: custom
   plugin: myplugin
   num_gpus: 0.1
 ```
 
-## SSE streaming
+## SSE streaming (TTS)
 
-To support streaming, yield SSE-formatted strings instead of returning a `RawSpeechResponse`:
+For streaming speech, yield `(pcm_bytes, sample_rate)` tuples from an async generator. `pcm_bytes` must be signed 16-bit little-endian mono PCM — the serving wrapper base64-encodes each chunk into SSE `speech.audio.delta` events.
 
 ```python
-async def generate(self, input, voice, request_id, stream_format):
-    if stream_format == "sse":
-        async def _stream():
-            for chunk in self._synthesize_chunks(input):
-                import base64, json
-                b64 = base64.b64encode(chunk).decode()
-                yield f"data: {json.dumps({'type': 'speech.audio.delta', 'audio': b64})}\n\n"
-            yield f"data: {json.dumps({'type': 'speech.audio.done'})}\n\n"
-        return _stream()
-    else:
-        audio = self._synthesize_full(input)
-        return RawSpeechResponse(audio=audio)
+async def create_speech(self, input, voice=None, speed=None, stream=False, request_id=None):
+    if stream:
+        return self._stream(input, voice, speed)
+    # non-stream path
+    audio = self._synthesize_full(input)
+    return RawSpeechResponse(audio=audio)
+
+async def _stream(self, input, voice, speed):
+    for pcm_chunk, sample_rate in self._synthesize_chunks(input):
+        yield pcm_chunk, sample_rate
 ```
 
 ## Plugin README
@@ -131,7 +182,7 @@ Every plugin must include a `README.md` in its package root (`plugins/myplugin/R
 - **Voices / options** — any model-specific choices (voice presets, providers, etc.)
 - **Example request** — a working `curl` command
 
-See the built-in plugins for reference: [Kokoro](../plugins/kokoro/README.md), [Bark](../plugins/bark/README.md), [Orpheus](../plugins/orpheus/README.md).
+See the built-in plugins for reference: [Kokoro ONNX](../plugins/kokoroonnx/README.md), [Bark](../plugins/bark/README.md), [Orpheus](../plugins/orpheus/README.md), [whisper.cpp](../plugins/whispercpp/README.md).
 
 ## Submitting to this repo
 

--- a/modelship/infer/custom/custom_infer.py
+++ b/modelship/infer/custom/custom_infer.py
@@ -4,12 +4,22 @@ from typing import cast
 
 from modelship.infer.base_infer import BaseInfer
 from modelship.infer.custom.openai.serving_speech import OpenAIServingSpeech
+from modelship.infer.custom.openai.serving_transcription import (
+    OpenAIServingTranscription,
+    OpenAIServingTranslation,
+)
 from modelship.infer.infer_config import ModelshipModelConfig, ModelUsecase, RawRequestProxy
 from modelship.logging import get_logger
 from modelship.openai.protocol import (
     ErrorResponse,
     RawSpeechResponse,
     SpeechRequest,
+    TranscriptionRequest,
+    TranscriptionResponse,
+    TranscriptionResponseVerbose,
+    TranslationRequest,
+    TranslationResponse,
+    TranslationResponseVerbose,
 )
 from modelship.plugins.base_plugin import BasePlugin, PluginProto
 
@@ -21,6 +31,8 @@ class CustomInfer(BaseInfer):
         super().__init__(model_config)
         self.custom_engine: BasePlugin | None = None
         self.serving_speech: OpenAIServingSpeech | None = None
+        self.serving_transcription: OpenAIServingTranscription | None = None
+        self.serving_translation: OpenAIServingTranslation | None = None
 
     def shutdown(self) -> None:
         pass
@@ -33,18 +45,16 @@ class CustomInfer(BaseInfer):
             await self.custom_engine.start()
             self._set_max_context_length(self.custom_engine.max_context_length())
 
-        self.serving_speech = await self.init_serving_speech()
+        usecase = self.model_config.usecase
+        if usecase is ModelUsecase.tts:
+            self.serving_speech = OpenAIServingSpeech(serving_engine=self.custom_engine)
+        elif usecase is ModelUsecase.transcription:
+            self.serving_transcription = OpenAIServingTranscription(serving_engine=self.custom_engine)
+        elif usecase is ModelUsecase.translation:
+            self.serving_translation = OpenAIServingTranslation(serving_engine=self.custom_engine)
 
     async def warmup(self) -> None:
         pass
-
-    async def init_serving_speech(self) -> OpenAIServingSpeech | None:
-        logger.info("init serving speech with model: %s", self.model_config.name)
-        return (
-            OpenAIServingSpeech(serving_engine=self.custom_engine)
-            if self.model_config.usecase is ModelUsecase.tts
-            else None
-        )
 
     async def create_speech(
         self, request: SpeechRequest, raw_request: RawRequestProxy
@@ -52,3 +62,17 @@ class CustomInfer(BaseInfer):
         if self.serving_speech is None:
             return await super().create_speech(request, raw_request)
         return await self.serving_speech.create_speech(request, raw_request)
+
+    async def create_transcription(
+        self, audio_data: bytes, request: TranscriptionRequest, raw_request: RawRequestProxy
+    ) -> ErrorResponse | TranscriptionResponse | TranscriptionResponseVerbose | AsyncGenerator[str, None]:
+        if self.serving_transcription is None:
+            return await super().create_transcription(audio_data, request, raw_request)
+        return await self.serving_transcription.create_transcription(audio_data, request, raw_request)
+
+    async def create_translation(
+        self, audio_data: bytes, request: TranslationRequest, raw_request: RawRequestProxy
+    ) -> ErrorResponse | TranslationResponse | TranslationResponseVerbose | AsyncGenerator[str, None]:
+        if self.serving_translation is None:
+            return await super().create_translation(audio_data, request, raw_request)
+        return await self.serving_translation.create_translation(audio_data, request, raw_request)

--- a/modelship/infer/custom/openai/serving_speech.py
+++ b/modelship/infer/custom/openai/serving_speech.py
@@ -1,8 +1,15 @@
+import base64
 from collections.abc import AsyncGenerator
 
 from modelship.infer.infer_config import RawRequestProxy
 from modelship.logging import get_logger
-from modelship.openai.protocol import ErrorResponse, RawSpeechResponse, SpeechRequest, create_error_response
+from modelship.openai.protocol import (
+    ErrorResponse,
+    RawSpeechResponse,
+    SpeechRequest,
+    SpeechResponse,
+    create_error_response,
+)
 from modelship.plugins.base_plugin import BasePlugin
 from modelship.utils import base_request_id
 
@@ -24,5 +31,26 @@ class OpenAIServingSpeech:
             return create_error_response("tts model is not yet accessible")
 
         request_id = f"{self.request_id_prefix}-{base_request_id(raw_request)}"
+        stream_sse = "stream_format" in request.model_fields_set and request.stream_format == "sse"
 
-        return await self.serving_engine.generate(request.input, request.voice, request_id, request.stream_format)
+        result = await self.serving_engine.create_speech(
+            input=request.input,
+            voice=request.voice,
+            speed=request.speed,
+            stream=stream_sse,
+            request_id=request_id,
+        )
+
+        if isinstance(result, ErrorResponse | RawSpeechResponse):
+            return result
+
+        return _sse_stream(result)
+
+
+async def _sse_stream(chunks: AsyncGenerator[tuple[bytes, int], None]) -> AsyncGenerator[str, None]:
+    async for pcm, _sample_rate in chunks:
+        audio_b64 = base64.b64encode(pcm).decode("ascii")
+        event = SpeechResponse(type="speech.audio.delta", audio=audio_b64)
+        yield f"data: {event.model_dump_json()}\n\n"
+    done = SpeechResponse(type="speech.audio.done")
+    yield f"data: {done.model_dump_json()}\n\n"

--- a/modelship/infer/custom/openai/serving_transcription.py
+++ b/modelship/infer/custom/openai/serving_transcription.py
@@ -1,0 +1,83 @@
+from modelship.infer.infer_config import RawRequestProxy
+from modelship.logging import TRACE, get_logger
+from modelship.openai.protocol import (
+    ErrorResponse,
+    TranscriptionRequest,
+    TranscriptionResponse,
+    TranscriptionUsageAudio,
+    TranslationRequest,
+    TranslationResponse,
+    create_error_response,
+)
+from modelship.plugins.base_plugin import BasePlugin
+from modelship.utils import base_request_id
+
+logger = get_logger("infer.custom.transcription")
+
+
+class OpenAIServingTranscription:
+    request_id_prefix = "asr"
+
+    def __init__(self, serving_engine: BasePlugin | None):
+        self.serving_engine = serving_engine
+
+    async def create_transcription(
+        self, audio_data: bytes, request: TranscriptionRequest, raw_request: RawRequestProxy
+    ) -> TranscriptionResponse | ErrorResponse:
+        if self.serving_engine is None:
+            return create_error_response("transcription model is not yet accessible")
+
+        request_id = f"{self.request_id_prefix}-{base_request_id(raw_request)}"
+        logger.info("transcription request %s", request_id)
+        logger.log(
+            TRACE,
+            "transcription request %s: language=%s, audio_bytes=%d",
+            request_id,
+            request.language,
+            len(audio_data),
+        )
+
+        result = await self.serving_engine.create_transcription(
+            audio_data=audio_data,
+            language=request.language,
+            prompt=request.prompt or None,
+            temperature=request.temperature,
+            request_id=request_id,
+        )
+        if isinstance(result, ErrorResponse):
+            return result
+
+        logger.log(TRACE, "transcription response %s: text=%r", request_id, result.text)
+        return TranscriptionResponse(
+            text=result.text,
+            usage=TranscriptionUsageAudio(seconds=int(result.duration_seconds or 0)),
+        )
+
+
+class OpenAIServingTranslation:
+    request_id_prefix = "translate"
+
+    def __init__(self, serving_engine: BasePlugin | None):
+        self.serving_engine = serving_engine
+
+    async def create_translation(
+        self, audio_data: bytes, request: TranslationRequest, raw_request: RawRequestProxy
+    ) -> TranslationResponse | ErrorResponse:
+        if self.serving_engine is None:
+            return create_error_response("translation model is not yet accessible")
+
+        request_id = f"{self.request_id_prefix}-{base_request_id(raw_request)}"
+        logger.info("translation request %s", request_id)
+        logger.log(TRACE, "translation request %s: audio_bytes=%d", request_id, len(audio_data))
+
+        result = await self.serving_engine.create_translation(
+            audio_data=audio_data,
+            prompt=request.prompt or None,
+            temperature=request.temperature,
+            request_id=request_id,
+        )
+        if isinstance(result, ErrorResponse):
+            return result
+
+        logger.log(TRACE, "translation response %s: text=%r", request_id, result.text)
+        return TranslationResponse(text=result.text)

--- a/modelship/infer/transformers/openai/serving_speech.py
+++ b/modelship/infer/transformers/openai/serving_speech.py
@@ -1,6 +1,3 @@
-import struct
-
-import numpy as np
 from transformers import Pipeline
 
 from modelship.infer.base_serving import OpenAIServing
@@ -13,36 +10,9 @@ from modelship.openai.protocol import (
     create_error_response,
 )
 from modelship.utils import base_request_id
+from modelship.utils.audio import to_wav
 
 logger = get_logger("infer.transformers.speech")
-
-
-def _audio_to_wav(audio: np.ndarray, sampling_rate: int) -> bytes:
-    """Convert a float32 numpy audio array to WAV bytes."""
-    if audio.ndim > 1:
-        audio = audio.squeeze()
-
-    pcm = (audio * 32767).astype(np.int16)
-    data_bytes = pcm.tobytes()
-
-    header = struct.pack(
-        "<4sI4s4sIHHIIHH4sI",
-        b"RIFF",
-        36 + len(data_bytes),
-        b"WAVE",
-        b"fmt ",
-        16,
-        1,  # PCM
-        1,  # mono
-        sampling_rate,
-        sampling_rate * 2,  # byte rate
-        2,  # block align
-        16,  # bits per sample
-        b"data",
-        len(data_bytes),
-    )
-
-    return header + data_bytes
 
 
 class OpenAIServingSpeech(OpenAIServing):
@@ -71,7 +41,7 @@ class OpenAIServingSpeech(OpenAIServing):
             logger.exception("speech inference failed for %s", request_id)
             return create_error_response("speech inference failed")
 
-        wav_bytes = _audio_to_wav(result["audio"], result["sampling_rate"])
+        wav_bytes = to_wav(result["audio"], result["sampling_rate"])
         logger.log(
             TRACE,
             "speech response %s: audio_bytes=%d, sample_rate=%d",

--- a/modelship/infer/transformers/openai/serving_transcription.py
+++ b/modelship/infer/transformers/openai/serving_transcription.py
@@ -1,8 +1,3 @@
-import io
-
-import librosa
-import numpy as np
-import soundfile as sf
 from transformers import Pipeline
 
 from modelship.infer.base_infer import MINIMAL_WAV
@@ -21,22 +16,15 @@ from modelship.openai.protocol import (
     create_error_response,
 )
 from modelship.utils import base_request_id
+from modelship.utils.audio import decode_audio
+
+
+def _pipeline_input(audio_data: bytes, target_sr: int) -> tuple[dict, int]:
+    samples, duration_seconds = decode_audio(audio_data, target_sr)
+    return {"raw": samples, "sampling_rate": target_sr}, duration_seconds
+
 
 logger = get_logger("infer.transformers.transcription")
-
-
-def _decode_audio(audio_data: bytes, target_sr: int) -> tuple[dict, int]:
-    """Decode audio bytes and resample to *target_sr*.
-
-    Returns the pipeline input dict and the duration in whole seconds.
-    """
-    samples, source_sr = sf.read(io.BytesIO(audio_data), dtype="float32")
-    if samples.ndim > 1:
-        samples = np.mean(samples, axis=1)
-    duration_seconds = int(len(samples) / source_sr)
-    if source_sr != target_sr:
-        samples = librosa.resample(samples, orig_sr=source_sr, target_sr=target_sr)
-    return {"raw": samples, "sampling_rate": target_sr}, duration_seconds
 
 
 class OpenAIServingTranscription(OpenAIServing):
@@ -53,7 +41,7 @@ class OpenAIServingTranscription(OpenAIServing):
 
     async def warmup(self) -> None:
         logger.info("Warming up transcription model: %s", self.model_name)
-        audio_input, _ = _decode_audio(MINIMAL_WAV, self._target_sr)
+        audio_input, _ = _pipeline_input(MINIMAL_WAV, self._target_sr)
         await self.run_in_executor(self._run, audio_input, None)
         logger.info("Warmup transcription done for %s", self.model_name)
 
@@ -68,7 +56,7 @@ class OpenAIServingTranscription(OpenAIServing):
         )
 
         try:
-            audio_input, duration_seconds = _decode_audio(audio_data, self._target_sr)
+            audio_input, duration_seconds = _pipeline_input(audio_data, self._target_sr)
             result = await self.run_in_executor(self._run, audio_input, language)
         except Exception:
             logger.exception("transcription inference failed for %s", request_id)
@@ -104,7 +92,7 @@ class OpenAIServingTranslation(OpenAIServing):
 
     async def warmup(self) -> None:
         logger.info("Warming up translation model: %s", self.model_name)
-        audio_input, _ = _decode_audio(MINIMAL_WAV, self._target_sr)
+        audio_input, _ = _pipeline_input(MINIMAL_WAV, self._target_sr)
         await self.run_in_executor(self._run, audio_input)
         logger.info("Warmup translation done for %s", self.model_name)
 
@@ -116,7 +104,7 @@ class OpenAIServingTranslation(OpenAIServing):
         logger.log(TRACE, "translation request %s: audio_bytes=%d", request_id, len(audio_data))
 
         try:
-            audio_input, _ = _decode_audio(audio_data, self._target_sr)
+            audio_input, _ = _pipeline_input(audio_data, self._target_sr)
             result = await self.run_in_executor(self._run, audio_input)
         except Exception:
             logger.exception("translation inference failed for %s", request_id)

--- a/modelship/openai/protocol.py
+++ b/modelship/openai/protocol.py
@@ -383,6 +383,52 @@ class RawSpeechResponse(BaseModel):
 
 
 # ---------------------------------------------------------------------------
+# Raw engine outputs
+#
+# Protocol-agnostic shapes returned by custom plugins. The OpenAI serving
+# wrappers translate these into the OpenAI-compatible responses above. Keeping
+# engines free of OpenAI concerns means a different protocol adapter (e.g.
+# Anthropic, gRPC) can be added later without changing any plugin.
+# ---------------------------------------------------------------------------
+
+
+class RawToolCall(BaseModel):
+    id: str
+    name: str
+    arguments: str = Field(..., description="JSON-encoded arguments as produced by the engine")
+
+
+class RawChatCompletion(BaseModel):
+    text: str
+    tool_calls: list[RawToolCall] = Field(default_factory=list)
+    finish_reason: Literal["stop", "length", "tool_calls", "content_filter"] = "stop"
+    prompt_tokens: int | None = None
+    completion_tokens: int | None = None
+
+
+class RawChatDelta(BaseModel):
+    text: str | None = None
+    tool_call: RawToolCall | None = None
+    finish_reason: Literal["stop", "length", "tool_calls", "content_filter"] | None = None
+
+
+class RawSegment(BaseModel):
+    text: str
+    start: float = Field(..., description="start time in seconds")
+    end: float = Field(..., description="end time in seconds")
+
+
+class RawTranscription(BaseModel):
+    text: str
+    language: str | None = None
+    duration_seconds: float | None = None
+    segments: list[RawSegment] = Field(default_factory=list)
+
+
+RawTranslation = RawTranscription
+
+
+# ---------------------------------------------------------------------------
 # Image generation
 # ---------------------------------------------------------------------------
 
@@ -441,7 +487,13 @@ __all__ = [
     "ImageObject",
     "OpenAIBaseModel",
     "PromptTokenUsageInfo",
+    "RawChatCompletion",
+    "RawChatDelta",
+    "RawSegment",
     "RawSpeechResponse",
+    "RawToolCall",
+    "RawTranscription",
+    "RawTranslation",
     "SpeechRequest",
     "SpeechResponse",
     "StreamOptions",

--- a/modelship/plugins/base_plugin.py
+++ b/modelship/plugins/base_plugin.py
@@ -1,9 +1,31 @@
+"""
+Base class for custom model plugins.
+
+Plugins are protocol-agnostic engines. Each `create_*` method takes raw
+inputs and returns raw outputs. OpenAI (or any other) protocol shaping is
+done by the serving wrappers, not the plugin itself. Override only the
+methods matching the plugin's `usecase`; unimplemented methods return a 404
+error.
+"""
+
 from abc import ABC, abstractmethod
 from collections.abc import AsyncGenerator
-from typing import Literal, Protocol
+from typing import Protocol
 
 from modelship.infer.infer_config import ModelshipModelConfig
-from modelship.openai.protocol import ErrorResponse, RawSpeechResponse
+from modelship.openai.protocol import (
+    ErrorInfo,
+    ErrorResponse,
+    RawChatCompletion,
+    RawChatDelta,
+    RawSpeechResponse,
+    RawTranscription,
+    RawTranslation,
+)
+
+_NOT_SUPPORTED = ErrorResponse(
+    error=ErrorInfo(message="plugin does not support this action", type="invalid_request_error", code=404)
+)
 
 
 class BasePlugin(ABC):
@@ -15,14 +37,72 @@ class BasePlugin(ABC):
     async def start(self):
         pass
 
-    @abstractmethod
-    async def generate(
-        self, input: str, voice: str, request_id: str, stream_format: Literal["sse", "audio"]
-    ) -> RawSpeechResponse | AsyncGenerator[str, None] | ErrorResponse:
-        pass
-
     def max_context_length(self) -> int | None:
         return None
+
+    async def create_chat_completion(
+        self,
+        messages: list[dict],
+        tools: list[dict] | None = None,
+        temperature: float | None = None,
+        top_p: float | None = None,
+        max_tokens: int | None = None,
+        stop: list[str] | None = None,
+        stream: bool = False,
+        request_id: str | None = None,
+    ) -> RawChatCompletion | AsyncGenerator[RawChatDelta, None] | ErrorResponse:
+        return _NOT_SUPPORTED
+
+    async def create_embedding(
+        self,
+        input: list[str],
+        request_id: str | None = None,
+    ) -> list[list[float]] | ErrorResponse:
+        return _NOT_SUPPORTED
+
+    async def create_transcription(
+        self,
+        audio_data: bytes,
+        language: str | None = None,
+        prompt: str | None = None,
+        temperature: float | None = None,
+        request_id: str | None = None,
+    ) -> RawTranscription | ErrorResponse:
+        return _NOT_SUPPORTED
+
+    async def create_translation(
+        self,
+        audio_data: bytes,
+        prompt: str | None = None,
+        temperature: float | None = None,
+        request_id: str | None = None,
+    ) -> RawTranslation | ErrorResponse:
+        return _NOT_SUPPORTED
+
+    async def create_speech(
+        self,
+        input: str,
+        voice: str | None = None,
+        speed: float | None = None,
+        stream: bool = False,
+        request_id: str | None = None,
+    ) -> RawSpeechResponse | AsyncGenerator[tuple[bytes, int], None] | ErrorResponse:
+        """Synthesize speech. Non-stream returns a full `RawSpeechResponse`;
+        stream yields `(pcm_bytes, sample_rate)` tuples where `pcm_bytes` is
+        signed 16-bit little-endian mono PCM."""
+        return _NOT_SUPPORTED
+
+    async def create_image_generation(
+        self,
+        prompt: str,
+        n: int = 1,
+        size: str | None = None,
+        num_inference_steps: int | None = None,
+        guidance_scale: float | None = None,
+        request_id: str | None = None,
+    ) -> list[bytes] | ErrorResponse:
+        """Returns a list of PNG-encoded image bytes."""
+        return _NOT_SUPPORTED
 
 
 class PluginProto(Protocol):

--- a/modelship/utils/audio.py
+++ b/modelship/utils/audio.py
@@ -1,0 +1,69 @@
+"""Audio utilities shared by TTS/STT engines and serving wrappers."""
+
+from __future__ import annotations
+
+import io
+import struct
+from math import gcd
+
+import librosa
+import numpy as np
+import soundfile as sf
+from scipy.signal import resample_poly
+
+
+def to_pcm16(audio: np.ndarray) -> bytes:
+    """Encode a numpy audio array as signed 16-bit little-endian PCM bytes.
+    Float arrays are clipped to [-1, 1] and scaled; int arrays pass through."""
+    if audio.ndim > 1:
+        audio = audio.squeeze()
+    if np.issubdtype(audio.dtype, np.floating):
+        audio = (np.clip(audio, -1.0, 1.0) * 32767).astype(np.int16)
+    elif audio.dtype != np.int16:
+        audio = audio.astype(np.int16)
+    return audio.tobytes()
+
+
+def resample(audio: np.ndarray, from_rate: int, to_rate: int) -> np.ndarray:
+    """Resample audio to `to_rate`. Returns the array unchanged if rates match."""
+    if from_rate == to_rate:
+        return audio
+    g = gcd(to_rate, from_rate)
+    return resample_poly(audio, to_rate // g, from_rate // g).astype(audio.dtype)
+
+
+def wrap_pcm16_wav(pcm: bytes, sample_rate: int) -> bytes:
+    """Wrap signed 16-bit mono PCM bytes with a WAV header."""
+    header = struct.pack(
+        "<4sI4s4sIHHIIHH4sI",
+        b"RIFF",
+        36 + len(pcm),
+        b"WAVE",
+        b"fmt ",
+        16,
+        1,  # PCM
+        1,  # mono
+        sample_rate,
+        sample_rate * 2,  # byte rate
+        2,  # block align
+        16,  # bits per sample
+        b"data",
+        len(pcm),
+    )
+    return header + pcm
+
+
+def to_wav(audio: np.ndarray, sample_rate: int) -> bytes:
+    """Encode a numpy audio array as a 16-bit PCM mono WAV file."""
+    return wrap_pcm16_wav(to_pcm16(audio), sample_rate)
+
+
+def decode_audio(data: bytes, target_sr: int) -> tuple[np.ndarray, int]:
+    """Decode audio bytes and resample to `target_sr`. Returns (samples, duration_seconds)."""
+    samples, source_sr = sf.read(io.BytesIO(data), dtype="float32")
+    if samples.ndim > 1:
+        samples = np.mean(samples, axis=1)
+    duration_seconds = int(len(samples) / source_sr)
+    if source_sr != target_sr:
+        samples = librosa.resample(samples, orig_sr=source_sr, target_sr=target_sr)
+    return samples, duration_seconds

--- a/plugins/bark/bark/bark.py
+++ b/plugins/bark/bark/bark.py
@@ -25,18 +25,16 @@ Example request:
       --output speech.wav
 """
 
-import io
 from collections.abc import AsyncGenerator
-from typing import Literal
 
 import torch
-from scipy.io.wavfile import write as write_wav
 from transformers import BarkModel, BarkProcessor
 
 from modelship.infer.infer_config import ModelshipModelConfig
 from modelship.logging import get_logger
 from modelship.openai.protocol import ErrorResponse, RawSpeechResponse, create_error_response
 from modelship.plugins.base_plugin import BasePlugin
+from modelship.utils.audio import to_wav
 
 logger = get_logger("plugin.bark")
 
@@ -60,18 +58,21 @@ class ModelPlugin(BasePlugin):
     async def start(self):
         pass
 
-    async def generate(
-        self, input: str, voice: str, request_id: str, stream_format: Literal["sse", "audio"]
-    ) -> RawSpeechResponse | AsyncGenerator[str, None] | ErrorResponse:
+    async def create_speech(
+        self,
+        input: str,
+        voice: str | None = None,
+        speed: float | None = None,
+        stream: bool = False,
+        request_id: str | None = None,
+    ) -> RawSpeechResponse | AsyncGenerator[tuple[bytes, int], None] | ErrorResponse:
         logger.info("started generation: %s with voice: %s to device %s", input, voice, self.device)
 
-        if stream_format == "sse":
-            return create_error_response("sse stream format not supported")
+        if stream:
+            return create_error_response("bark does not support streaming")
 
         inputs = self.processor(input, voice_preset=voice).to(device=self.device)
         sample_rate = getattr(self.model.generation_config, "sample_rate", 24000)  # type: ignore[union-attr]
         speech_output = self.model.generate(**inputs).cpu().numpy().squeeze()  # type: ignore[call-arg]
 
-        buf = io.BytesIO()
-        write_wav(buf, rate=sample_rate, data=speech_output)
-        return RawSpeechResponse(audio=buf.getvalue(), media_type="audio/wav")
+        return RawSpeechResponse(audio=to_wav(speech_output, sample_rate), media_type="audio/wav")

--- a/plugins/kokoro/kokoro/__init__.py
+++ b/plugins/kokoro/kokoro/__init__.py
@@ -1,3 +1,0 @@
-from kokoro.kokoro import ModelPlugin
-
-__all__ = ["ModelPlugin"]

--- a/plugins/kokoroonnx/README.md
+++ b/plugins/kokoroonnx/README.md
@@ -1,17 +1,17 @@
-# Kokoro TTS Plugin
+# Kokoro ONNX TTS Plugin
 
 ONNX-based text-to-speech using [Kokoro](https://github.com/thewh1teagle/kokoro-onnx). Fast, lightweight, supports GPU and CPU inference.
 
 ## Installation
 
 ```bash
-uv sync --extra kokoro
+uv sync --extra kokoroonnx
 ```
 
 Or via Docker:
 
 ```
-MSHIP_PLUGINS=kokoro
+MSHIP_PLUGINS=kokoroonnx
 ```
 
 ## Requirements
@@ -26,7 +26,7 @@ models:
     model: hexgrad/Kokoro-82M
     usecase: tts
     loader: custom
-    plugin: kokoro
+    plugin: kokoroonnx
     num_gpus: 0.07
     plugin_config:
       onnx_provider: CUDAExecutionProvider
@@ -47,7 +47,7 @@ models:
     model: hexgrad/Kokoro-82M
     usecase: tts
     loader: custom
-    plugin: kokoro
+    plugin: kokoroonnx
     num_gpus: 0
     num_cpus: 1
     plugin_config:

--- a/plugins/kokoroonnx/kokoroonnx/__init__.py
+++ b/plugins/kokoroonnx/kokoroonnx/__init__.py
@@ -1,0 +1,3 @@
+from kokoroonnx.kokoroonnx import ModelPlugin
+
+__all__ = ["ModelPlugin"]

--- a/plugins/kokoroonnx/kokoroonnx/kokoroonnx.py
+++ b/plugins/kokoroonnx/kokoroonnx/kokoroonnx.py
@@ -18,44 +18,40 @@ Example request:
 
     curl http://localhost:8000/v1/audio/speech \\
       -H "Content-Type: application/json" \\
-      -d '{"model": "kokoro", "input": "Hello world", "voice": "af_heart", "response_format": "wav"}' \\
+      -d '{"model": "kokoroonnx", "input": "Hello world", "voice": "af_heart", "response_format": "wav"}' \\
       --output speech.wav
 """
 
-import base64
-import io
 import os
 import shutil
 from collections.abc import AsyncGenerator
-from typing import Literal
 
 import numpy as np
 import onnxruntime as ort  # type: ignore[import-unresolved]
 from kokoro_onnx import Kokoro  # type: ignore[import-unresolved]
-from scipy.io.wavfile import write as write_wav
-from scipy.signal import resample_poly
 
 from modelship.infer.infer_config import ModelshipModelConfig
 from modelship.logging import get_logger
-from modelship.openai.protocol import ErrorResponse, RawSpeechResponse, SpeechResponse
+from modelship.openai.protocol import ErrorResponse, RawSpeechResponse
 from modelship.plugins.base_plugin import BasePlugin
 from modelship.utils import download, plugins_dir
+from modelship.utils.audio import resample, to_pcm16, to_wav
 
-logger = get_logger("plugin.kokoro")
+logger = get_logger("plugin.kokoroonnx")
 
 
 class ModelPlugin(BasePlugin):
     def __init__(self, model_config: ModelshipModelConfig):
         if not shutil.which("espeak-ng") and not shutil.which("espeak"):
             raise RuntimeError(
-                "espeak/espeak-ng is required by kokoro but not found on this system. "
+                "espeak/espeak-ng is required by kokoroonnx but not found on this system. "
                 "Install it with: apt-get install -y espeak-ng (Debian/Ubuntu) "
                 "or brew install espeak (macOS)"
             )
         logger.info("onnxruntime device: %s", ort.get_device())
         logger.info("available providers: %s", ort.get_available_providers())
 
-        plugin_dir = f"{plugins_dir()}/kokoro"
+        plugin_dir = f"{plugins_dir()}/kokoroonnx"
         os.makedirs(plugin_dir, exist_ok=True)
 
         model_path = f"{plugin_dir}/kokoro-v1.0.onnx"
@@ -87,44 +83,37 @@ class ModelPlugin(BasePlugin):
     async def start(self):
         pass
 
-    def _resample(self, audio: np.ndarray, from_rate: int) -> tuple[np.ndarray, int]:
-        if self.target_sample_rate is None or from_rate == self.target_sample_rate:
+    def _maybe_resample(self, audio: np.ndarray, from_rate: int) -> tuple[np.ndarray, int]:
+        if self.target_sample_rate is None:
             return audio, from_rate
-        from math import gcd
+        return resample(audio, from_rate, self.target_sample_rate), self.target_sample_rate
 
-        g = gcd(self.target_sample_rate, from_rate)
-        audio = resample_poly(audio, self.target_sample_rate // g, from_rate // g).astype(audio.dtype)
-        return audio, self.target_sample_rate
-
-    async def generate(
-        self, input: str, voice: str, request_id: str, stream_format: Literal["sse", "audio"]
-    ) -> RawSpeechResponse | AsyncGenerator[str, None] | ErrorResponse:
+    async def create_speech(
+        self,
+        input: str,
+        voice: str | None = None,
+        speed: float | None = None,
+        stream: bool = False,
+        request_id: str | None = None,
+    ) -> RawSpeechResponse | AsyncGenerator[tuple[bytes, int], None] | ErrorResponse:
+        voice = voice or "af_heart"
+        speed = speed or 1.0
         logger.info("started generation: %s with voice: %s", input, voice)
 
-        if stream_format == "sse":
-            return self.generate_sse(input, voice, request_id)
-        else:
-            chunks = []
-            sample_rate = self.target_sample_rate
-            async for audio_bytes, sr in self.kokoro.create_stream(input, voice=voice, speed=1.0, lang="en-us"):  # type: ignore[union-attr]
-                audio_bytes, sample_rate = self._resample(audio_bytes, sr)
-                chunks.append(audio_bytes)
+        if stream:
+            return self._stream(input, voice, speed)
 
-            logger.info("got %d chunks (sample rate %s) for input: %s", len(chunks), sample_rate, input)
-            audio = np.concatenate(chunks)
-            if np.issubdtype(audio.dtype, np.floating):
-                audio = (np.clip(audio, -1.0, 1.0) * 32767).astype(np.int16)
-            buf = io.BytesIO()
-            write_wav(buf, rate=sample_rate, data=audio)
-            return RawSpeechResponse(audio=buf.getvalue(), media_type="audio/wav")
+        chunks: list[np.ndarray] = []
+        sample_rate = self.target_sample_rate or 0
+        async for audio, sr in self.kokoro.create_stream(input, voice=voice, speed=speed, lang="en-us"):  # type: ignore[union-attr]
+            audio, sample_rate = self._maybe_resample(audio, sr)
+            chunks.append(audio)
 
-    async def generate_sse(self, input: str, voice: str, request_id: str) -> AsyncGenerator[str, None]:
-        async for audio_bytes, sample_rate in self.kokoro.create_stream(input, voice=voice, speed=1.0, lang="en-us"):  # type: ignore[union-attr]
-            audio_bytes, sample_rate = self._resample(audio_bytes, sample_rate)
-            logger.debug("audio chunk sample_rate=%s bytes=%d", sample_rate, len(audio_bytes))
-            encoded_audio = base64.b64encode(audio_bytes).decode("utf-8")
-            event_data = SpeechResponse(audio=encoded_audio, type="speech.audio.delta")
-            yield f"data: {event_data.model_dump_json()}\n\n"
+        logger.info("got %d chunks (sample rate %s) for input: %s", len(chunks), sample_rate, input)
+        combined = np.concatenate(chunks)
+        return RawSpeechResponse(audio=to_wav(combined, sample_rate), media_type="audio/wav")
 
-        completion_event = SpeechResponse(audio=None, type="speech.audio.done")
-        yield f"data: {completion_event.model_dump_json()}\n\n"
+    async def _stream(self, input: str, voice: str, speed: float) -> AsyncGenerator[tuple[bytes, int], None]:
+        async for audio, sr in self.kokoro.create_stream(input, voice=voice, speed=speed, lang="en-us"):  # type: ignore[union-attr]
+            audio, sr = self._maybe_resample(audio, sr)
+            yield to_pcm16(audio), sr

--- a/plugins/kokoroonnx/pyproject.toml
+++ b/plugins/kokoroonnx/pyproject.toml
@@ -1,0 +1,24 @@
+[project]
+name = "kokoroonnx"
+version = "0.1.0"
+description = "Kokoro ONNX TTS plugin for Modelship"
+requires-python = "==3.12.10"
+dependencies = [
+    "modelship",
+    "kokoro-onnx[gpu]>=0.4.9",
+    "numpy>=2.2.6",
+    "onnxruntime-gpu>=1.20.1",
+    "scipy>=1.16.1",
+]
+
+[build-system]
+requires = ["uv_build"]
+build-backend = "uv_build"
+
+[tool.uv.sources]
+modelship = { workspace = true }
+
+[tool.uv.build-backend]
+module-name = "kokoroonnx"
+module-root = ""
+

--- a/plugins/orpheus/orpheus/orpheus.py
+++ b/plugins/orpheus/orpheus/orpheus.py
@@ -29,12 +29,8 @@ Example request:
       --output speech.wav
 """
 
-import base64
-import io
 import os
-import wave
 from collections.abc import AsyncGenerator
-from typing import Literal
 
 import numpy as np
 import torch
@@ -47,8 +43,9 @@ from vllm.v1.engine.async_llm import AsyncLLM
 
 from modelship.infer.infer_config import ModelshipModelConfig
 from modelship.logging import get_logger
-from modelship.openai.protocol import ErrorResponse, RawSpeechResponse, SpeechResponse
+from modelship.openai.protocol import ErrorResponse, RawSpeechResponse
 from modelship.plugins.base_plugin import BasePlugin
+from modelship.utils.audio import wrap_pcm16_wav
 
 logger = get_logger("plugin.orpheus")
 
@@ -208,40 +205,37 @@ class ModelPlugin(BasePlugin):
         formatted_prompt = f"{voice}: {prompt}"
         return f"<|audio|>{formatted_prompt}<|eot_id|>"
 
-    async def generate(
-        self, input: str, voice: str, request_id: str, stream_format: Literal["sse", "audio"]
-    ) -> RawSpeechResponse | AsyncGenerator[str, None] | ErrorResponse:
+    async def create_speech(
+        self,
+        input: str,
+        voice: str | None = None,
+        speed: float | None = None,
+        stream: bool = False,
+        request_id: str | None = None,
+    ) -> RawSpeechResponse | AsyncGenerator[tuple[bytes, int], None] | ErrorResponse:
+        voice = voice or "zoe"
+        request_id = request_id or ""
         logger.info("started generation: %s with voice: %s", input, voice)
-        if stream_format == "sse":
-            return self.generate_sse(input, voice, request_id)
-        else:
-            buf = io.BytesIO()
-            with wave.open(buf, "wb") as wf:
-                wf.setnchannels(1)
-                wf.setsampwidth(2)
-                wf.setframerate(24000)
-                total_frames = 0
-                async for audio_bytes in self.generate_audio_bytes_async(input, voice, request_id):
-                    logger.debug("audio chunk bytes=%d", len(audio_bytes))
-                    frame_count = len(audio_bytes) // (wf.getsampwidth() * wf.getnchannels())
-                    total_frames += frame_count
-                    wf.writeframes(audio_bytes)
 
-            duration = total_frames / 24000
-            logger.info("audio has total duration of %s seconds", duration)
-            return RawSpeechResponse(audio=buf.getvalue(), media_type="audio/wav")
+        if stream:
+            return self._stream(input, voice, request_id)
 
-    async def generate_sse(self, input: str, voice: str, request_id: str) -> AsyncGenerator[str, None]:
-        async for audio_bytes in self.generate_audio_bytes_async(input, voice, request_id):
+        pcm_chunks: list[bytes] = []
+        async for audio_bytes in self._generate_audio_bytes(input, voice, request_id):
             logger.debug("audio chunk bytes=%d", len(audio_bytes))
-            encoded_audio = base64.b64encode(audio_bytes).decode("utf-8")
-            event_data = SpeechResponse(audio=encoded_audio, type="speech.audio.delta")
-            yield f"data: {event_data.model_dump_json()}\n\n"
+            pcm_chunks.append(audio_bytes)
 
-        completion_event = SpeechResponse(audio=None, type="speech.audio.done")
-        yield f"data: {completion_event.model_dump_json()}\n\n"
+        pcm = b"".join(pcm_chunks)
+        duration = (len(pcm) // 2) / 24000
+        logger.info("audio has total duration of %s seconds", duration)
+        return RawSpeechResponse(audio=wrap_pcm16_wav(pcm, 24000), media_type="audio/wav")
 
-    async def generate_audio_bytes_async(self, input: str, voice: str, request_id: str) -> AsyncGenerator[bytes, None]:
+    async def _stream(self, input: str, voice: str, request_id: str) -> AsyncGenerator[tuple[bytes, int], None]:
+        async for audio_bytes in self._generate_audio_bytes(input, voice, request_id):
+            logger.debug("audio chunk bytes=%d", len(audio_bytes))
+            yield audio_bytes, 24000
+
+    async def _generate_audio_bytes(self, input: str, voice: str, request_id: str) -> AsyncGenerator[bytes, None]:
         async for audio_bytes in _tokens_decoder(self.generate_tokens_async(input, voice, request_id)):
             yield audio_bytes
 

--- a/plugins/whispercpp/README.md
+++ b/plugins/whispercpp/README.md
@@ -1,0 +1,62 @@
+# whisper.cpp STT Plugin
+
+Speech-to-text using [whisper.cpp](https://github.com/ggerganov/whisper.cpp) via [pywhispercpp](https://github.com/absadiki/pywhispercpp). CPU-only, no PyTorch — ideal for low-resource hosts (Intel N100 mini-PCs, ARM boards) where a full transformers stack is too heavy.
+
+## Installation
+
+```bash
+uv sync --extra whispercpp
+```
+
+Or via Docker:
+
+```
+MSHIP_PLUGINS=whispercpp
+```
+
+## Configuration
+
+```yaml
+models:
+  - name: whisper
+    model: base.en
+    usecase: transcription
+    loader: custom
+    plugin: whispercpp
+    num_gpus: 0
+    num_cpus: 1
+    plugin_config:
+      n_threads: 2
+```
+
+### plugin_config Options
+
+| Option | Type | Default | Description |
+|---|---|---|---|
+| `models_dir` | string | `<plugins_dir>/whispercpp` | Directory to store/load ggml model files |
+| `n_threads` | int | pywhispercpp default | CPU threads for inference |
+
+## Models
+
+Models are specified by their whisper.cpp short name and downloaded automatically on first use. Pick the smallest model that meets your accuracy needs:
+
+| Model | Size | Notes |
+|---|---|---|
+| `tiny.en` / `tiny` | ~75 MB | Fastest, lowest accuracy |
+| `base.en` / `base` | ~150 MB | Recommended for English on a mini-PC |
+| `small.en` / `small` | ~500 MB | Better accuracy, ~2× slower than base |
+| `medium.en` / `medium` | ~1.5 GB | High accuracy, significant CPU load |
+| `large-v3` | ~3 GB | Best accuracy, not recommended for CPU-only boxes |
+
+`.en` variants are English-only and noticeably faster. Drop the suffix for multilingual support.
+
+## Example Request
+
+```bash
+curl http://localhost:8000/v1/audio/transcriptions \
+  -H "Content-Type: multipart/form-data" \
+  -F file=@audio.wav \
+  -F model=whisper
+```
+
+Also supports `/v1/audio/translations` — sets `translate: true` to produce English output from non-English audio.

--- a/plugins/whispercpp/pyproject.toml
+++ b/plugins/whispercpp/pyproject.toml
@@ -1,14 +1,11 @@
 [project]
-name = "kokoro"
+name = "whispercpp"
 version = "0.1.0"
-description = "Kokoro ONNX TTS plugin for Modelship"
+description = "whisper.cpp STT plugin for Modelship (via pywhispercpp)"
 requires-python = "==3.12.10"
 dependencies = [
     "modelship",
-    "kokoro-onnx[gpu]>=0.4.9",
-    "numpy>=2.2.6",
-    "onnxruntime-gpu>=1.20.1",
-    "scipy>=1.16.1",
+    "pywhispercpp>=1.3.0",
 ]
 
 [build-system]
@@ -19,6 +16,5 @@ build-backend = "uv_build"
 modelship = { workspace = true }
 
 [tool.uv.build-backend]
-module-name = "kokoro"
+module-name = "whispercpp"
 module-root = ""
-

--- a/plugins/whispercpp/whispercpp/__init__.py
+++ b/plugins/whispercpp/whispercpp/__init__.py
@@ -1,0 +1,3 @@
+from whispercpp.whispercpp import ModelPlugin
+
+__all__ = ["ModelPlugin"]

--- a/plugins/whispercpp/whispercpp/whispercpp.py
+++ b/plugins/whispercpp/whispercpp/whispercpp.py
@@ -1,0 +1,103 @@
+"""
+whisper.cpp STT plugin for Modelship.
+
+Uses pywhispercpp (Python bindings for whisper.cpp) to run Whisper locally
+without PyTorch. Ideal for low-resource hosts (Intel N100 mini-PCs, ARM boards)
+where a full transformers stack is too heavy.
+
+Plugin config options (via plugin_config in models.yaml):
+
+    models_dir:   Directory to store/load ggml model files (default: plugins dir)
+    n_threads:    CPU threads for inference (default: pywhispercpp default)
+
+Example models.yaml entry:
+
+    - name: "whisper-base"
+      model: "base.en"
+      usecase: "stt"
+      loader: "custom"
+      plugin: "whispercpp"
+      num_gpus: 0
+      num_cpus: 2
+      plugin_config:
+        n_threads: 4
+
+Example request:
+
+    curl http://localhost:8000/v1/audio/transcriptions \\
+      -H "Content-Type: multipart/form-data" \\
+      -F file=@audio.wav \\
+      -F model=whisper-base
+"""
+
+import os
+
+from pywhispercpp.model import Model  # type: ignore[import-unresolved]
+
+from modelship.infer.infer_config import ModelshipModelConfig
+from modelship.logging import get_logger
+from modelship.openai.protocol import ErrorResponse, RawSegment, RawTranscription, RawTranslation
+from modelship.plugins.base_plugin import BasePlugin
+from modelship.utils import plugins_dir
+from modelship.utils.audio import decode_audio
+
+logger = get_logger("plugin.whispercpp")
+
+_WHISPER_SAMPLE_RATE = 16000
+
+
+class ModelPlugin(BasePlugin):
+    def __init__(self, model_config: ModelshipModelConfig):
+        self.model_config = model_config
+        plugin_config = model_config.plugin_config or {}
+
+        models_dir = plugin_config.get("models_dir", f"{plugins_dir()}/whispercpp")
+        os.makedirs(models_dir, exist_ok=True)
+
+        kwargs: dict = {"models_dir": models_dir}
+        if (n_threads := plugin_config.get("n_threads")) is not None:
+            kwargs["n_threads"] = n_threads
+
+        logger.info("loading whisper.cpp model: %s (dir=%s)", model_config.model, models_dir)
+        self.model = Model(model_config.model, **kwargs)
+
+    async def start(self):
+        pass
+
+    async def create_transcription(
+        self,
+        audio_data: bytes,
+        language: str | None = None,
+        prompt: str | None = None,
+        temperature: float | None = None,
+        request_id: str | None = None,
+    ) -> RawTranscription | ErrorResponse:
+        return self._run(audio_data, language=language, translate=False)
+
+    async def create_translation(
+        self,
+        audio_data: bytes,
+        prompt: str | None = None,
+        temperature: float | None = None,
+        request_id: str | None = None,
+    ) -> RawTranslation | ErrorResponse:
+        return self._run(audio_data, language=None, translate=True)
+
+    def _run(self, audio_data: bytes, language: str | None, translate: bool) -> RawTranscription:
+        samples, duration_seconds = decode_audio(audio_data, _WHISPER_SAMPLE_RATE)
+        params: dict = {"translate": translate}
+        if language:
+            params["language"] = language
+
+        segments = self.model.transcribe(samples, **params)
+
+        text = "".join(s.text for s in segments).strip()
+        raw_segments = [RawSegment(text=s.text.strip(), start=s.t0 / 100.0, end=s.t1 / 100.0) for s in segments]
+        detected_lang = "en" if translate else language
+
+        return RawTranscription(
+            text=text,
+            language=detected_lang,
+            duration_seconds=float(duration_seconds),
+            segments=raw_segments,
+        )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ dependencies = [
     "python-multipart>=0.0.20",
     "ray[data,default,serve-grpc]>=2.51.1",
     "librosa>=0.11.0",
+    "scipy>=1.16.1",
     "soundfile>=0.13.0",
     "requests>=2.32.5",
 ]
@@ -51,9 +52,10 @@ cpu = [
     "sentence-transformers>=3.0.0",
     "llama-cpp-python>=0.3.6",
 ]
-kokoro = ["kokoro"]
+kokoroonnx = ["kokoroonnx"]
 bark = ["bark"]
 orpheus = ["orpheus"]
+whispercpp = ["whispercpp"]
 otel = [
     "opentelemetry-sdk>=1.20.0",
     "opentelemetry-exporter-otlp>=1.20.0",
@@ -90,9 +92,10 @@ url = "https://download.pytorch.org/whl/cu128"
 explicit = true
 
 [tool.uv.sources]
-kokoro = { workspace = true }
+kokoroonnx = { workspace = true }
 bark = { workspace = true }
 orpheus = { workspace = true }
+whispercpp = { workspace = true }
 torch = [
   { index = "pytorch-cu128", extra = "gpu" },
   { index = "pytorch-cpu", extra = "cpu" },

--- a/start.py
+++ b/start.py
@@ -298,7 +298,7 @@ def main(argv: list[str] | None = None):
                 ModelshipAPI.options(
                     name=gateway_name,
                     num_replicas=1,
-                    ray_actor_options={"num_cpus": 1},
+                    ray_actor_options={"num_cpus": 0},
                 ).bind(),
                 name=gateway_name,
                 route_prefix="/",

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -80,9 +80,9 @@ class TestModelshipModelConfig:
             model="some-model",
             usecase=ModelUsecase.tts,
             loader=ModelLoader.custom,
-            plugin="kokoro",
+            plugin="kokoroonnx",
         )
-        assert config.plugin == "kokoro"
+        assert config.plugin == "kokoroonnx"
 
     def test_custom_loader_plugin_only(self):
         config = ModelshipModelConfig(
@@ -90,9 +90,9 @@ class TestModelshipModelConfig:
             model="some-model",
             usecase=ModelUsecase.tts,
             loader=ModelLoader.custom,
-            plugin="kokoro",
+            plugin="kokoroonnx",
         )
-        assert config.plugin == "kokoro"
+        assert config.plugin == "kokoroonnx"
 
     def test_model_required(self):
         with pytest.raises(ValidationError, match="Field required"):
@@ -176,7 +176,7 @@ class TestModelshipConfig:
                     model="some-model",
                     usecase=ModelUsecase.tts,
                     loader=ModelLoader.custom,
-                    plugin="kokoro",
+                    plugin="kokoroonnx",
                     num_gpus=0.05,
                 ),
             ]
@@ -197,7 +197,7 @@ class TestModelshipConfig:
                     model="hexgrad/Kokoro-82M",
                     usecase=ModelUsecase.tts,
                     loader=ModelLoader.custom,
-                    plugin="kokoro",
+                    plugin="kokoroonnx",
                     num_gpus=0.07,
                 ),
                 ModelshipModelConfig(
@@ -205,7 +205,7 @@ class TestModelshipConfig:
                     model="hexgrad/Kokoro-82M",
                     usecase=ModelUsecase.tts,
                     loader=ModelLoader.custom,
-                    plugin="kokoro",
+                    plugin="kokoroonnx",
                     num_gpus=0,
                 ),
             ]

--- a/uv.lock
+++ b/uv.lock
@@ -21,9 +21,10 @@ conflicts = [[
 [manifest]
 members = [
     "bark",
-    "kokoro",
+    "kokoroonnx",
     "modelship",
     "orpheus",
+    "whispercpp",
 ]
 
 [[package]]
@@ -1247,27 +1248,6 @@ wheels = [
 ]
 
 [[package]]
-name = "kokoro"
-version = "0.1.0"
-source = { editable = "plugins/kokoro" }
-dependencies = [
-    { name = "kokoro-onnx", extra = ["gpu"] },
-    { name = "modelship" },
-    { name = "numpy" },
-    { name = "onnxruntime-gpu" },
-    { name = "scipy" },
-]
-
-[package.metadata]
-requires-dist = [
-    { name = "kokoro-onnx", extras = ["gpu"], specifier = ">=0.4.9" },
-    { name = "modelship", editable = "." },
-    { name = "numpy", specifier = ">=2.2.6" },
-    { name = "onnxruntime-gpu", specifier = ">=1.20.1" },
-    { name = "scipy", specifier = ">=1.16.1" },
-]
-
-[[package]]
 name = "kokoro-onnx"
 version = "0.4.9"
 source = { registry = "https://pypi.org/simple" }
@@ -1286,6 +1266,27 @@ wheels = [
 [package.optional-dependencies]
 gpu = [
     { name = "onnxruntime-gpu", marker = "(platform_machine == 'x86_64' and sys_platform != 'darwin') or (platform_machine != 'x86_64' and extra == 'extra-9-modelship-cpu' and extra == 'extra-9-modelship-gpu') or (sys_platform == 'darwin' and extra == 'extra-9-modelship-cpu' and extra == 'extra-9-modelship-gpu')" },
+]
+
+[[package]]
+name = "kokoroonnx"
+version = "0.1.0"
+source = { editable = "plugins/kokoroonnx" }
+dependencies = [
+    { name = "kokoro-onnx", extra = ["gpu"] },
+    { name = "modelship" },
+    { name = "numpy" },
+    { name = "onnxruntime-gpu" },
+    { name = "scipy" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "kokoro-onnx", extras = ["gpu"], specifier = ">=0.4.9" },
+    { name = "modelship", editable = "." },
+    { name = "numpy", specifier = ">=2.2.6" },
+    { name = "onnxruntime-gpu", specifier = ">=1.20.1" },
+    { name = "scipy", specifier = ">=1.16.1" },
 ]
 
 [[package]]
@@ -1537,6 +1538,7 @@ dependencies = [
     { name = "python-multipart" },
     { name = "ray", extra = ["data", "default", "serve-grpc"] },
     { name = "requests" },
+    { name = "scipy" },
     { name = "soundfile" },
 ]
 
@@ -1571,8 +1573,8 @@ gpu = [
     { name = "transformers" },
     { name = "vllm", extra = ["audio"], marker = "extra == 'extra-9-modelship-gpu'" },
 ]
-kokoro = [
-    { name = "kokoro" },
+kokoroonnx = [
+    { name = "kokoroonnx" },
 ]
 orpheus = [
     { name = "orpheus" },
@@ -1580,6 +1582,9 @@ orpheus = [
 otel = [
     { name = "opentelemetry-exporter-otlp" },
     { name = "opentelemetry-sdk" },
+]
+whispercpp = [
+    { name = "whispercpp" },
 ]
 
 [package.metadata]
@@ -1592,7 +1597,7 @@ requires-dist = [
     { name = "fastapi", specifier = ">=0.116.1" },
     { name = "flashinfer-python", marker = "extra == 'gpu'", specifier = ">=0.6.1" },
     { name = "httpx", specifier = ">=0.28.1" },
-    { name = "kokoro", marker = "extra == 'kokoro'", editable = "plugins/kokoro" },
+    { name = "kokoroonnx", marker = "extra == 'kokoroonnx'", editable = "plugins/kokoroonnx" },
     { name = "librosa", specifier = ">=0.11.0" },
     { name = "llama-cpp-python", marker = "extra == 'cpu'", specifier = ">=0.3.6" },
     { name = "llama-cpp-python", marker = "extra == 'gpu'", specifier = ">=0.3.6" },
@@ -1610,6 +1615,7 @@ requires-dist = [
     { name = "ray", extras = ["data", "default", "serve-grpc"], specifier = ">=2.51.1" },
     { name = "requests", specifier = ">=2.32.5" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.11.0" },
+    { name = "scipy", specifier = ">=1.16.1" },
     { name = "sentence-transformers", marker = "extra == 'cpu'", specifier = ">=3.0.0" },
     { name = "sentence-transformers", marker = "extra == 'gpu'", specifier = ">=3.0.0" },
     { name = "soundfile", specifier = ">=0.13.0" },
@@ -1621,8 +1627,9 @@ requires-dist = [
     { name = "transformers", marker = "extra == 'gpu'", specifier = ">=4.57.5" },
     { name = "vllm", marker = "extra == 'gpu'", specifier = "==0.18.0" },
     { name = "vllm", extras = ["audio"], marker = "extra == 'gpu'", specifier = "==0.18.0" },
+    { name = "whispercpp", marker = "extra == 'whispercpp'", editable = "plugins/whispercpp" },
 ]
-provides-extras = ["gpu", "cpu", "kokoro", "bark", "orpheus", "otel", "dev"]
+provides-extras = ["gpu", "cpu", "kokoroonnx", "bark", "orpheus", "whispercpp", "otel", "dev"]
 
 [[package]]
 name = "mpmath"
@@ -2974,6 +2981,27 @@ wheels = [
 ]
 
 [[package]]
+name = "pywhispercpp"
+version = "1.4.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+    { name = "platformdirs" },
+    { name = "requests" },
+    { name = "tqdm" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f6/7d/fe4b2b190d6cdcf0d5e4ca2b946d73bc449a586606a24d25ff50ffec5a5c/pywhispercpp-1.4.1.tar.gz", hash = "sha256:520ce9275bb6fc81e0daa2e08144a80ee006b117a18058a77860c5b1c9c122f4", size = 1812704, upload-time = "2025-12-30T03:02:12.54Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/93/81/a4ca043b96a1cd05659af556223de31ce336f5c88f1decd9ca4def8b8f42/pywhispercpp-1.4.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:92168783736e23e9e274e4496024a7a25d670601a130a35befd627b6f717a98a", size = 2207307, upload-time = "2025-12-30T03:01:22.876Z" },
+    { url = "https://files.pythonhosted.org/packages/77/63/7f3f7af598bfaa0fd4836cbd16716a7098c521a76404d5f7bac6211ec725/pywhispercpp-1.4.1-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ed46e7469feaad4a03e25a9f75fe54da791d161489ca02c160540135f21ac481", size = 2378182, upload-time = "2025-12-30T03:01:24.115Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/5f/6ad9e807bf705c053a87078aec118f1d154247418a592a2ac0a7622b0539/pywhispercpp-1.4.1-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:aef812596e4726a76c8b5a090d3e4f0ad9e2ebc70f004164ec754a60aaf56446", size = 2630413, upload-time = "2025-12-30T03:01:25.915Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/06/9dac4ebee6fb436650965161082e7de674c68a959fd4ee530cbb231eb4f4/pywhispercpp-1.4.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:b0dd76b28359f7cb82b999627acd4b6a6c1f7aa8106810601d80712d873e3f90", size = 3285003, upload-time = "2025-12-30T03:01:27.676Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/91/72c3b3f85239816d5414b12b190b474e9e7e37472fb0b1cfdff75d42448b/pywhispercpp-1.4.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:8f7f2cd5a0f876134d7ee85c7603e55d0df830ca2e8d910cc11d7e8c0423b739", size = 3556791, upload-time = "2025-12-30T03:01:29.417Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/77/bc7c07353afcf31c81817fcced7a09457aadfe2f825d6243664189955715/pywhispercpp-1.4.1-cp312-cp312-win32.whl", hash = "sha256:dfe69c89c830aad506685c460d5115e6a52159150b86ee2b9a2618e7786767be", size = 1041447, upload-time = "2025-12-30T03:01:30.686Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/b0/ffcb3e797d80b02e77a174e60f80cd94e851491647e64227ca76b4e2bcf8/pywhispercpp-1.4.1-cp312-cp312-win_amd64.whl", hash = "sha256:4beb57ec35dc0457188470ab4ef673620ce9a49a99ddecd0ae76567986dba908", size = 1222302, upload-time = "2025-12-30T03:01:32.631Z" },
+]
+
+[[package]]
 name = "pywin32"
 version = "311"
 source = { registry = "https://pypi.org/simple" }
@@ -4151,6 +4179,21 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/91/d6/7d4553ad4bf1c0421e1ebd4b18de5d9098383b5caa1d937b63df8d04b565/websockets-16.0-cp312-cp312-win32.whl", hash = "sha256:eaded469f5e5b7294e2bdca0ab06becb6756ea86894a47806456089298813c89", size = 178261, upload-time = "2026-01-10T09:22:56.251Z" },
     { url = "https://files.pythonhosted.org/packages/c3/f0/f3a17365441ed1c27f850a80b2bc680a0fa9505d733fe152fdf5e98c1c0b/websockets-16.0-cp312-cp312-win_amd64.whl", hash = "sha256:5569417dc80977fc8c2d43a86f78e0a5a22fee17565d78621b6bb264a115d4ea", size = 178693, upload-time = "2026-01-10T09:22:57.478Z" },
     { url = "https://files.pythonhosted.org/packages/6f/28/258ebab549c2bf3e64d2b0217b973467394a9cea8c42f70418ca2c5d0d2e/websockets-16.0-py3-none-any.whl", hash = "sha256:1637db62fad1dc833276dded54215f2c7fa46912301a24bd94d45d46a011ceec", size = 171598, upload-time = "2026-01-10T09:23:45.395Z" },
+]
+
+[[package]]
+name = "whispercpp"
+version = "0.1.0"
+source = { editable = "plugins/whispercpp" }
+dependencies = [
+    { name = "modelship" },
+    { name = "pywhispercpp" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "modelship", editable = "." },
+    { name = "pywhispercpp", specifier = ">=1.3.0" },
 ]
 
 [[package]]


### PR DESCRIPTION
…secases

Previously the custom plugin loader supported only TTS — BasePlugin exposed a single create_speech path and CustomInfer only routed to it. This expands the plugin system to cover all usecases (chat, embed, transcription, translation, tts, image): BasePlugin now has a create_* method per usecase with a 404 fallback, plugins return protocol-agnostic raw outputs, and OpenAI-shape adaptation happens in serving wrappers under modelship/infer/custom/openai/.

- Add whispercpp plugin (CPU-only STT via pywhispercpp) with README
- Wire transcription/translation adapters into the custom loader
- Rename kokoro plugin to kokoroonnx (parallels whispercpp naming, reflects the ONNX Runtime backend); update configs, tests, docs, lock
- Add mini-pc.yaml example (llama.cpp chat + Kokoro ONNX TTS + whisper.cpp STT for Intel N100-class hosts)
- Drop gateway num_cpus from 1 to 0 so the async FastAPI router overlaps with model actors instead of reserving a dedicated core
- Rewrite docs/plugins.md (was stale — described a TTS-only generate() API that no longer exists); refresh README / architecture / model-configuration / development / monitoring with new plugin list

