### PR TITLE
feat: /status readiness endpoint with per-model load timings

### DIFF
--- a/docs/monitoring.md
+++ b/docs/monitoring.md
@@ -238,14 +238,37 @@ All thresholds are starting points. Adjust based on your deployment:
 - **TTFT**: 5s is generous. For interactive chat, consider 2-3s.
 - **GPU memory**: 1 GB threshold assumes you're not running anything else on the GPU. Raise if you have shared workloads.
 
-## Health Check
+## Health and readiness
 
-A health endpoint is always available regardless of the metrics toggle:
+Two endpoints are always available regardless of the metrics toggle.
+
+**`/health`** — cheap liveness probe. Returns 200 as soon as the gateway is up (before model deployments finish):
 
 ```bash
 curl http://localhost:8000/health
-# {"status": "ok"}
+# {"status": "ok", "uptime_s": 12.3}
 ```
+
+**`/status`** — readiness + timing. Returns 200 when every expected model has a registered deployment; 503 with the same JSON body while any model is still pending. Bodies carry full state so a single poll tells you what's loaded, what's outstanding, and how long each model took to come up:
+
+```bash
+curl http://localhost:8000/status
+# 200 when ready:
+# {
+#   "status": "ok",
+#   "ready": true,
+#   "uptime_s": 420.5,
+#   "time_to_ready_s": 215.3,
+#   "models_loaded":   ["kokoro", "llm", "nomic-embed", "whisper"],
+#   "models_expected": ["llm", "kokoro", "whisper", "nomic-embed"],
+#   "models_pending":  [],
+#   "model_load_times_s": {"llm": 50.2, "kokoro": 8.1, "whisper": 120.5, "nomic-embed": 36.5}
+# }
+```
+
+Per-model timings are gateway-measured: the gap between one model registering and the next (models deploy sequentially in `start.py`), so the first model's entry includes any framework-level setup time preceding it.
+
+Use `/health` for Kubernetes liveness probes and `/status` for readiness probes — `/status` returning 503 prevents a service from flipping traffic onto the pod before models are loaded.
 
 ## Modelship Metrics Reference
 

--- a/docs/production-readiness.md
+++ b/docs/production-readiness.md
@@ -14,7 +14,7 @@ Future development priorities for making Modelship production-ready, organized b
 
 ### Health & Readiness
 
-- [ ] **Detailed readiness probe** — `/health` must check model health, GPU status, and Ray cluster connectivity (currently returns `ok` unconditionally)
+- [x] **Detailed readiness probe** — `/status` returns 200 only when every expected model is registered with the gateway; 503 with loaded/pending lists while loading. `/health` stays as a cheap liveness endpoint. Per-model load times and total time-to-ready are exposed via `/status` for observability.
 - [ ] **Model-specific health checks** — per-model liveness status (vLLM engine, Ray actor state)
 - [ ] **GPU memory checks** — detect and report memory pressure before OOM
 
@@ -35,7 +35,7 @@ Future development priorities for making Modelship production-ready, organized b
 - [ ] **Kubernetes manifests** — Deployment, Service, ConfigMap, PVC, Ingress with proper resource requests/limits, GPU scheduling, node affinity, tolerations
 - [ ] **Helm chart** — parameterized deployment for different environments
 - [ ] **Docker Compose** — for simpler non-K8s deployments
-- [ ] **Liveness/readiness probes in container spec** — wire the improved `/health` endpoint into K8s probes
+- [ ] **Liveness/readiness probes in container spec** — wire `/health` (liveness) and `/status` (readiness) into K8s probes
 
 ### Alerting & Observability
 

--- a/modelship/openai/api.py
+++ b/modelship/openai/api.py
@@ -120,6 +120,21 @@ class ModelshipAPI:
         self.models: dict[str, list[DeploymentHandle]] = {}
         self._round_robin: dict[str, int] = {}
         self.model_list: list[OpenAiModelCard] = []
