### PR TITLE
feat: implement dynamic wheel-based plugin deployment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ __pycache__
 .claude
 *.DS_Store
 .cache
+.build
 local_models
 models-cache
 config/models.yaml

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,7 +46,7 @@ Entry point is `start.py` (not a console script, not `python -m`). It:
 3. Deploys models **additively** by default (new deployments get a random suffix, e.g. `qwen-a3f9k`). Pass `--redeploy` to tear everything down first.
 4. Starts a FastAPI gateway Ray Serve app named `modelship api` (override with `--gateway-name`), listening on port `8000`.
 
-The Docker image's `CMD` (`scripts/start.sh`) auto-runs `uv sync` with the right extras based on `MSHIP_PLUGINS` and `RAY_HEAD_GPU_NUM`, then `ray start`, then `uv run start.py`. The Dev Container overrides this, so inside a Dev Container you must run those steps manually (see `docs/development.md`).
+The Docker image's `CMD` (`scripts/start.sh`) auto-runs `uv sync` with the right extras based on `RAY_HEAD_GPU_NUM`, then `ray start`, then `uv run start.py`. The Dev Container overrides this, so inside a Dev Container you must run those steps manually (see `docs/development.md`).
 
 ## Architecture quick map
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,7 +37,7 @@ CI mirrors `make lint` + `pytest tests/ -v`. Match it locally before pushing.
 3. Deploys models **additively** by default (each gets a random suffix like `qwen-a3f9k`). Use `--redeploy` to tear everything down first.
 4. Starts a FastAPI Ray Serve app named `modelship api` on port 8000. Override via `--gateway-name` (multiple gateways can coexist on one cluster).
 
