### PR TITLE
build: drop --compile-bytecode from uv sync in Docker builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -138,7 +138,7 @@ ADD --chown=$UID:$GID ./plugins plugins
 USER modelship
 
 RUN --mount=type=cache,target=/.cache/uv,uid=$UID,gid=$GID \
-    uv sync --locked --no-install-project --compile-bytecode \
+    uv sync --locked --no-install-project \
         --extra gpu \
         --extra kokoroonnx \
         --extra bark \
@@ -153,7 +153,7 @@ FROM builder AS dev
 USER modelship
 
 RUN --mount=type=cache,target=/.cache/uv,uid=$UID,gid=$GID \
-    uv sync --locked --no-install-project --compile-bytecode --extra dev --extra gpu
+    uv sync --locked --no-install-project --extra dev --extra gpu
 
 ADD --chown=$UID:$GID ./scripts/start_ray.sh /modelship/scripts/start_ray.sh
 

--- a/Dockerfile.cpu
+++ b/Dockerfile.cpu
@@ -75,7 +75,7 @@ ADD --chown=$UID:$GID ./plugins plugins
 USER modelship
 
 RUN --mount=type=cache,target=/.cache/uv,uid=$UID,gid=$GID \
-    uv sync --locked --no-install-project --compile-bytecode \
+    uv sync --locked --no-install-project \
         --extra cpu \
         --extra kokoroonnx \
         --extra bark \
@@ -90,7 +90,7 @@ FROM builder AS dev
 USER modelship
 
 RUN --mount=type=cache,target=/.cache/uv,uid=$UID,gid=$GID \
-    uv sync --locked --no-install-project --compile-bytecode --extra dev --extra cpu
+    uv sync --locked --no-install-project --extra dev --extra cpu
 
 ADD --chown=$UID:$GID ./scripts/start_ray.sh /modelship/scripts/start_ray.sh
 


### PR DESCRIPTION
Release builds were OOM-ing the GHA runner's disk when installing pandas during the builder stage sync. Eager bytecode compilation roughly doubles the venv's Python-source footprint; skipping it frees enough space to fit the gpu + plugin extras. Tradeoff is a small first-import cost per module, which amortises to zero for a long-running Ray Serve process.