+        self.expected_models: list[str] = []
+        self._started_at = time.time()
+        # Timing state — set_expected_models stamps a start, each add_models
+        # arrival records the gap since the previous arrival as that model's
+        # load duration (start.py deploys sequentially so the gap ≈ load time).
+        self._expected_set_at: float | None = None
+        self._last_model_at: float | None = None
+        self._all_ready_at: float | None = None
+        self._model_load_times: dict[str, float] = {}
+
+    async def set_expected_models(self, names: list[str]):
+        self.expected_models = list(names)
+        now = time.time()
+        self._expected_set_at = now
+        self._last_model_at = now
 
     async def add_models(self, deployments: dict[str, str]):
         """Register new model deployments with the gateway.
@@ -134,12 +149,22 @@ class ModelshipAPI:
                 logger.exception("Failed to get handle for app: %s", app_name)
                 continue
 
-            if model_name not in self.models:
+            newly_added = model_name not in self.models
+            if newly_added:
                 self.models[model_name] = []
                 self._round_robin[model_name] = 0
                 self.model_list.append(OpenAiModelCard(id=model_name))
             self.models[model_name].append(handle)
             logger.info("Registered deployment: %s (model: %s)", app_name, model_name)
+
+            if newly_added:
+                now = time.time()
+                base = self._last_model_at or self._started_at
+                self._model_load_times[model_name] = round(now - base, 2)
+                self._last_model_at = now
+
+        if self.expected_models and self._all_ready_at is None and all(m in self.models for m in self.expected_models):
+            self._all_ready_at = time.time()
 
         MODELS_LOADED.set(len(self.models))
 
@@ -219,7 +244,35 @@ class ModelshipAPI:
 
     @app.get("/health")
     async def health(self):
-        return {"status": "ok"}
+        return {
+            "status": "ok",
+            "uptime_s": round(time.time() - self._started_at, 1),
+        }
+
+    def _status_body(self) -> dict:
+        expected = list(self.expected_models)
+        pending = [m for m in expected if m not in self.models] if expected else []
+        ready = bool(expected) and len(pending) == 0
+        time_to_ready: float | None = None
+        if self._all_ready_at is not None and self._expected_set_at is not None:
+            time_to_ready = round(self._all_ready_at - self._expected_set_at, 2)
+        return {
+            "status": "ok",
+            "ready": ready,
+            "uptime_s": round(time.time() - self._started_at, 1),
+            "time_to_ready_s": time_to_ready,
+            "models_loaded": sorted(self.models.keys()),
+            "models_expected": expected,
+            "models_pending": pending,
+            "model_load_times_s": dict(self._model_load_times),
+        }
+
+    @app.get("/status")
+    async def status(self):
+        body = self._status_body()
+        if body["ready"]:
+            return body
+        return JSONResponse(status_code=503, content=body)
 
     @app.get("/v1/models", response_model=OpenaiModelList)
     async def list_models(self):

--- a/start.py
+++ b/start.py
@@ -269,6 +269,28 @@ def main(argv: list[str] | None = None):
     signal.signal(signal.SIGTERM, _cleanup)
 
     try:
+        # Start the gateway FIRST on fresh install so /health, /v1/models, and
+        # /readyz are reachable while models are still loading. Models register
+        # with the gateway as they come up (incremental add_models calls).
+        if fresh_install:
+            logger.info("Starting API gateway...")
+            serve.run(
+                ModelshipAPI.options(
+                    name=gateway_name,
+                    num_replicas=1,
+                    ray_actor_options={"num_cpus": 0},
+                ).bind(),
+                name=gateway_name,
+                route_prefix="/",
+            )
+            logger.info("Gateway up — /health and /readyz now serving.")
+
+        gateway_handle = serve.get_app_handle(gateway_name)
+        try:
+            gateway_handle.set_expected_models.remote([c.name for c in sorted_models]).result()
+        except Exception:
+            logger.exception("Failed to seed expected model list on gateway (non-fatal).")
+
         # Deploy models one at a time. serve.run() blocks until the deployment reaches
         # RUNNING, ensuring each model fully initialises (and releases its load-time
         # memory spike) before the next one starts.
@@ -291,23 +313,11 @@ def main(argv: list[str] | None = None):
             )
             logger.info("Model ready: %s (deployment: %s)", config.name, deployment_name)
 
-        # Ensure the gateway is running, then register the new models with it.
-        if fresh_install:
-            logger.info("Starting API gateway...")
-            serve.run(
-                ModelshipAPI.options(
-                    name=gateway_name,
-                    num_replicas=1,
-                    ray_actor_options={"num_cpus": 0},
-                ).bind(),
-                name=gateway_name,
-                route_prefix="/",
-            )
-
-        if deployed_this_run:
-            gateway_handle = serve.get_app_handle(gateway_name)
-            gateway_handle.add_models.remote(deployed_this_run).result()
-            logger.info("Registered %d deployment(s) with gateway.", len(deployed_this_run))
+            # Register immediately so /v1/models reflects progress.
+            try:
+                gateway_handle.add_models.remote({deployment_name: config.name}).result()
+            except Exception:
+                logger.exception("Failed to register %s with gateway", deployment_name)
 
         logger.info("Deploy complete. %d new deployment(s) from this run.", len(deployed_this_run))
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -72,6 +72,41 @@ class TestAddModels:
         assert "qwen" not in api.models
         assert len(api.model_list) == 0
 
+    @pytest.mark.asyncio
+    async def test_records_per_model_load_times_and_ready_timestamp(self, api):
+        await api.set_expected_models(["qwen", "kokoro"])
+        assert api._expected_set_at is not None
+        assert api._all_ready_at is None
+
+        mock_handle = MagicMock()
+        with patch("modelship.openai.api.serve.get_app_handle", return_value=mock_handle):
+            await api.add_models({"qwen-a3f9k": "qwen"})
+            assert "qwen" in api._model_load_times
+            assert api._model_load_times["qwen"] >= 0
+            assert api._all_ready_at is None
+
+            await api.add_models({"kokoro-c1m4n": "kokoro"})
+            assert "kokoro" in api._model_load_times
+            assert api._all_ready_at is not None
+
+    @pytest.mark.asyncio
+    async def test_status_body_ready_flag(self, api):
+        await api.set_expected_models(["qwen"])
+        body = api._status_body()
+        assert body["ready"] is False
+        assert body["models_pending"] == ["qwen"]
+        assert body["time_to_ready_s"] is None
+
+        mock_handle = MagicMock()
+        with patch("modelship.openai.api.serve.get_app_handle", return_value=mock_handle):
+            await api.add_models({"qwen-a3f9k": "qwen"})
+
+        body = api._status_body()
+        assert body["ready"] is True
+        assert body["models_pending"] == []
+        assert body["time_to_ready_s"] is not None
+        assert "qwen" in body["model_load_times_s"]
+
 
 class TestGetHandle:
     @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Makes readiness observable while models load. Previously \`/health\` was unreachable on fresh installs until **every** model deployment reached RUNNING — users hit a multi-minute black box and often couldn't tell whether progress was being made or whether a deploy was stuck.

### Startup order (\`start.py\`)
- **Deploy the gateway first** on fresh install. \`/health\`, \`/status\`, and \`/v1/models\` now serve from the moment the process is up.
- Seed expected model names via \`gateway_handle.set_expected_models([...])\`.
- Call \`gateway_handle.add_models({deployment_name: model_name})\` **per model**, as soon as that model's \`serve.run()\` returns, instead of batching at the end. \`/v1/models\` reflects progress incrementally.

### Endpoints (\`modelship/openai/api.py\`)
- **\`/health\`** — slim liveness. Always 200. Body: \`{status, uptime_s}\`. Already middleware-bypassed for API-key auth; keeping it cheap preserves that.
- **\`/status\`** — readiness. 200 when every expected model is registered, **503** with the same JSON body while any model is pending. Response shape:
  \`\`\`json
  {
    \"status\": \"ok\",
    \"ready\": true,
    \"uptime_s\": 420.5,
    \"time_to_ready_s\": 215.3,
    \"models_loaded\":   [\"kokoro\", \"llm\", \"nomic-embed\", \"whisper\"],
    \"models_expected\": [\"llm\", \"kokoro\", \"whisper\", \"nomic-embed\"],
    \"models_pending\":  [],
    \"model_load_times_s\": { \"llm\": 50.2, \"kokoro\": 8.1, \"whisper\": 120.5, \"nomic-embed\": 36.5 }
  }
  \`\`\`

### Timing source
- Gateway-measured: \`set_expected_models\` stamps a start timestamp; each \`add_models\` arrival records the gap since the previous arrival as that model's load duration. Models deploy sequentially in \`start.py\`, so the gap ≈ load time.
- The first model's entry absorbs any \`start.py\` setup before the first \`serve.run()\` returns — documented inline with a one-line comment.
- \`time_to_ready_s\` = (last-model-ready time − expected-set time); \`null\` until ready.

### Tests (\`tests/test_api.py\`)
- New: \`test_records_per_model_load_times_and_ready_timestamp\`, \`test_status_body_ready_flag\`.
- Existing 23 tests still pass (25/25 total).

### Docs
- \`docs/monitoring.md\` — \`/health\` + \`/status\` reference with sample bodies and guidance on K8s liveness/readiness probe wiring.
- \`docs/production-readiness.md\` — detailed-readiness-probe checkbox marked done; K8s probes line now points at both endpoints.

## Observed live run

On an RTX 4090 with the 24gb preset (4 models, weights cached), \`/status\` returned \`ready: true\` after \`time_to_ready_s: 419.79\`, with \`{llm: 81.36, kokoro: 5.2, whisper: 311.08, nomic-embed: 22.15}\`. Whisper dominated, exactly what the per-model breakdown is meant to surface.

## Test plan

- [ ] \`make lint && make test\` — all 25 pass.
- [ ] Boot a preset; while models load, \`curl http://localhost:8000/status\` returns **503** with partial \`model_load_times_s\`.
- [ ] \`curl http://localhost:8000/health\` returns **200** with \`{status, uptime_s}\` while still loading.
- [ ] Once ready, \`/status\` returns **200** with \`time_to_ready_s\` set and every expected model present in \`models_loaded\`.
- [ ] \`/readyz\` (old, temporary name in no released version) returns **404**.