-Docker's `scripts/start.sh` auto-runs `uv sync` (extras chosen from `MSHIP_PLUGINS` + `RAY_HEAD_GPU_NUM`), `ray start`, then `uv run start.py`. The Dev Container overrides this — inside it you must run those steps manually.
+Docker's `scripts/start.sh` auto-runs `uv sync` (extras chosen based on `RAY_HEAD_GPU_NUM`), `ray start`, then `uv run start.py`. The Dev Container overrides this — inside it you must run those steps manually.
 
 ## Architecture map
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,7 +9,7 @@ The recommended way to develop is via the VS Code Dev Container. See [docs/devel
 **Quick version:**
 
 1. Install Docker + NVIDIA Container Toolkit
-2. Set `HF_TOKEN` and `MSHIP_PLUGINS` environment variables
+2. Set the `HF_TOKEN` environment variable
 3. Open the project in VS Code and select **Dev Containers: Reopen in Container**
 4. Inside the container:
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -79,6 +79,7 @@ ENV MSHIP_LOG_LEVEL=INFO
 ENV MSHIP_LOG_FORMAT=text
 ENV UV_PYTHON_INSTALL_DIR=/usr/local/uv/python
 ENV PATH="$UV_PROJECT_ENVIRONMENT/bin:$PATH"
+ENV MSHIP_PLUGIN_WHEEL_DIR=/opt/modelship/plugin-wheels
 
 # onnxruntime-gpu (pulled in by the kokoroonnx plugin) dlopen()s
 # libonnxruntime_providers_cuda.so which has plain DT_NEEDED entries for
@@ -91,7 +92,8 @@ ENV PATH="$UV_PROJECT_ENVIRONMENT/bin:$PATH"
 # shell-evaluate.
 ENV LD_LIBRARY_PATH="/.venv/lib/python3.12/site-packages/nvidia/cublas/lib:/.venv/lib/python3.12/site-packages/nvidia/cudnn/lib:/.venv/lib/python3.12/site-packages/nvidia/cufft/lib:/.venv/lib/python3.12/site-packages/nvidia/curand/lib:/.venv/lib/python3.12/site-packages/nvidia/nvjitlink/lib"
 
-RUN mkdir -p /.cache /.venv && chown -R $UID:$GID /modelship /.cache /.venv
+RUN mkdir -p /.cache /.venv $MSHIP_PLUGIN_WHEEL_DIR && \
+    chown -R $UID:$GID /modelship /.cache /.venv $MSHIP_PLUGIN_WHEEL_DIR
 
 # =============================================================================
 # builder — adds build toolchain (nvcc, build-essential, dev headers, git) and
@@ -99,9 +101,9 @@ RUN mkdir -p /.cache /.venv && chown -R $UID:$GID /modelship /.cache /.venv
 # compile wheels from source (flashinfer, llama-cpp-python, etc.). All of this
 # stays in the builder stage and is NOT copied into prod.
 #
-# The venv is resolved with --extra gpu plus every plugin extra so prod doesn't
-# need network access or a compiler at runtime — scripts/start.sh's uv sync
-# just toggles which plugins are "active" via MSHIP_PLUGINS.
+# The venv is resolved with --extra gpu only (no plugin extras). Plugin
+# wheels are built separately into $MSHIP_PLUGIN_WHEEL_DIR and shipped to Ray
+# workers per-deployment via runtime_env from start.py.
 # =============================================================================
 FROM base AS builder
 
@@ -133,27 +135,36 @@ RUN uv venv
 ADD --chown=$UID:$GID ./pyproject.toml pyproject.toml
 ADD --chown=$UID:$GID ./README.md README.md
 ADD --chown=$UID:$GID ./uv.lock uv.lock
+ADD --chown=$UID:$GID ./Makefile Makefile
 ADD --chown=$UID:$GID ./plugins plugins
 
 USER modelship
 
 RUN --mount=type=cache,target=/.cache/uv,uid=$UID,gid=$GID \
-    uv sync --locked --no-install-project \
-        --extra gpu \
-        --extra kokoroonnx \
-        --extra bark \
-        --extra orpheus \
-        --extra whispercpp
+    uv sync --locked --no-install-project --extra gpu
+
+# Build plugin wheels into $MSHIP_PLUGIN_WHEEL_DIR. Plugins are NOT installed
+# into /.venv — they ship to Ray workers per-deployment via runtime_env, so the
+# prod venv stays lean.
+RUN make plugin-wheels
 
 # =============================================================================
-# dev — inherits builder (keeps toolchain) and adds dev extras.
+# dev — inherits builder (keeps toolchain) and adds dev extras PLUS plugin
+# extras so developers get editable installs for interactive REPL / pytest.
+# Prod does not inherit this stage.
 # =============================================================================
 FROM builder AS dev
 
 USER modelship
 
 RUN --mount=type=cache,target=/.cache/uv,uid=$UID,gid=$GID \
-    uv sync --locked --no-install-project --extra dev --extra gpu
+    uv sync --locked --no-install-project \
+        --extra dev \
+        --extra gpu \
+        --extra kokoroonnx \
+        --extra bark \
+        --extra orpheus \
+        --extra whispercpp
 
 ADD --chown=$UID:$GID ./scripts/start_ray.sh /modelship/scripts/start_ray.sh
 
@@ -167,6 +178,7 @@ FROM base AS prod
 
 COPY --from=builder --chown=$UID:$GID /usr/local/uv/python /usr/local/uv/python
 COPY --from=builder --chown=$UID:$GID /.venv /.venv
+COPY --from=builder --chown=$UID:$GID $MSHIP_PLUGIN_WHEEL_DIR $MSHIP_PLUGIN_WHEEL_DIR
 
 ADD --chown=$UID:$GID ./pyproject.toml pyproject.toml
 ADD --chown=$UID:$GID ./README.md README.md

--- a/Dockerfile
+++ b/Dockerfile
@@ -158,13 +158,9 @@ FROM builder AS dev
 USER modelship
 
 RUN --mount=type=cache,target=/.cache/uv,uid=$UID,gid=$GID \
-    uv sync --locked --no-install-project \
-        --extra dev \
-        --extra gpu \
-        --extra kokoroonnx \
-        --extra bark \
-        --extra orpheus \
-        --extra whispercpp
+    # Dynamically inject an --extra flag for every plugin directory
+    PLUGIN_EXTRAS=$(find plugins -mindepth 1 -maxdepth 1 -type d -exec basename {} \; | xargs -I {} echo -n "--extra {} ") && \
+    uv sync --locked --no-install-project --extra dev --extra gpu $PLUGIN_EXTRAS
 
 ADD --chown=$UID:$GID ./scripts/start_ray.sh /modelship/scripts/start_ray.sh
 

--- a/Dockerfile.cpu
+++ b/Dockerfile.cpu
@@ -46,12 +46,15 @@ ENV MSHIP_LOG_LEVEL=INFO
 ENV MSHIP_LOG_FORMAT=text
 ENV UV_PYTHON_INSTALL_DIR=/usr/local/uv/python
 ENV PATH="$UV_PROJECT_ENVIRONMENT/bin:$PATH"
+ENV MSHIP_PLUGIN_WHEEL_DIR=/opt/modelship/plugin-wheels
 
-RUN mkdir -p /.cache /.venv && chown -R $UID:$GID /modelship /.cache /.venv
+RUN mkdir -p /.cache /.venv $MSHIP_PLUGIN_WHEEL_DIR && \
+    chown -R $UID:$GID /modelship /.cache /.venv $MSHIP_PLUGIN_WHEEL_DIR
 
 # =============================================================================
-# builder — adds build toolchain, resolves /.venv with all plugin extras
-# pre-baked so runtime needs no compiler.
+# builder — adds build toolchain, resolves /.venv with --extra cpu only.
+# Plugin wheels are built separately into $MSHIP_PLUGIN_WHEEL_DIR and shipped
+# to Ray workers per-deployment via runtime_env from start.py.
 # =============================================================================
 FROM base AS builder
 
@@ -70,27 +73,36 @@ RUN uv venv
 ADD --chown=$UID:$GID ./pyproject.toml pyproject.toml
 ADD --chown=$UID:$GID ./README.md README.md
 ADD --chown=$UID:$GID ./uv.lock uv.lock
+ADD --chown=$UID:$GID ./Makefile Makefile
 ADD --chown=$UID:$GID ./plugins plugins
 
 USER modelship
 
 RUN --mount=type=cache,target=/.cache/uv,uid=$UID,gid=$GID \
-    uv sync --locked --no-install-project \
-        --extra cpu \
-        --extra kokoroonnx \
-        --extra bark \
-        --extra orpheus \
-        --extra whispercpp
+    uv sync --locked --no-install-project --extra cpu
+
+# Build plugin wheels into $MSHIP_PLUGIN_WHEEL_DIR. Plugins are NOT installed
+# into /.venv — they ship to Ray workers per-deployment via runtime_env, so the
+# prod venv stays lean.
+RUN make plugin-wheels
 
 # =============================================================================
-# dev — inherits builder (keeps toolchain) and adds dev extras.
+# dev — inherits builder (keeps toolchain) and adds dev extras PLUS plugin
+# extras so developers get editable installs for interactive REPL / pytest.
+# Prod does not inherit this stage.
 # =============================================================================
 FROM builder AS dev
 
 USER modelship
 
 RUN --mount=type=cache,target=/.cache/uv,uid=$UID,gid=$GID \
-    uv sync --locked --no-install-project --extra dev --extra cpu
+    uv sync --locked --no-install-project \
+        --extra dev \
+        --extra cpu \
+        --extra kokoroonnx \
+        --extra bark \
+        --extra orpheus \
+        --extra whispercpp
 
 ADD --chown=$UID:$GID ./scripts/start_ray.sh /modelship/scripts/start_ray.sh
 
@@ -104,6 +116,7 @@ FROM base AS prod
 
 COPY --from=builder --chown=$UID:$GID /usr/local/uv/python /usr/local/uv/python
 COPY --from=builder --chown=$UID:$GID /.venv /.venv
+COPY --from=builder --chown=$UID:$GID $MSHIP_PLUGIN_WHEEL_DIR $MSHIP_PLUGIN_WHEEL_DIR
 
 ADD --chown=$UID:$GID ./pyproject.toml pyproject.toml
 ADD --chown=$UID:$GID ./README.md README.md

--- a/Dockerfile.cpu
+++ b/Dockerfile.cpu
@@ -96,13 +96,9 @@ FROM builder AS dev
 USER modelship
 
 RUN --mount=type=cache,target=/.cache/uv,uid=$UID,gid=$GID \
-    uv sync --locked --no-install-project \
-        --extra dev \
-        --extra cpu \
-        --extra kokoroonnx \
-        --extra bark \
-        --extra orpheus \
-        --extra whispercpp
+    # Dynamically inject an --extra flag for every plugin directory
+    PLUGIN_EXTRAS=$(find plugins -mindepth 1 -maxdepth 1 -type d -exec basename {} \; | xargs -I {} echo -n "--extra {} ") && \
+    uv sync --locked --no-install-project --extra dev --extra cpu $PLUGIN_EXTRAS
 
 ADD --chown=$UID:$GID ./scripts/start_ray.sh /modelship/scripts/start_ray.sh
 

--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ PLUGIN_SOURCES = $(shell find plugins/$(1) -type f -not -path '*/.*' -not -path 
 .SECONDEXPANSION:
 $(PLUGIN_STAMP_DIR)/%.stamp: $$(call PLUGIN_SOURCES,%)
 	@mkdir -p $(MSHIP_PLUGIN_WHEEL_DIR) $(PLUGIN_STAMP_DIR)
-	@rm -f $(MSHIP_PLUGIN_WHEEL_DIR)/$*-*.whl
+	@rm -f $(MSHIP_PLUGIN_WHEEL_DIR)/$(subst -,_,$*)-*.whl
 	uv build --package $* --wheel --out-dir $(MSHIP_PLUGIN_WHEEL_DIR)
 	@touch $@
 

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,11 @@ MAJOR   := $(shell echo $(VERSION) | cut -d. -f1)
 MINOR   := $(shell echo $(VERSION) | cut -d. -f2)
 PATCH   := $(shell echo $(VERSION) | cut -d. -f3)
 
-.PHONY: test lint lint-fix release-patch release-minor release-major _release
+MSHIP_PLUGIN_WHEEL_DIR ?= .build/plugin-wheels
+PLUGIN_STAMP_DIR := .build/plugin-stamps
+PLUGINS          := $(notdir $(wildcard plugins/*))
+
+.PHONY: test lint lint-fix release-patch release-minor release-major _release plugin-wheels plugin-wheels-clean
 
 test:
 	uv run pytest tests/ -v
@@ -16,6 +20,26 @@ lint:
 lint-fix:
 	uv run ruff check --fix .
 	uv run ruff format .
+
+# Per-plugin source-tracked wheel build. Each plugin gets a stamp file whose
+# prereqs are every file under its source tree; changing a source invalidates
+# only that plugin's stamp, so subsequent `make plugin-wheels` runs are
+# incremental. Stale wheels for the same plugin are purged before each build
+# to keep a single wheel per plugin in the output dir (simplifies lookup from
+# start.py, which globs for <name>-*.whl).
+plugin-wheels: $(foreach p,$(PLUGINS),$(PLUGIN_STAMP_DIR)/$(p).stamp)
+
+PLUGIN_SOURCES = $(shell find plugins/$(1) -type f -not -path '*/.*' -not -path '*/__pycache__/*' 2>/dev/null)
+
+.SECONDEXPANSION:
+$(PLUGIN_STAMP_DIR)/%.stamp: $$(call PLUGIN_SOURCES,%)
+	@mkdir -p $(MSHIP_PLUGIN_WHEEL_DIR) $(PLUGIN_STAMP_DIR)
+	@rm -f $(MSHIP_PLUGIN_WHEEL_DIR)/$*-*.whl
+	uv build --package $* --wheel --out-dir $(MSHIP_PLUGIN_WHEEL_DIR)
+	@touch $@
+
+plugin-wheels-clean:
+	rm -rf $(MSHIP_PLUGIN_WHEEL_DIR) $(PLUGIN_STAMP_DIR)
 
 release-patch:
 	$(eval NEW_VERSION := $(MAJOR).$(MINOR).$(shell echo $$(($(PATCH)+1))))

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ PATCH   := $(shell echo $(VERSION) | cut -d. -f3)
 
 MSHIP_PLUGIN_WHEEL_DIR ?= .build/plugin-wheels
 PLUGIN_STAMP_DIR := .build/plugin-stamps
-PLUGINS          := $(notdir $(wildcard plugins/*))
+PLUGINS          := $(notdir $(patsubst %/,%,$(wildcard plugins/*/)))
 
 .PHONY: test lint lint-fix release-patch release-minor release-major _release plugin-wheels plugin-wheels-clean
 

--- a/README.md
+++ b/README.md
@@ -170,18 +170,14 @@ Built-in plugins:
 - [Orpheus](plugins/orpheus/README.md) — expressive TTS
 - [whisper.cpp](plugins/whispercpp/README.md) — CPU-only STT via `pywhispercpp`
 
-To enable plugins, pass them as extras at sync time:
+To enable plugins for local development, pass them as extras at sync time:
 
 ```bash
 uv sync --extra kokoroonnx
 uv sync --extra kokoroonnx --extra whispercpp  # multiple plugins
 ```
 
-When using Docker, set the `MSHIP_PLUGINS` environment variable:
-
-```
-MSHIP_PLUGINS=kokoroonnx,whispercpp
-```
+For deployment, plugins are automatically loaded from wheels via Ray's `runtime_env` when referenced in `models.yaml`.
 
 For a full guide on writing your own plugin, see [Plugin Development](docs/plugins.md).
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -54,7 +54,7 @@ Custom backends are isolated `uv` workspace packages under `plugins/`. Each plug
 
 - Implements `BasePlugin` and overrides the `create_*` method(s) matching its `usecase` (e.g. `create_speech` for TTS, `create_transcription` for STT)
 - Has its own dependencies, isolated from the main project
-- Is opt-in via `uv sync --extra <plugin>` or the `MSHIP_PLUGINS` env var
+- Is automatically loaded from wheels via Ray's `runtime_env` when referenced in `models.yaml`
 - Returns raw, protocol-agnostic outputs; OpenAI-shape adaptation is handled by the serving wrappers in `modelship/infer/custom/openai/`
 
 See [Plugin Development](plugins.md) for details.

--- a/docs/development.md
+++ b/docs/development.md
@@ -14,7 +14,6 @@ The recommended way to develop Modelship is with VS Code Dev Containers. The con
 
    ```bash
    export HF_TOKEN=your_token_here
-   export MSHIP_PLUGINS=kokoroonnx  # optional — comma-separated list of plugins to install
    ```
 
 2. Open the repo in VS Code and run **Dev Containers: Reopen in Container** from the command palette (`Ctrl+Shift+P` / `Cmd+Shift+P`).
@@ -94,7 +93,6 @@ The dev image does not bake in source files. Mount the repo root so changes take
 ```bash
 docker run -it --rm --shm-size=8g --gpus all \
   -e HF_TOKEN=your_token_here \
-  -e MSHIP_PLUGINS=kokoroonnx \
   -e RAY_HEAD_GPU_NUM=1 \
   --mount type=bind,src=./,dst=/modelship \
   -v ./models-cache:/.cache \
@@ -111,7 +109,7 @@ docker run -it --rm --shm-size=8g \
   -p 8000:8000 modelship_dev_cpu
 ```
 
-The container's entrypoint (`start.sh`) automatically syncs dependencies (including any plugins listed in `MSHIP_PLUGINS`), starts the Ray head node, and drops into a shell. Then start the server:
+The container's entrypoint (`start.sh`) automatically syncs dependencies, starts the Ray head node, and drops into a shell. Then start the server:
 
 ```bash
 uv run start.py

--- a/docs/model-configuration.md
+++ b/docs/model-configuration.md
@@ -68,7 +68,7 @@ python start.py --config config/tts.yaml --gateway-name "tts-api"
 | `model` | string | HuggingFace model ID |
 | `usecase` | string | `generate`, `embed`, `transcription`, `translation`, `tts`, or `image` |
 | `loader` | string | `vllm`, `transformers`, `diffusers`, `llama_cpp`, or `custom` |
-| `plugin` | string | Plugin module name (required when `loader: custom`); must be installed via `uv sync --extra <plugin>` |
+| `plugin` | string | Plugin module name (required when `loader: custom`); automatically loaded from wheels when referenced |
 | `num_gpus` | float | Fraction of a GPU to allocate (0.0-1.0); also sets vLLM `gpu_memory_utilization` |
 | `num_cpus` | float | CPU units to allocate (default `0.1`) |
 | `num_replicas` | int | Number of identical Ray Serve replicas for this deployment (default `1`) |
@@ -343,7 +343,6 @@ In this example, requests to model `kokoro` are distributed across three backend
 | Variable | Description | Default |
 |---|---|---|
 | `HF_TOKEN` | HuggingFace access token | — |
-| `MSHIP_PLUGINS` | Comma-separated list of plugins to install at startup (e.g. `kokoroonnx,whispercpp`) | — |
 | `MSHIP_CACHE_DIR` | Model cache directory (HuggingFace + plugins) | `/.cache` |
 | `MSHIP_GATEWAY_NAME` | Name for the API gateway app | `modelship api` |
 | `MSHIP_MAX_REQUEST_BODY_BYTES` | Maximum allowed request body size in bytes | `52428800` (50 MB) |

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -44,8 +44,7 @@ name = "myplugin"
 version = "0.1.0"
 requires-python = "==3.12.10"
 dependencies = [
-    "modelship",
-    # your plugin's dependencies
+    # only packages unique to your plugin — see "Dependency contract" below
 ]
 
 [build-system]
@@ -59,6 +58,14 @@ modelship = { workspace = true }
 module-name = "myplugin"
 module-root = ""
 ```
+
+#### Dependency contract
+
+Plugins assume the host environment provides `modelship` itself plus the full core/gpu/cpu stack: `torch`, `torchvision`, `transformers`, `sentence-transformers`, `numpy`, `scipy`, `librosa`, `soundfile`, `llama-cpp-python`, `onnxruntime[-gpu]`, `diffusers`, `accelerate`, `vllm`. **Do not redeclare any of these in your plugin's `dependencies`.**
+
+Why: plugin wheels are shipped to Ray workers via `runtime_env`, which installs them into a per-job venv layered over a base image that already has the core stack baked in. Redeclaring `modelship` or `torch` causes pip to either pull a second copy from PyPI (version drift, two packages on `sys.path`) or error on the layered install.
+
+Declare only what's unique to your plugin — e.g. `kokoro-onnx`, `pywhispercpp`, `snac`. Dev-time imports of `modelship.*` resolve because the workspace's shared `.venv` always has the root `modelship` package installed; you don't need to declare it to get IDE/pyright support.
 
 ### 3. Implement `ModelPlugin`
 
@@ -177,7 +184,7 @@ async def _stream(self, input, voice, speed):
 
 Every plugin must include a `README.md` in its package root (`plugins/myplugin/README.md`). This is the primary documentation for users configuring the plugin. It should cover:
 
-- **Installation** — how to install the plugin (`uv sync --extra` and `MSHIP_PLUGINS`)
+- **Installation** — how to install the plugin (`uv sync --extra` for local development; automatic via wheels for deployment)
 - **Configuration** — example `models.yaml` entry with all `plugin_config` options documented in a table
 - **Voices / options** — any model-specific choices (voice presets, providers, etc.)
 - **Example request** — a working `curl` command

--- a/plugins/bark/pyproject.toml
+++ b/plugins/bark/pyproject.toml
@@ -3,13 +3,7 @@ name = "bark"
 version = "0.1.0"
 description = "Bark TTS plugin for Modelship"
 requires-python = "==3.12.10"
-dependencies = [
-    "modelship",
-    "transformers>=4.57.5",
-    "torch>=2.10.0",
-    "scipy>=1.16.1",
-    "numpy>=2.2.6",
-]
+dependencies = []
 
 [build-system]
 requires = ["uv_build"]

--- a/plugins/kokoroonnx/kokoroonnx/kokoroonnx.py
+++ b/plugins/kokoroonnx/kokoroonnx/kokoroonnx.py
@@ -22,13 +22,16 @@ Example request:
       --output speech.wav
 """
 
+import ctypes.util
 import os
 import shutil
 from collections.abc import AsyncGenerator
+from pathlib import Path
 
 import numpy as np
-import onnxruntime as ort  # type: ignore[import-unresolved]
+import onnxruntime as ort
 from kokoro_onnx import Kokoro  # type: ignore[import-unresolved]
+from kokoro_onnx.config import EspeakConfig  # type: ignore[import-unresolved]
 
 from modelship.infer.infer_config import ModelshipModelConfig
 from modelship.logging import get_logger
@@ -36,6 +39,28 @@ from modelship.openai.protocol import ErrorResponse, RawSpeechResponse
 from modelship.plugins.base_plugin import BasePlugin
 from modelship.utils import download, plugins_dir
 from modelship.utils.audio import resample, to_pcm16, to_wav
+
+
+def _resolve_system_espeak() -> EspeakConfig | None:
+    """Locate the system-installed espeak-ng library + data.
+
+    espeakng-loader bundles a library with a CI-runner data path baked in that
+    SIGSEGVs at runtime; prefer the apt-installed espeak-ng when present. Falls
+    back to espeakng-loader's bundled copy if the system install is missing.
+    """
+    lib = ctypes.util.find_library("espeak-ng") or ctypes.util.find_library("espeak")
+    if not lib:
+        return None
+    # Typical Debian/Ubuntu layout: lib in /usr/lib/<triple>/, data next to it.
+    for candidate in (
+        "/usr/lib/x86_64-linux-gnu/espeak-ng-data",
+        "/usr/lib/aarch64-linux-gnu/espeak-ng-data",
+        "/usr/share/espeak-ng-data",
+    ):
+        if Path(candidate, "phontab").is_file():
+            return EspeakConfig(lib_path=lib, data_path=candidate)
+    return None
+
 
 logger = get_logger("plugin.kokoroonnx")
 
@@ -68,7 +93,12 @@ class ModelPlugin(BasePlugin):
         onnx_provider = (model_config.plugin_config or {}).get("onnx_provider", "CUDAExecutionProvider")
         os.environ["ONNX_PROVIDER"] = onnx_provider
         logger.info("ONNX_PROVIDER=%s", onnx_provider)
-        self.kokoro = Kokoro(model_path, voices_path)
+        espeak_config = _resolve_system_espeak()
+        if espeak_config:
+            logger.info("using system espeak-ng: lib=%s data=%s", espeak_config.lib_path, espeak_config.data_path)
+        else:
+            logger.warning("system espeak-ng not found; falling back to bundled espeakng-loader (may crash)")
+        self.kokoro = Kokoro(model_path, voices_path, espeak_config=espeak_config)
         logger.info("kokoro session providers: %s", self.kokoro.sess.get_providers())
         self.target_sample_rate: int | None = (model_config.plugin_config or {}).get("sample_rate")
 

--- a/plugins/kokoroonnx/pyproject.toml
+++ b/plugins/kokoroonnx/pyproject.toml
@@ -4,10 +4,7 @@ version = "0.1.0"
 description = "Kokoro ONNX TTS plugin for Modelship"
 requires-python = "==3.12.10"
 dependencies = [
-    "modelship",
     "kokoro-onnx>=0.4.9",
-    "numpy>=2.2.6",
-    "scipy>=1.16.1",
 ]
 
 [build-system]

--- a/plugins/orpheus/pyproject.toml
+++ b/plugins/orpheus/pyproject.toml
@@ -4,10 +4,7 @@ version = "0.1.0"
 description = "Orpheus TTS plugin for Modelship"
 requires-python = "==3.12.10"
 dependencies = [
-    "modelship",
-    "snac",
-    "transformers>=4.57.5",
-    "numpy>=2.2.6",
+    "snac>=1.2.1",
 ]
 
 [build-system]
@@ -20,3 +17,6 @@ modelship = { workspace = true }
 [tool.uv.build-backend]
 module-name = "orpheus"
 module-root = ""
+
+[tool.modelship]
+supports = ["gpu"]

--- a/plugins/whispercpp/pyproject.toml
+++ b/plugins/whispercpp/pyproject.toml
@@ -4,7 +4,6 @@ version = "0.1.0"
 description = "whisper.cpp STT plugin for Modelship (via pywhispercpp)"
 requires-python = "==3.12.10"
 dependencies = [
-    "modelship",
     "pywhispercpp>=1.3.0",
 ]
 

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -1,29 +1,8 @@
 #!/bin/bash
 set -e
 
-# When MSHIP_SKIP_SYNC=true (the default in prebuilt images where the venv is
-# already fully resolved by the builder stage), skip the runtime `uv sync`.
-# This keeps startup fast AND preserves every pre-baked plugin, so users can
-# reference any plugin in models.yaml without having to set MSHIP_PLUGINS.
-# Set MSHIP_SKIP_SYNC=false to force a re-sync (useful when running from a
-# bind-mounted source tree during development or when adding a plugin extra
-# on a non-prebuilt image).
-if [ "${MSHIP_SKIP_SYNC:-true}" != "true" ]; then
-    EXTRAS=""
-    if [ -n "${MSHIP_PLUGINS}" ]; then
-        for plugin in $(echo "${MSHIP_PLUGINS}" | tr ',' ' '); do
-            EXTRAS="$EXTRAS --extra $plugin"
-        done
-    fi
-
-    # Detect if we should use GPU based on RAY_HEAD_GPU_NUM
-    if [ "${RAY_HEAD_GPU_NUM:-0}" -gt 0 ]; then
-        EXTRAS="$EXTRAS --extra gpu"
-    else
-        EXTRAS="$EXTRAS --extra cpu"
-    fi
-
-    uv sync --project /modelship --locked $EXTRAS
+if [ -n "${MSHIP_PLUGINS}" ]; then
+    echo "warning: MSHIP_PLUGINS is deprecated and ignored; plugins referenced in models.yaml are loaded from ${MSHIP_PLUGIN_WHEEL_DIR:-<unset>} via Ray runtime_env." >&2
 fi
 
 if [ "${MSHIP_USE_EXISTING_RAY_CLUSTER}" != "true" ]; then

--- a/start.py
+++ b/start.py
@@ -194,10 +194,11 @@ def _plugin_wheel_dir() -> Path:
 
 def resolve_plugin_wheel(plugin: str) -> Path:
     wheel_dir = _plugin_wheel_dir()
-    wheels = sorted(wheel_dir.glob(f"{plugin}-*.whl"))
+    normalized_name = plugin.replace("-", "_")
+    wheels = sorted(wheel_dir.glob(f"{normalized_name}-*.whl"))
     if not wheels:
         raise RuntimeError(
-            f"No wheel found for plugin '{plugin}' in {wheel_dir}. "
+            f"No wheel found for plugin '{plugin}' (normalized: '{normalized_name}') in {wheel_dir}. "
             f"Build wheels with `make plugin-wheels` (or rebuild the Docker image), "
             f"or set MSHIP_PLUGIN_WHEEL_DIR to the directory containing them."
         )

--- a/start.py
+++ b/start.py
@@ -1,5 +1,4 @@
 import argparse
-import importlib
 import os
 import random
 import signal
@@ -7,6 +6,15 @@ import socket
 import string
 import sys
 import time
+from pathlib import Path
+
+# Must be set BEFORE `import ray`: ray_constants.RAY_ENABLE_UV_RUN_RUNTIME_ENV
+# is a module-level constant, evaluated at ray's import time. Leaving it on
+# makes Ray auto-inject `py_executable="uv run --python X"` whenever the driver
+# runs under `uv run`, which overrides the per-job virtualenv that
+# runtime_env.pip creates for plugin wheels — breaking plugin imports in the
+# worker. Keep the uv hook off so runtime_env.pip's py_executable survives.
+os.environ.setdefault("RAY_ENABLE_UV_RUN_RUNTIME_ENV", "false")
 
 import ray
 from pydantic_yaml import parse_yaml_raw_as
@@ -120,7 +128,7 @@ def _apply_args_to_env(args: argparse.Namespace) -> None:
         os.environ["MSHIP_OPENAI_API_PORT"] = str(args.openai_api_port)
 
 
-def build_actor_options(config: ModelshipModelConfig) -> dict:
+def build_actor_options(config: ModelshipModelConfig, plugin_wheel: Path | None = None) -> dict:
     env_vars = _build_cache_env_vars()
     for log_var in ("MSHIP_LOG_LEVEL", "MSHIP_LOG_FORMAT", "MSHIP_LOG_TARGET"):
         val = os.environ.get(log_var)
@@ -166,18 +174,37 @@ def build_actor_options(config: ModelshipModelConfig) -> dict:
         else:
             num_gpus = config.num_gpus
 
+    runtime_env: dict = {"env_vars": env_vars}
+    if plugin_wheel is not None:
+        # Ship the plugin to the Ray worker via runtime_env. Ray content-hashes
+        # and caches the resulting per-job venv, so repeat deploys of the same
+        # wheel reuse the install.
+        runtime_env["pip"] = [str(plugin_wheel)]
+
     return {
         "num_gpus": num_gpus,
         "num_cpus": config.num_cpus,
-        "runtime_env": {"env_vars": env_vars},
+        "runtime_env": runtime_env,
     }
 
 
-def ensure_plugin(module_name: str):
-    try:
-        importlib.import_module(module_name)
-    except ImportError as err:
-        raise RuntimeError(f"Plugin '{module_name}' is not installed. Run: uv sync --extra {module_name}") from err
+def _plugin_wheel_dir() -> Path:
+    return Path(os.environ.get("MSHIP_PLUGIN_WHEEL_DIR", ".build/plugin-wheels"))
+
+
+def resolve_plugin_wheel(plugin: str) -> Path:
+    wheel_dir = _plugin_wheel_dir()
+    wheels = sorted(wheel_dir.glob(f"{plugin}-*.whl"))
+    if not wheels:
+        raise RuntimeError(
+            f"No wheel found for plugin '{plugin}' in {wheel_dir}. "
+            f"Build wheels with `make plugin-wheels` (or rebuild the Docker image), "
+            f"or set MSHIP_PLUGIN_WHEEL_DIR to the directory containing them."
+        )
+    # Absolute path required: Ray workers run with a different cwd
+    # (/tmp/ray/session_*/runtime_resources/.../exec_cwd), so a relative wheel
+    # path in runtime_env.pip would fail to resolve on the worker.
+    return wheels[-1].resolve()
 
 
 def _make_operator_id() -> str:
@@ -247,9 +274,12 @@ def main(argv: list[str] | None = None):
 
     logger.info("Init modelship app with config: %s", yml_conf)
 
+    # Pre-flight: resolve every referenced plugin wheel up front so a missing
+    # wheel fails the whole startup before any Ray deploy is attempted.
+    plugin_wheels: dict[str, Path] = {}
     for config in yml_conf.models:
-        if config.loader == ModelLoader.custom and config.plugin:
-            ensure_plugin(config.plugin)
+        if config.loader == ModelLoader.custom and config.plugin and config.plugin not in plugin_wheels:
+            plugin_wheels[config.plugin] = resolve_plugin_wheel(config.plugin)
 
     # Schedule TP>1 models first so they claim whole GPU units before fractional
     # models consume the pool.
@@ -322,7 +352,8 @@ def main(argv: list[str] | None = None):
             made_progress = False
 
             for config in list(remaining):
-                actor_opts = build_actor_options(config)
+                wheel = plugin_wheels.get(config.plugin) if config.plugin else None
+                actor_opts = build_actor_options(config, plugin_wheel=wheel)
                 deployment_name = f"{config.name}-{_rand_suffix()}"
 
                 reserved, _reason = ray.get(

--- a/tests/test_start.py
+++ b/tests/test_start.py
@@ -1,6 +1,12 @@
 """Tests for start.py CLI argument parsing and helpers."""
 
-from start import _rand_suffix, parse_args
+import os
+from pathlib import Path
+from unittest.mock import patch
+
+from start import _rand_suffix, build_actor_options, parse_args, resolve_plugin_wheel
+
+from modelship.infer.infer_config import ModelLoader, ModelshipModelConfig, ModelUsecase
 
 
 class TestParseArgs:
@@ -61,3 +67,68 @@ class TestRandSuffix:
         for _ in range(50):
             suffix = _rand_suffix()
             assert all(c.islower() or c.isdigit() for c in suffix)
+
+
+class TestBuildActorOptions:
+    def test_basic_options(self):
+        config = ModelshipModelConfig(
+            name="test-model",
+            model="some-model",
+            usecase=ModelUsecase.generate,
+            loader=ModelLoader.vllm,
+            num_gpus=1,
+            num_cpus=2,
+        )
+        opts = build_actor_options(config)
+        assert opts["num_gpus"] == 1
+        assert opts["num_cpus"] == 2
+        assert "env_vars" in opts["runtime_env"]
+        assert "pip" not in opts["runtime_env"]
+
+    def test_with_plugin_wheel(self):
+        config = ModelshipModelConfig(
+            name="test-model",
+            model="some-model",
+            usecase=ModelUsecase.generate,
+            loader=ModelLoader.custom,
+            plugin="myplugin",
+        )
+        wheel_path = Path("/tmp/myplugin-0.1.0-py3-none-any.whl")
+        opts = build_actor_options(config, plugin_wheel=wheel_path)
+        assert opts["runtime_env"]["pip"] == [str(wheel_path)]
+
+    def test_llama_cpp_force_cpu(self):
+        config = ModelshipModelConfig(
+            name="test-model",
+            model="some-model",
+            usecase=ModelUsecase.generate,
+            loader=ModelLoader.llama_cpp,
+            num_gpus=1,
+        )
+        opts = build_actor_options(config)
+        assert opts["num_gpus"] == 0
+
+
+class TestResolvePluginWheel:
+    def test_resolves_latest_wheel(self, tmp_path):
+        wheel_dir = tmp_path / "wheels"
+        wheel_dir.mkdir()
+        (wheel_dir / "myplugin-0.1.0-py3-none-any.whl").touch()
+        (wheel_dir / "myplugin-0.1.1-py3-none-any.whl").touch()
+
+        with patch.dict(os.environ, {"MSHIP_PLUGIN_WHEEL_DIR": str(wheel_dir)}):
+            wheel = resolve_plugin_wheel("myplugin")
+            assert wheel.name == "myplugin-0.1.1-py3-none-any.whl"
+            assert wheel.is_absolute()
+
+    def test_raises_if_no_wheel(self, tmp_path):
+        import pytest
+
+        wheel_dir = tmp_path / "wheels"
+        wheel_dir.mkdir()
+
+        with (
+            patch.dict(os.environ, {"MSHIP_PLUGIN_WHEEL_DIR": str(wheel_dir)}),
+            pytest.raises(RuntimeError, match="No wheel found for plugin 'myplugin'"),
+        ):
+            resolve_plugin_wheel("myplugin")

--- a/uv.lock
+++ b/uv.lock
@@ -254,25 +254,6 @@ wheels = [
 name = "bark"
 version = "0.1.0"
 source = { editable = "plugins/bark" }
-dependencies = [
-    { name = "modelship" },
-    { name = "numpy" },
-    { name = "scipy" },
-    { name = "torch", version = "2.10.0+cu128", source = { registry = "https://download.pytorch.org/whl/cu128" }, marker = "extra == 'extra-9-modelship-gpu'" },
-    { name = "torch", version = "2.11.0", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "(sys_platform == 'darwin' and extra == 'extra-9-modelship-cpu') or (extra == 'extra-9-modelship-cpu' and extra == 'extra-9-modelship-gpu')" },
-    { name = "torch", version = "2.11.0", source = { registry = "https://pypi.org/simple" }, marker = "(extra == 'extra-9-modelship-cpu' and extra == 'extra-9-modelship-gpu') or (extra != 'extra-9-modelship-cpu' and extra != 'extra-9-modelship-gpu')" },
-    { name = "torch", version = "2.11.0+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "(sys_platform != 'darwin' and extra == 'extra-9-modelship-cpu') or (extra == 'extra-9-modelship-cpu' and extra == 'extra-9-modelship-gpu')" },
-    { name = "transformers" },
-]
-
-[package.metadata]
-requires-dist = [
-    { name = "modelship", editable = "." },
-    { name = "numpy", specifier = ">=2.2.6" },
-    { name = "scipy", specifier = ">=1.16.1" },
-    { name = "torch", specifier = ">=2.10.0" },
-    { name = "transformers", specifier = ">=4.57.5" },
-]
 
 [[package]]
 name = "blake3"
@@ -1269,18 +1250,10 @@ version = "0.1.0"
 source = { editable = "plugins/kokoroonnx" }
 dependencies = [
     { name = "kokoro-onnx" },
-    { name = "modelship" },
-    { name = "numpy" },
-    { name = "scipy" },
 ]
 
 [package.metadata]
-requires-dist = [
-    { name = "kokoro-onnx", specifier = ">=0.4.9" },
-    { name = "modelship", editable = "." },
-    { name = "numpy", specifier = ">=2.2.6" },
-    { name = "scipy", specifier = ">=1.16.1" },
-]
+requires-dist = [{ name = "kokoro-onnx", specifier = ">=0.4.9" }]
 
 [[package]]
 name = "language-tags"
@@ -2405,19 +2378,11 @@ name = "orpheus"
 version = "0.1.0"
 source = { editable = "plugins/orpheus" }
 dependencies = [
-    { name = "modelship" },
-    { name = "numpy" },
     { name = "snac" },
-    { name = "transformers" },
 ]
 
 [package.metadata]
-requires-dist = [
-    { name = "modelship", editable = "." },
-    { name = "numpy", specifier = ">=2.2.6" },
-    { name = "snac" },
-    { name = "transformers", specifier = ">=4.57.5" },
-]
+requires-dist = [{ name = "snac", specifier = ">=1.2.1" }]
 
 [[package]]
 name = "outlines-core"
@@ -4183,15 +4148,11 @@ name = "whispercpp"
 version = "0.1.0"
 source = { editable = "plugins/whispercpp" }
 dependencies = [
-    { name = "modelship" },
     { name = "pywhispercpp" },
 ]
 
 [package.metadata]
-requires-dist = [
-    { name = "modelship", editable = "." },
-    { name = "pywhispercpp", specifier = ">=1.3.0" },
-]
+requires-dist = [{ name = "pywhispercpp", specifier = ">=1.3.0" }]
 
 [[package]]
 name = "win32-setctime"


### PR DESCRIPTION
Refactors the plugin architecture to move from a monolithic pre-baked environment to a dynamic, wheel-based deployment system using Ray's runtime_env.

- Build standalone plugin wheels via `make plugin-wheels`.
- Inject plugin wheels dynamically into Ray workers at deployment.
- Simplify plugin dependencies by removing core packages.
- Deprecate MSHIP_PLUGINS in favor of automatic resolution from models.yaml.
- Add system espeak-ng resolver to kokoroonnx for improved stability.
- Update documentation and tests to reflect the new architecture.


