### PR TITLE
feat: make Ray CPU/GPU allocation auto-detect by default

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -73,7 +73,6 @@ ENV MSHIP_CACHE_DIR=/.cache
 ENV UV_CACHE_DIR=${MSHIP_CACHE_DIR}/uv
 ENV RAY_REDIS_PORT=6379
 ENV RAY_CLUSTER_ADDRESS=0.0.0.0
-ENV RAY_HEAD_CPU_NUM=2
 ENV MSHIP_USE_EXISTING_RAY_CLUSTER=false
 ENV MSHIP_METRICS=true
 ENV RAY_METRICS_EXPORT_PORT=8079
@@ -82,11 +81,6 @@ ENV MSHIP_LOG_FORMAT=text
 ENV UV_PYTHON_INSTALL_DIR=/usr/local/uv/python
 ENV PATH="$UV_PROJECT_ENVIRONMENT/bin:$PATH"
 ENV MSHIP_PLUGIN_WHEEL_DIR=/opt/modelship/plugin-wheels
-
-# Set default RAY_HEAD_GPU_NUM based on variant
-ENV RAY_HEAD_GPU_NUM=${MSHIP_VARIANT#cpu}
-ENV RAY_HEAD_GPU_NUM=${RAY_HEAD_GPU_NUM:+1}
-ENV RAY_HEAD_GPU_NUM=${RAY_HEAD_GPU_NUM:-0}
 
 # onnxruntime-gpu (pulled in by the kokoroonnx plugin) dlopen()s
 # libonnxruntime_providers_cuda.so which has plain DT_NEEDED entries for

--- a/README.md
+++ b/README.md
@@ -150,7 +150,6 @@ For high-throughput GPU inference, use the standard image and add `--gpus all`. 
 ```bash
 docker run --rm --shm-size=8g --gpus all \
   -e HF_TOKEN=your_token_here \
-  -e RAY_HEAD_GPU_NUM=1 \
   -v ./models.yaml:/modelship/config/models.yaml \
   -v ./models-cache:/.cache \
   -p 8000:8000 \

--- a/docs/development.md
+++ b/docs/development.md
@@ -18,18 +18,16 @@ The recommended way to develop Modelship is with VS Code Dev Containers. The con
 
 2. Open the repo in VS Code and run **Dev Containers: Reopen in Container** from the command palette (`Ctrl+Shift+P` / `Cmd+Shift+P`).
 
-3. Once inside the container, sync dependencies and start the Ray head node:
+3. Once inside the container, sync dependencies and start the Ray head node. By default, Ray will auto-detect the available CPUs and GPUs. You can restrict its usage by passing `--num-cpus` and `--num-gpus`.
 
    ```bash
    # Sync project deps (add --extra <plugin> for each plugin you need)
    uv sync --extra dev
 
-   # Start the Ray head node
+   # Start the Ray head node (auto-detects resources by default)
    ray start --head \
      --port=${RAY_REDIS_PORT} \
      --dashboard-host=0.0.0.0 \
-     --num-cpus=${RAY_HEAD_CPU_NUM} \
-     --num-gpus=${RAY_HEAD_GPU_NUM} \
      --disable-usage-stats
    ```
 
@@ -56,8 +54,8 @@ The following environment variables are set in the dev image with sensible defau
 |---|---|---|
 | `RAY_REDIS_PORT` | `6379` | Ray GCS port |
 | `RAY_CLUSTER_ADDRESS` | `ray://0.0.0.0` | Ray cluster address |
-| `RAY_HEAD_CPU_NUM` | `2` | CPUs allocated to Ray head |
-| `RAY_HEAD_GPU_NUM` | `1` | GPUs allocated to Ray head (set to `0` for CPU-only development) |
+| `RAY_HEAD_CPU_NUM` | *(unset)* | **Optional override:** CPUs allocated to Ray head. If unset, Ray auto-detects. |
+| `RAY_HEAD_GPU_NUM` | *(unset)* | **Optional override:** GPUs allocated to Ray head. If unset, Ray auto-detects. |
 | `MSHIP_CACHE_DIR` | `/.cache` | Model cache directory |
 | `MSHIP_USE_EXISTING_RAY_CLUSTER` | `false` | Set to `true` to skip starting a Ray head node |
 
@@ -93,7 +91,6 @@ The dev image does not bake in source files. Mount the repo root so changes take
 ```bash
 docker run -it --rm --shm-size=8g --gpus all \
   -e HF_TOKEN=your_token_here \
-  -e RAY_HEAD_GPU_NUM=1 \
   --mount type=bind,src=./,dst=/modelship \
   -v ./models-cache:/.cache \
   -p 8000:8000 modelship_dev
@@ -103,13 +100,12 @@ docker run -it --rm --shm-size=8g --gpus all \
 ```bash
 docker run -it --rm --shm-size=8g \
   -e HF_TOKEN=your_token_here \
-  -e RAY_HEAD_GPU_NUM=0 \
   --mount type=bind,src=./,dst=/modelship \
   -v ./models-cache:/.cache \
   -p 8000:8000 modelship_dev_cpu
 ```
 
-The container's entrypoint (`start.sh`) automatically syncs dependencies, starts the Ray head node, and drops into a shell. Then start the server:
+The container's entrypoint (`start.sh`) automatically starts the Ray head node (auto-detecting resources) and drops into a shell. Then start the server:
 
 ```bash
 uv run start.py

--- a/docs/model-configuration.md
+++ b/docs/model-configuration.md
@@ -351,8 +351,8 @@ In this example, requests to model `kokoro` are distributed across three backend
 | `CUDA_DEVICE_ORDER` | GPU enumeration order; set to `PCI_BUS_ID` for deterministic ordering in multi-GPU systems | `PCI_BUS_ID` |
 | `RAY_REDIS_PORT` | Ray GCS server port | `6379` |
 | `RAY_DASHBOARD_PORT` | Ray dashboard port | `8265` |
-| `RAY_HEAD_CPU_NUM` | CPUs allocated to Ray head | `2` |
-| `RAY_HEAD_GPU_NUM` | GPUs allocated to Ray head | `2` |
+| `RAY_HEAD_CPU_NUM` | Optional override: CPUs allocated to Ray head | — |
+| `RAY_HEAD_GPU_NUM` | Optional override: GPUs allocated to Ray head | — |
 | `RAY_OBJECT_STORE_SHM_SIZE` | Shared memory for Ray object store | `8g` |
 | `VLLM_USE_V1` | Use vLLM v1 API | `1` |
 | `ONNX_PROVIDER` | ONNX Runtime execution provider | `CUDAExecutionProvider` |

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -6,7 +6,14 @@ if [ -n "${MSHIP_PLUGINS}" ]; then
 fi
 
 if [ "${MSHIP_USE_EXISTING_RAY_CLUSTER}" != "true" ]; then
-    /modelship/scripts/start_ray.sh --num-cpus "${RAY_HEAD_CPU_NUM}" --num-gpus "${RAY_HEAD_GPU_NUM}"
+    RAY_ARGS=""
+    if [ -n "${RAY_HEAD_CPU_NUM}" ]; then
+        RAY_ARGS="${RAY_ARGS} --num-cpus ${RAY_HEAD_CPU_NUM}"
+    fi
+    if [ -n "${RAY_HEAD_GPU_NUM}" ]; then
+        RAY_ARGS="${RAY_ARGS} --num-gpus ${RAY_HEAD_GPU_NUM}"
+    fi
+    /modelship/scripts/start_ray.sh ${RAY_ARGS}
 fi
 
 cd /modelship && uv run --no-sync start.py

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -6,14 +6,14 @@ if [ -n "${MSHIP_PLUGINS}" ]; then
 fi
 
 if [ "${MSHIP_USE_EXISTING_RAY_CLUSTER}" != "true" ]; then
-    RAY_ARGS=""
+    RAY_ARGS=()
     if [ -n "${RAY_HEAD_CPU_NUM}" ]; then
-        RAY_ARGS="${RAY_ARGS} --num-cpus ${RAY_HEAD_CPU_NUM}"
+        RAY_ARGS+=(--num-cpus "${RAY_HEAD_CPU_NUM}")
     fi
     if [ -n "${RAY_HEAD_GPU_NUM}" ]; then
-        RAY_ARGS="${RAY_ARGS} --num-gpus ${RAY_HEAD_GPU_NUM}"
+        RAY_ARGS+=(--num-gpus "${RAY_HEAD_GPU_NUM}")
     fi
-    /modelship/scripts/start_ray.sh ${RAY_ARGS}
+    /modelship/scripts/start_ray.sh "${RAY_ARGS[@]}"
 fi
 
 cd /modelship && uv run --no-sync start.py

--- a/scripts/start_ray.sh
+++ b/scripts/start_ray.sh
@@ -19,21 +19,21 @@ while [[ $# -gt 0 ]]; do
     esac
 done
 
-RAY_FLAGS="--head --dashboard-host=0.0.0.0 --disable-usage-stats"
+RAY_FLAGS=(--head --dashboard-host=0.0.0.0 --disable-usage-stats)
 
 if [ -n "${NUM_CPUS}" ]; then
-    RAY_FLAGS="${RAY_FLAGS} --num-cpus=${NUM_CPUS}"
+    RAY_FLAGS+=(--num-cpus="${NUM_CPUS}")
 fi
 
 if [ -n "${NUM_GPUS}" ]; then
-    RAY_FLAGS="${RAY_FLAGS} --num-gpus=${NUM_GPUS}"
+    RAY_FLAGS+=(--num-gpus="${NUM_GPUS}")
 fi
 
 if [ "${ENABLE_METRICS}" = "true" ]; then
-    RAY_FLAGS="${RAY_FLAGS} --metrics-export-port=${RAY_METRICS_EXPORT_PORT:-8079}"
+    RAY_FLAGS+=(--metrics-export-port="${RAY_METRICS_EXPORT_PORT:-8079}")
 fi
 
-ray start ${RAY_FLAGS}
+ray start "${RAY_FLAGS[@]}"
 
 if ! ray status; then
     echo "ray cluster failed to start"

--- a/scripts/start_ray.sh
+++ b/scripts/start_ray.sh
@@ -2,11 +2,13 @@
 set -e
 
 usage() {
-    echo "Usage: start_ray.sh --num-cpus <n> --num-gpus <n> [--enable-metrics <true|false>]"
+    echo "Usage: start_ray.sh [--num-cpus <n>] [--num-gpus <n>] [--enable-metrics <true|false>]"
     exit 1
 }
 
 ENABLE_METRICS="true"
+NUM_CPUS=""
+NUM_GPUS=""
 
 while [[ $# -gt 0 ]]; do
     case "$1" in
@@ -17,20 +19,21 @@ while [[ $# -gt 0 ]]; do
     esac
 done
 
-[ -z "${NUM_CPUS}" ] && usage
-[ -z "${NUM_GPUS}" ] && usage
+RAY_FLAGS="--head --dashboard-host=0.0.0.0 --disable-usage-stats"
 
-METRICS_FLAG=""
-if [ "${ENABLE_METRICS}" = "true" ]; then
-    METRICS_FLAG="--metrics-export-port=${RAY_METRICS_EXPORT_PORT:-8079}"
+if [ -n "${NUM_CPUS}" ]; then
+    RAY_FLAGS="${RAY_FLAGS} --num-cpus=${NUM_CPUS}"
 fi
 
-ray start --head \
-    --dashboard-host=0.0.0.0 \
-    --num-cpus="${NUM_CPUS}" \
-    --num-gpus="${NUM_GPUS}" \
-    --disable-usage-stats \
-    ${METRICS_FLAG}
+if [ -n "${NUM_GPUS}" ]; then
+    RAY_FLAGS="${RAY_FLAGS} --num-gpus=${NUM_GPUS}"
+fi
+
+if [ "${ENABLE_METRICS}" = "true" ]; then
+    RAY_FLAGS="${RAY_FLAGS} --metrics-export-port=${RAY_METRICS_EXPORT_PORT:-8079}"
+fi
+
+ray start ${RAY_FLAGS}
 
 if ! ray status; then
     echo "ray cluster failed to start"


### PR DESCRIPTION
Removes hardcoded RAY_HEAD_CPU_NUM and RAY_HEAD_GPU_NUM defaults so Ray automatically detects available resources based on the host or container cgroups.

- Updates start_ray.sh to make --num-cpus and --num-gpus optional
- Removes ENV defaults from Dockerfile
- Updates README and docs to reflect auto-detection behavior


