### PR TITLE
docs: refresh roadmap and remove stale MSHIP_PLUGINS references

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,7 +46,7 @@ Entry point is `start.py` (not a console script, not `python -m`). It:
 3. Deploys models **additively** by default (new deployments get a random suffix, e.g. `qwen-a3f9k`). Pass `--redeploy` to tear everything down first.
 4. Starts a FastAPI gateway Ray Serve app named `modelship api` (override with `--gateway-name`), listening on port `8000`.
 
-The Docker image's `CMD` (`scripts/start.sh`) auto-runs `uv sync` with the right extras based on `RAY_HEAD_GPU_NUM`, then `ray start`, then `uv run start.py`. The Dev Container overrides this, so inside a Dev Container you must run those steps manually (see `docs/development.md`).
+The Docker image's `CMD` (`scripts/start.sh`) starts the Ray head (auto-detecting CPUs/GPUs unless `RAY_HEAD_CPU_NUM` / `RAY_HEAD_GPU_NUM` are set) and runs `uv run --no-sync start.py` against the venv baked at build time (extras selected by `--build-arg MSHIP_VARIANT=gpu|cpu`). Plugin wheels under `MSHIP_PLUGIN_WHEEL_DIR` are injected per-deployment via Ray `runtime_env`, resolved automatically from `models.yaml`. The Dev Container overrides this `CMD`, so inside a Dev Container you must run those steps manually (see `docs/development.md`).
 
 ## Architecture quick map
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,7 +37,7 @@ CI mirrors `make lint` + `pytest tests/ -v`. Match it locally before pushing.
 3. Deploys models **additively** by default (each gets a random suffix like `qwen-a3f9k`). Use `--redeploy` to tear everything down first.
 4. Starts a FastAPI Ray Serve app named `modelship api` on port 8000. Override via `--gateway-name` (multiple gateways can coexist on one cluster).
 
-Docker's `scripts/start.sh` auto-runs `uv sync` (extras chosen based on `RAY_HEAD_GPU_NUM`), `ray start`, then `uv run start.py`. The Dev Container overrides this — inside it you must run those steps manually.
+Docker's `scripts/start.sh` starts Ray (auto-detecting CPUs/GPUs unless `RAY_HEAD_CPU_NUM`/`RAY_HEAD_GPU_NUM` set) and runs `uv run --no-sync start.py` against the prebuilt venv (extras chosen by `--build-arg MSHIP_VARIANT=gpu|cpu`). Plugin wheels in `MSHIP_PLUGIN_WHEEL_DIR` ship to Ray workers per-deployment via `runtime_env`, resolved from `models.yaml`. The Dev Container overrides this — inside it you must `uv sync`, `ray start`, and run `start.py` manually.
 
 ## Architecture map
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -2,10 +2,14 @@
 
 High-level view of where Modelship is headed. If something here interests you, open an issue or jump into a discussion — contributions are welcome.
 
-## In Progress
+## Recently Shipped
 
-- **Transformers CPU backend** — run chat, embeddings, STT, and TTS on CPU-only machines via HuggingFace Transformers (landed in v0.1.22, expanding model support)
-- **Observability** — Prometheus metrics, Grafana dashboard, structured JSON logging, syslog and OpenTelemetry export (mostly complete)
+- **Dynamic wheel-based plugins** (v0.1.32-dev) — plugin packages build into standalone wheels and are injected into Ray workers at deployment via `runtime_env`. `MSHIP_PLUGINS` is deprecated; plugins resolve automatically from `models.yaml`.
+- **Unified Dockerfile** (v0.1.32-dev) — single `Dockerfile` with `--build-arg MSHIP_VARIANT=cpu|gpu`; `Dockerfile.cpu` removed.
+- **Auto-detected Ray resources** (v0.1.32-dev) — `RAY_HEAD_CPU_NUM` / `RAY_HEAD_GPU_NUM` are now optional overrides; Ray auto-detects CPUs and GPUs from the host or container cgroups.
+- **CPU inference backends** — `transformers` (v0.1.22) and `llama_cpp` (v0.1.24) loaders cover chat, embeddings, STT, and TTS without a GPU.
+- **Cluster-wide deploy coordinator** (v0.1.30) — retry-pass deploy loop and `/status` readiness endpoint with per-model load timings.
+- **Observability** — Prometheus metrics, Grafana dashboard, structured JSON logging, syslog and OpenTelemetry export, alerting rules.
 
 ## Up Next
 
@@ -13,22 +17,25 @@ High-level view of where Modelship is headed. If something here interests you, o
 - API endpoint tests for all `/v1/` routes
 - Integration tests with real model loading (small models)
 - Streaming (SSE) correctness tests
-- Plugin lifecycle tests
+- Plugin lifecycle tests (wheel build, runtime_env injection, fallback paths)
 
 ### Core Improvements
-- Detailed health checks — `/health` should verify model state, GPU status, and Ray cluster connectivity
+- Detailed health checks — `/health` should verify model state, GPU status, and Ray cluster connectivity per model
 - Model hot-reload — apply `models.yaml` changes without full server restart
 - Docker Compose for simpler non-K8s deployments
+- Helm chart and Kubernetes manifests with proper GPU scheduling, probes, and resource limits
 
 ### Plugin Ecosystem
