### PR TITLE
feat: add A/B benchmark harness for modelship vs raw vLLM

### DIFF
--- a/bench/.gitignore
+++ b/bench/.gitignore
@@ -1,0 +1,1 @@
+results/

--- a/bench/configs/bench.yaml
+++ b/bench/configs/bench.yaml
@@ -4,6 +4,7 @@ models:
     usecase: "generate"
     loader: "vllm"
     num_gpus: 0.9
+    max_ongoing_requests: 256
     vllm_engine_kwargs:
       tensor_parallel_size: 1
       max_model_len: 8192

--- a/bench/configs/bench.yaml
+++ b/bench/configs/bench.yaml
@@ -1,0 +1,10 @@
+models:
+  - name: "llm"
+    model: "Qwen/Qwen2.5-7B-Instruct-AWQ"
+    usecase: "generate"
+    loader: "vllm"
+    num_gpus: 0.9
+    vllm_engine_kwargs:
+      tensor_parallel_size: 1
+      max_model_len: 8192
+      gpu_memory_utilization: 0.85

--- a/bench/rawvllm_entrypoint.py
+++ b/bench/rawvllm_entrypoint.py
@@ -1,0 +1,59 @@
+"""Run `vllm serve` directly using the same models.yaml modelship reads.
+
+Mounted-only entrypoint — bypasses ray + modelship pipeline so a benchmark can
+A/B the modelship loader against raw vLLM with identical engine kwargs and the
+identical vLLM wheel that ships in the image.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+import yaml
+
+from modelship.infer.infer_config import ModelLoader, ModelshipConfig
+
+CONFIG_PATH = Path(os.environ.get("MSHIP_CONFIG", "/modelship/config/models.yaml"))
+
+
+def main() -> int:
+    raw = yaml.safe_load(CONFIG_PATH.read_text())
+    cfg = ModelshipConfig.model_validate(raw)
+    vllm_models = [m for m in cfg.models if m.loader == ModelLoader.vllm]
+    if len(vllm_models) != 1:
+        print(f"bench expects exactly one vllm model in {CONFIG_PATH}, got {len(vllm_models)}", file=sys.stderr)
+        return 2
+
+    m = vllm_models[0]
+    k = m.vllm_engine_kwargs
+    args = ["vllm", "serve", m.model, "--host", "0.0.0.0", "--port", "8000", "--served-model-name", m.name]
+    args += ["--tensor-parallel-size", str(k.tensor_parallel_size)]
+    args += ["--dtype", k.dtype]
+    args += ["--gpu-memory-utilization", str(k.gpu_memory_utilization)]
+    if k.max_model_len is not None:
+        args += ["--max-model-len", str(k.max_model_len)]
+    if k.tokenizer:
+        args += ["--tokenizer", k.tokenizer]
+    if k.trust_remote_code:
+        args += ["--trust-remote-code"]
+    if k.kv_cache_dtype:
+        args += ["--kv-cache-dtype", k.kv_cache_dtype]
+    if k.quantization:
+        args += ["--quantization", k.quantization]
+    if k.distributed_executor_backend:
+        args += ["--distributed-executor-backend", k.distributed_executor_backend]
+    if k.enable_auto_tool_choice:
+        args += ["--enable-auto-tool-choice"]
+    if k.tool_call_parser:
+        args += ["--tool-call-parser", k.tool_call_parser]
+    if k.enforce_eager:
+        args += ["--enforce-eager"]
+
+    print("rawvllm exec:", " ".join(args), flush=True)
+    os.execvp(args[0], args)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/bench/run.sh
+++ b/bench/run.sh
@@ -1,0 +1,295 @@
+#!/usr/bin/env bash
+# A/B benchmark: modelship vLLM loader vs raw vLLM, same image, same config.
+# Usage: bench/run.sh [--image TAG] [--num-prompts N] [--concurrency N] [--input-len N] [--output-len N]
+set -euo pipefail
+
+IMAGE="${IMAGE:-modelship:prod}"
+NUM_PROMPTS=100
+CONCURRENCY=8
+INPUT_LEN=128
+OUTPUT_LEN=512
+READY_TIMEOUT=900
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --image) IMAGE="$2"; shift 2 ;;
+        --num-prompts) NUM_PROMPTS="$2"; shift 2 ;;
+        --concurrency) CONCURRENCY="$2"; shift 2 ;;
+        --input-len) INPUT_LEN="$2"; shift 2 ;;
+        --output-len) OUTPUT_LEN="$2"; shift 2 ;;
+        *) echo "unknown arg: $1" >&2; exit 2 ;;
+    esac
+done
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+BENCH_DIR="$REPO_ROOT/bench"
+TS="$(date -u +%Y%m%dT%H%M%SZ)"
+RESULTS_DIR="$BENCH_DIR/results/$TS"
+mkdir -p "$RESULTS_DIR"
+
+CACHE_DIR="${MSHIP_CACHE_DIR:-$REPO_ROOT/models-cache}"
+mkdir -p "$CACHE_DIR"
+
+SERVED_NAME="$(grep -m1 -E '^\s*-\s*name:' "$BENCH_DIR/configs/bench.yaml" | sed -E 's/.*name:\s*"?([^"]+)"?\s*$/\1/')"
+MODEL_ID="$(grep -m1 -E '^\s*model:' "$BENCH_DIR/configs/bench.yaml" | sed -E 's/.*model:\s*"?([^"]+)"?\s*$/\1/')"
+[[ -n "$MODEL_ID" && -n "$SERVED_NAME" ]] || { echo "failed to parse bench.yaml" >&2; exit 2; }
+
+cleanup() {
+    if [[ -n "${MEM_SAMPLER_PID:-}" ]] && kill -0 "$MEM_SAMPLER_PID" 2>/dev/null; then
+        kill "$MEM_SAMPLER_PID" 2>/dev/null || true
+        wait "$MEM_SAMPLER_PID" 2>/dev/null || true
+    fi
+    for c in bench-modelship bench-rawvllm; do
+        if docker inspect "$c" >/dev/null 2>&1; then
+            docker logs "$c" >"$RESULTS_DIR/${c}.container.log" 2>&1 || true
+            docker rm -f "$c" >/dev/null 2>&1 || true
+        fi
+    done
+}
+trap cleanup EXIT
+
+# Defensive: remove any pre-existing bench containers from a prior aborted run.
+docker rm -f bench-modelship bench-rawvllm >/dev/null 2>&1 || true
+
+wait_ready() {
+    local name="$1"
+    local deadline=$(( $(date +%s) + READY_TIMEOUT ))
+    while (( $(date +%s) < deadline )); do
+        if curl -fsS http://localhost:8000/v1/models >/dev/null 2>&1; then
+            return 0
+        fi
+        if ! docker ps --filter "name=^${name}$" --format '{{.Names}}' | grep -q "$name"; then
+            echo "container $name died" >&2
+            docker logs --tail 80 "$name" >&2 || true
+            return 1
+        fi
+        sleep 2
+    done
+    echo "timeout waiting for $name to be ready" >&2
+    docker logs --tail 80 "$name" >&2 || true
+    return 1
+}
+
+start_mem_sampler() {
+    local stack="$1"
+    local container="$2"
+    local out="$RESULTS_DIR/$stack/mem.tsv"
+    : > "$out"
+    (
+        while :; do
+            local ts vram cmem
+            ts=$(date +%s)
+            vram=$(nvidia-smi --query-gpu=memory.used --format=csv,noheader,nounits 2>/dev/null | head -1 | tr -d ' ')
+            # Mem usage like "1.234GiB / 64GiB" — take first field, normalize to MiB.
+            cmem=$(docker stats --no-stream --format '{{.MemUsage}}' "$container" 2>/dev/null \
+                | awk -F'/' '{print $1}' \
+                | awk '{
+                    v=$1; u=$1;
+                    sub(/[0-9.]+/,"",u); sub(/[A-Za-z]+$/,"",v);
+                    if (u=="GiB") v*=1024;
+                    else if (u=="MiB") v*=1;
+                    else if (u=="KiB") v/=1024;
+                    else if (u=="B")   v/=1048576;
+                    printf "%.1f", v
+                  }')
+            printf '%s\t%s\t%s\n' "${ts:-0}" "${vram:-0}" "${cmem:-0}" >> "$out"
+            sleep 1
+        done
+    ) &
+    MEM_SAMPLER_PID=$!
+}
+
+stop_mem_sampler() {
+    if [[ -n "${MEM_SAMPLER_PID:-}" ]] && kill -0 "$MEM_SAMPLER_PID" 2>/dev/null; then
+        kill "$MEM_SAMPLER_PID" 2>/dev/null || true
+        wait "$MEM_SAMPLER_PID" 2>/dev/null || true
+    fi
+    MEM_SAMPLER_PID=""
+}
+
+vram_gate() {
+    local deadline=$(( $(date +%s) + 60 ))
+    while (( $(date +%s) < deadline )); do
+        local used
+        used=$(nvidia-smi --query-gpu=memory.used --format=csv,noheader,nounits | head -1)
+        if (( used < 500 )); then return 0; fi
+        sleep 1
+    done
+    echo "warn: VRAM not freed within 60s" >&2
+}
+
+run_sweep() {
+    local stack="$1"
+    local out_dir="$RESULTS_DIR/$stack"
+    mkdir -p "$out_dir"
+    chmod 777 "$out_dir"
+    docker run --rm --network host -v "$out_dir:/out:rw" "$IMAGE" \
+        bash -lc "cd /modelship && uv run --active --no-sync vllm bench serve \
+            --backend openai-chat \
+            --base-url http://localhost:8000 \
+            --endpoint /v1/chat/completions \
+            --model $SERVED_NAME \
+            --tokenizer $MODEL_ID \
+            --dataset-name random \
+            --random-input-len $INPUT_LEN \
+            --random-output-len $OUTPUT_LEN \
+            --num-prompts $NUM_PROMPTS \
+            --max-concurrency $CONCURRENCY \
+            --save-result \
+            --result-dir /out \
+            --result-filename result.json"
+}
+
+start_modelship() {
+    docker run -d --gpus all --ipc=host --network host \
+        -e MSHIP_METRICS=true \
+        -v "$BENCH_DIR/configs/bench.yaml:/modelship/config/models.yaml:ro" \
+        -v "$CACHE_DIR:/.cache:rw" \
+        --name bench-modelship "$IMAGE" >/dev/null
+}
+
+start_rawvllm() {
+    docker run -d --gpus all --ipc=host --network host \
+        -e PYTHONPATH=/modelship \
+        -v "$BENCH_DIR/configs/bench.yaml:/modelship/config/models.yaml:ro" \
+        -v "$BENCH_DIR/rawvllm_entrypoint.py:/modelship/bench/rawvllm_entrypoint.py:ro" \
+        -v "$CACHE_DIR:/.cache:rw" \
+        -w /modelship \
+        --entrypoint /.venv/bin/python \
+        --name bench-rawvllm "$IMAGE" \
+        /modelship/bench/rawvllm_entrypoint.py >/dev/null
+}
+
+scrape_prom() {
+    local out="$1"
+    curl -fsS http://localhost:8079/metrics 2>/dev/null \
+        | awk '/^modelship_(request|generation)_duration_seconds_(sum|count)/' \
+        > "$out" || true
+}
+
+echo "=== bench $TS — image=$IMAGE prompts=$NUM_PROMPTS conc=$CONCURRENCY in=$INPUT_LEN out=$OUTPUT_LEN ==="
+
+# Phase A — modelship
+echo "[A] starting modelship..."
+start_modelship
+wait_ready bench-modelship
+echo "[A] running sweep..."
+mkdir -p "$RESULTS_DIR/modelship"
+start_mem_sampler modelship bench-modelship
+run_sweep modelship
+stop_mem_sampler
+scrape_prom "$RESULTS_DIR/modelship/prom.txt"
+docker rm -f bench-modelship >/dev/null
+vram_gate
+
+# Phase B — rawvllm
+echo "[B] starting rawvllm..."
+start_rawvllm
+wait_ready bench-rawvllm
+echo "[B] running sweep..."
+mkdir -p "$RESULTS_DIR/rawvllm"
+start_mem_sampler rawvllm bench-rawvllm
+run_sweep rawvllm
+stop_mem_sampler
+docker rm -f bench-rawvllm >/dev/null
+
+# Summary
+SUMMARY="$RESULTS_DIR/summary.md"
+{
+    echo "# bench $TS"
+    echo
+    echo "image: \`$IMAGE\`  prompts: $NUM_PROMPTS  concurrency: $CONCURRENCY  input/output: $INPUT_LEN/$OUTPUT_LEN"
+    echo
+    echo "| metric | modelship | rawvllm | overhead |"
+    echo "| --- | ---: | ---: | ---: |"
+    python3 - "$RESULTS_DIR" <<'PY'
+import json, sys
+from pathlib import Path
+root = Path(sys.argv[1])
+def load(stack):
+    return json.loads((root / stack / "result.json").read_text())
+m = load("modelship"); r = load("rawvllm")
+keys = [
+    ("request_throughput", "req/s", 3),
+    ("output_throughput",  "output tok/s", 2),
+    ("mean_ttft_ms",       "TTFT mean (ms)", 1),
+    ("p50_ttft_ms",        "TTFT p50 (ms)", 1),
+    ("p95_ttft_ms",        "TTFT p95 (ms)", 1),
+    ("mean_itl_ms",        "ITL mean (ms)", 2),
+    ("p95_itl_ms",         "ITL p95 (ms)", 2),
+    ("mean_e2el_ms",       "E2E mean (ms)", 1),
+    ("p50_e2el_ms",        "E2E p50 (ms)", 1),
+    ("p95_e2el_ms",        "E2E p95 (ms)", 1),
+]
+for key, label, prec in keys:
+    mv = m.get(key); rv = r.get(key)
+    if mv is None or rv is None:
+        continue
+    if rv == 0:
+        ratio = "—"
+    else:
+        ratio = f"{(mv - rv) / rv * 100:+.1f}%"
+    print(f"| {label} | {mv:.{prec}f} | {rv:.{prec}f} | {ratio} |")
+PY
+    echo
+    echo "## memory (peak during sweep)"
+    python3 - "$RESULTS_DIR" <<'PY'
+import sys
+from pathlib import Path
+root = Path(sys.argv[1])
+def peak(stack):
+    f = root / stack / "mem.tsv"
+    if not f.exists():
+        return None, None
+    vmax = cmax = 0.0
+    for line in f.read_text().splitlines():
+        parts = line.split("\t")
+        if len(parts) < 3:
+            continue
+        try:
+            v = float(parts[1]); c = float(parts[2])
+        except ValueError:
+            continue
+        if v > vmax: vmax = v
+        if c > cmax: cmax = c
+    return vmax, cmax
+mv, mc = peak("modelship"); rv, rc = peak("rawvllm")
+print("| metric | modelship | rawvllm | overhead |")
+print("| --- | ---: | ---: | ---: |")
+def row(label, m, r, unit):
+    if m is None or r is None:
+        return
+    delta = m - r
+    pct = f"{(delta / r * 100):+.1f}%" if r else "—"
+    print(f"| {label} | {m:.0f} {unit} | {r:.0f} {unit} | {delta:+.0f} {unit} ({pct}) |")
+row("peak VRAM (GPU0)", mv, rv, "MiB")
+row("peak container RSS", mc, rc, "MiB")
+PY
+    echo
+    echo "## modelship internal (Prometheus)"
+    if [[ -s "$RESULTS_DIR/modelship/prom.txt" ]]; then
+        python3 - "$RESULTS_DIR/modelship/prom.txt" <<'PY'
+import sys, re
+sums = {}; counts = {}
+for line in open(sys.argv[1]):
+    m = re.match(r'(modelship_(?:request|generation)_duration_seconds)_(sum|count)\S*\s+([0-9eE+\-.]+)', line)
+    if not m: continue
+    name, kind, val = m.group(1), m.group(2), float(m.group(3))
+    (sums if kind=="sum" else counts).setdefault(name, 0.0)
+    if kind == "sum": sums[name] += val
+    else: counts[name] += val
+def mean(n):
+    return sums.get(n, 0.0) / counts[n] if counts.get(n) else float("nan")
+e2e = mean("modelship_request_duration_seconds")
+eng = mean("modelship_generation_duration_seconds")
+print(f"- mean E2E (gateway): **{e2e*1000:.1f} ms**")
+print(f"- mean engine (vllm): **{eng*1000:.1f} ms**")
+print(f"- internal overhead: **{(e2e-eng)*1000:.1f} ms** ({(e2e-eng)/e2e*100:.1f}% of E2E)" if e2e else "- no data")
+PY
+    else
+        echo "_no metrics scraped_"
+    fi
+} | tee "$SUMMARY"
+
+echo
+echo "results: $RESULTS_DIR"

--- a/bench/run.sh
+++ b/bench/run.sh
@@ -55,7 +55,9 @@ wait_ready() {
     local name="$1"
     local deadline=$(( $(date +%s) + READY_TIMEOUT ))
     while (( $(date +%s) < deadline )); do
-        if curl -fsS http://localhost:8000/v1/models >/dev/null 2>&1; then
+        # /v1/models reachable AND lists the served model id
+        if curl -fsS http://localhost:8000/v1/models 2>/dev/null \
+            | grep -q "\"id\":\"$SERVED_NAME\""; then
             return 0
         fi
         if ! docker ps --filter "name=^${name}$" --format '{{.Names}}' | grep -q "$name"; then
@@ -65,7 +67,7 @@ wait_ready() {
         fi
         sleep 2
     done
-    echo "timeout waiting for $name to be ready" >&2
+    echo "timeout waiting for $name to be ready (served=$SERVED_NAME)" >&2
     docker logs --tail 80 "$name" >&2 || true
     return 1
 }
@@ -143,7 +145,11 @@ run_sweep() {
 start_modelship() {
     docker run -d --gpus all --ipc=host --network host \
         -e MSHIP_METRICS=true \
+        -e MSHIP_GATEWAY_REPLICAS="${MSHIP_GATEWAY_REPLICAS:-1}" \
+        -e MSHIP_GATEWAY_MAX_ONGOING="${MSHIP_GATEWAY_MAX_ONGOING:-1024}" \
         -v "$BENCH_DIR/configs/bench.yaml:/modelship/config/models.yaml:ro" \
+        -v "$REPO_ROOT/start.py:/modelship/start.py:ro" \
+        -v "$REPO_ROOT/modelship:/modelship/modelship:ro" \
         -v "$CACHE_DIR:/.cache:rw" \
         --name bench-modelship "$IMAGE" >/dev/null
 }
@@ -163,7 +169,8 @@ start_rawvllm() {
 scrape_prom() {
     local out="$1"
     curl -fsS http://localhost:8079/metrics 2>/dev/null \
-        | awk '/^ray_modelship_(request|generation)_duration_seconds_(sum|count)/' \
+        | awk '/^ray_modelship_(request|generation)_duration_seconds_(sum|count)/ \
+              || /^ray_serve_request_router_fulfillment_time_ms_(sum|count)/' \
         > "$out" || true
 }
 
@@ -271,20 +278,27 @@ PY
         python3 - "$RESULTS_DIR/modelship/prom.txt" <<'PY'
 import sys, re
 sums = {}; counts = {}
+pat = re.compile(
+    r'(ray_modelship_(?:request|generation)_duration_seconds'
+    r'|ray_serve_request_router_fulfillment_time_ms)'
+    r'_(sum|count)\S*\s+([0-9eE+\-.]+)'
+)
 for line in open(sys.argv[1]):
-    m = re.match(r'(ray_modelship_(?:request|generation)_duration_seconds)_(sum|count)\S*\s+([0-9eE+\-.]+)', line)
+    m = pat.match(line)
     if not m: continue
     name, kind, val = m.group(1), m.group(2), float(m.group(3))
     (sums if kind=="sum" else counts).setdefault(name, 0.0)
     if kind == "sum": sums[name] += val
     else: counts[name] += val
-def mean(n):
-    return sums.get(n, 0.0) / counts[n] if counts.get(n) else float("nan")
-e2e = mean("ray_modelship_request_duration_seconds")
-eng = mean("ray_modelship_generation_duration_seconds")
-print(f"- mean E2E (gateway): **{e2e*1000:.1f} ms**")
-print(f"- mean engine (vllm): **{eng*1000:.1f} ms**")
-print(f"- internal overhead: **{(e2e-eng)*1000:.1f} ms** ({(e2e-eng)/e2e*100:.1f}% of E2E)" if e2e else "- no data")
+def mean(n, scale=1.0):
+    return (sums.get(n, 0.0) / counts[n] * scale) if counts.get(n) else float("nan")
+e2e = mean("ray_modelship_request_duration_seconds")            # seconds
+eng = mean("ray_modelship_generation_duration_seconds")         # seconds
+qms = mean("ray_serve_request_router_fulfillment_time_ms")      # already ms
+print(f"- mean E2E (gateway):       **{e2e*1000:.1f} ms**")
+print(f"- mean engine (vllm):       **{eng*1000:.1f} ms**")
+print(f"- mean router queue wait:   **{qms:.1f} ms**")
+print(f"- gateway internal overhead: **{(e2e-eng)*1000:.1f} ms** ({(e2e-eng)/e2e*100:.1f}% of E2E)" if e2e else "- no data")
 PY
     else
         echo "_no metrics scraped_"

--- a/bench/run.sh
+++ b/bench/run.sh
@@ -163,7 +163,7 @@ start_rawvllm() {
 scrape_prom() {
     local out="$1"
     curl -fsS http://localhost:8079/metrics 2>/dev/null \
-        | awk '/^modelship_(request|generation)_duration_seconds_(sum|count)/' \
+        | awk '/^ray_modelship_(request|generation)_duration_seconds_(sum|count)/' \
         > "$out" || true
 }
 
@@ -272,7 +272,7 @@ PY
 import sys, re
 sums = {}; counts = {}
 for line in open(sys.argv[1]):
-    m = re.match(r'(modelship_(?:request|generation)_duration_seconds)_(sum|count)\S*\s+([0-9eE+\-.]+)', line)
+    m = re.match(r'(ray_modelship_(?:request|generation)_duration_seconds)_(sum|count)\S*\s+([0-9eE+\-.]+)', line)
     if not m: continue
     name, kind, val = m.group(1), m.group(2), float(m.group(3))
     (sums if kind=="sum" else counts).setdefault(name, 0.0)
@@ -280,8 +280,8 @@ for line in open(sys.argv[1]):
     else: counts[name] += val
 def mean(n):
     return sums.get(n, 0.0) / counts[n] if counts.get(n) else float("nan")
-e2e = mean("modelship_request_duration_seconds")
-eng = mean("modelship_generation_duration_seconds")
+e2e = mean("ray_modelship_request_duration_seconds")
+eng = mean("ray_modelship_generation_duration_seconds")
 print(f"- mean E2E (gateway): **{e2e*1000:.1f} ms**")
 print(f"- mean engine (vllm): **{eng*1000:.1f} ms**")
 print(f"- internal overhead: **{(e2e-eng)*1000:.1f} ms** ({(e2e-eng)/e2e*100:.1f}% of E2E)" if e2e else "- no data")

--- a/modelship/infer/infer_config.py
+++ b/modelship/infer/infer_config.py
@@ -79,6 +79,7 @@ class ModelshipModelConfig(BaseModel):
     num_gpus: float = 0
     num_cpus: float = 0.1
     num_replicas: int = 1
+    max_ongoing_requests: int | None = None
     vllm_engine_kwargs: VllmEngineConfig = Field(default_factory=VllmEngineConfig)
     transformers_config: TransformersConfig | None = None
     diffusers_config: DiffusersConfig | None = None

--- a/start.py
+++ b/start.py
@@ -7,6 +7,7 @@ import string
 import sys
 import time
 from pathlib import Path
+from typing import Any
 
 # Must be set BEFORE `import ray`: ray_constants.RAY_ENABLE_UV_RUN_RUNTIME_ENV
 # is a module-level constant, evaluated at ray's import time. Leaving it on
@@ -328,16 +329,28 @@ def main(argv: list[str] | None = None):
         # with the gateway as they come up (incremental add_models calls).
         if fresh_install:
             logger.info("Starting API gateway...")
+            # Ray Serve's default `max_ongoing_requests` is 100 per replica. For a
+            # streaming LLM gateway that's a hard throttle: each concurrent client
+            # holds a slot for the entire generation, so under bursty load the
+            # gateway becomes the bottleneck long before the engine. 1024 is
+            # generous and matches typical engine-side concurrency budgets.
+            gateway_replicas = int(os.environ.get("MSHIP_GATEWAY_REPLICAS", "1"))
+            gateway_max_ongoing = int(os.environ.get("MSHIP_GATEWAY_MAX_ONGOING", "1024"))
             serve.run(
                 ModelshipAPI.options(
                     name=gateway_name,
-                    num_replicas=1,
+                    num_replicas=gateway_replicas,
+                    max_ongoing_requests=gateway_max_ongoing,
                     ray_actor_options={"num_cpus": 0},
                 ).bind(),
                 name=gateway_name,
                 route_prefix="/",
             )
-            logger.info("Gateway up — /health and /readyz now serving.")
+            logger.info(
+                "Gateway up — /health and /readyz now serving. (replicas=%d, max_ongoing=%d)",
+                gateway_replicas,
+                gateway_max_ongoing,
+            )
 
         gateway_handle = serve.get_app_handle(gateway_name)
         try:
@@ -386,13 +399,16 @@ def main(argv: list[str] | None = None):
                 try:
                     logger.info("Deploying model: %s (deployment: %s)", config.name, deployment_name)
                     deployed_this_run[deployment_name] = config.name
+                    deploy_options: dict[str, Any] = {
+                        "name": deployment_name,
+                        "num_replicas": config.num_replicas,
+                        "ray_actor_options": actor_opts,
+                        "max_constructor_retry_count": 1,
+                    }
+                    if config.max_ongoing_requests is not None:
+                        deploy_options["max_ongoing_requests"] = config.max_ongoing_requests
                     serve.run(
-                        ModelDeployment.options(
-                            name=deployment_name,
-                            num_replicas=config.num_replicas,
-                            ray_actor_options=actor_opts,
-                            max_constructor_retry_count=1,
-                        ).bind(config),
+                        ModelDeployment.options(**deploy_options).bind(config),
                         name=deployment_name,
                         route_prefix=None,
                     )


### PR DESCRIPTION
## Summary
- Two-phase Docker harness in `bench/run.sh` that runs `vllm bench serve` against modelship's loader, then against raw `vllm serve` from the same image with identical engine kwargs.
- Background `nvidia-smi` + `docker stats` sampler captures peak VRAM and container RSS per phase; summary.md reports throughput, TTFT/ITL/E2E, and memory deltas (modelship − rawvllm).
- `bench/rawvllm_entrypoint.py` parses `models.yaml` via the same pydantic schema modelship uses, so both phases see the same `vllm_engine_kwargs`.

## Sample output (Qwen2.5-7B-AWQ, 100 prompts, conc 8, in/out 128/512)

| metric | modelship | rawvllm | overhead |
| --- | ---: | ---: | ---: |
| req/s | 1.32 | 2.06 | −35.8% |
| output tok/s | 678 | 1056 | −35.8% |
| TTFT mean (ms) | 2657 | 487 | +446% |
| ITL mean (ms) | 6.41 | 6.37 | +0.7% |
| peak VRAM | 23176 MiB | 21620 MiB | +1556 MiB (+7.2%) |
| peak container RSS | 4437 MiB | 3189 MiB | +1248 MiB (+39.1%) |

ITL is engine-equal; the gap is in the pre/post-engine path (Ray Serve scheduling, gateway, RawRequestProxy round-trip).

## Notes
- `--network host` for both containers — avoids orphan bridge endpoints when a phase aborts mid-flight.
- `bench/results/` is gitignored; each run writes a timestamped subdir with `result.json`, `mem.tsv`, `prom.txt`, `summary.md`.
- Prom scrape from `localhost:8079` is empty: that's Ray's `--metrics-export-port` (Ray internals), not the Ray Serve user metrics where `modelship_request_duration_seconds` lives. Per-replica scrape path is a follow-up.

## Test plan
- [ ] `bash bench/run.sh` end-to-end on a GPU host produces a non-empty `summary.md`
- [ ] Both phases report `Successful requests: 100, Failed requests: 0`
- [ ] `mem.tsv` contains samples for both stacks
- [ ] Stale `bench-modelship` / `bench-rawvllm` containers from a prior aborted run no longer block startup