-- More TTS backends (community-contributed)
+- More TTS / STT backends (community-contributed)
 - Plugin template / scaffolding CLI for faster plugin development
-- Broader plugin types beyond TTS (e.g. custom pre/post-processing, custom loaders)
+- Broader plugin types beyond TTS/STT (e.g. custom pre/post-processing, custom loaders)
+- Plugin sandboxing or signature verification (plugins currently run with full server privileges)
 
 ### Documentation
 - OpenAPI/Swagger spec for the API
 - Performance tuning guide (vLLM engine kwargs, batch sizes, KV cache)
 - Capacity planning guide — model co-location recommendations per GPU size
+- Multi-node Ray cluster setup (head + workers, networking, failure handling)
 
 ## Contributing
 

--- a/config/examples/full-stack.yaml
+++ b/config/examples/full-stack.yaml
@@ -1,6 +1,5 @@
 # Full AI stack on a single GPU: chat + TTS + STT + embeddings + image gen.
 # Tune num_gpus fractions to fit your VRAM budget.
-# Plugins (Kokoro ONNX) require `MSHIP_PLUGINS=kokoroonnx` or `uv sync --extra kokoroonnx`.
 
 models:
   - name: "llm"

--- a/config/examples/kokoro-tts.yaml
+++ b/config/examples/kokoro-tts.yaml
@@ -1,5 +1,4 @@
-# Kokoro ONNX TTS plugin — install with `uv sync --extra kokoroonnx`
-# or set MSHIP_PLUGINS=kokoroonnx for Docker.
+# Kokoro ONNX TTS plugin.
 #
 # The same model name can appear twice with different configs; requests are
 # load-balanced round-robin across all matching deployments.

--- a/config/examples/mini-pc.yaml
+++ b/config/examples/mini-pc.yaml
@@ -1,7 +1,5 @@
 # Low-resource home-assistant stack for a mini-PC (e.g. Intel N100, 16 GB RAM).
 # CPU-only: quantized chat via llama.cpp, Kokoro ONNX TTS, whisper.cpp STT.
-# Install plugins: `uv sync --extra kokoroonnx --extra whispercpp`
-# Docker: MSHIP_PLUGINS=kokoroonnx,whispercpp
 # Note: kokoroonnx needs espeak-ng on the host (apt-get install -y espeak-ng).
 
 models:

--- a/plugins/bark/README.md
+++ b/plugins/bark/README.md
@@ -4,15 +4,13 @@ Text-to-speech using [Bark](https://github.com/suno-ai/bark) by Suno. Supports m
 
 ## Installation
 
+For local development:
+
 ```bash
 uv sync --extra bark
 ```
 
-Or via Docker:
-
-```
-MSHIP_PLUGINS=bark
-```
+For Docker, no extra setup is needed — plugins referenced in `models.yaml` are loaded automatically from pre-built wheels via Ray's `runtime_env`.
 
 ## Configuration
 

--- a/plugins/kokoroonnx/README.md
+++ b/plugins/kokoroonnx/README.md
@@ -4,15 +4,13 @@ ONNX-based text-to-speech using [Kokoro](https://github.com/thewh1teagle/kokoro-
 
 ## Installation
 
+For local development:
+
 ```bash
 uv sync --extra kokoroonnx
 ```
 
-Or via Docker:
-
-```
-MSHIP_PLUGINS=kokoroonnx
-```
+For Docker, no extra setup is needed — plugins referenced in `models.yaml` are loaded automatically from pre-built wheels via Ray's `runtime_env`.
 
 ## Requirements
 

--- a/plugins/orpheus/README.md
+++ b/plugins/orpheus/README.md
@@ -4,15 +4,13 @@ Text-to-speech using [Orpheus TTS](https://github.com/canopylabs/orpheus-tts) by
 
 ## Installation
 
+For local development:
+
 ```bash
 uv sync --extra orpheus
 ```
 
-Or via Docker:
-
-```
-MSHIP_PLUGINS=orpheus
-```
+For Docker, no extra setup is needed — plugins referenced in `models.yaml` are loaded automatically from pre-built wheels via Ray's `runtime_env`.
 
 ## Configuration
 

--- a/plugins/whispercpp/README.md
+++ b/plugins/whispercpp/README.md
@@ -4,15 +4,13 @@ Speech-to-text using [whisper.cpp](https://github.com/ggerganov/whisper.cpp) via
 
 ## Installation
 
+For local development:
+
 ```bash
 uv sync --extra whispercpp
 ```
 
-Or via Docker:
-
-```
-MSHIP_PLUGINS=whispercpp
-```
+For Docker, no extra setup is needed — plugins referenced in `models.yaml` are loaded automatically from pre-built wheels via Ray's `runtime_env`.
 
 ## Configuration
 


### PR DESCRIPTION
ROADMAP gains a "Recently Shipped" section covering dynamic wheel-based plugins, the unified Dockerfile, Ray resource auto-detection, and the deploy coordinator. Plugin READMEs and example configs drop the deprecated MSHIP_PLUGINS env var. AGENTS.md and CLAUDE.md correct the note that scripts/start.sh runs uv sync at runtime — the venv is now baked at build time via --build-arg MSHIP_VARIANT.

