### PR TITLE
fix: propagate log levels before ray import and add pip for runtime_env

### DIFF
--- a/docs/model-configuration.md
+++ b/docs/model-configuration.md
@@ -15,7 +15,7 @@ Models are configured in a YAML file (default: `config/models.yaml`). Each entry
 | `--use-existing-ray-cluster` | `MSHIP_USE_EXISTING_RAY_CLUSTER` | `false` | Connect to an existing Ray cluster |
 | `--redeploy` | — | `false` | Tear down all existing deployments before deploying |
 | `--cache-dir` | `MSHIP_CACHE_DIR` | `/.cache` | Base cache directory |
-| `--log-level` | `MSHIP_LOG_LEVEL` | `INFO` | Log level |
+| — | `MSHIP_LOG_LEVEL` | `INFO` | Log level (env-var-only: must be set before `import ray` so library loggers latch the right level) |
 | `--log-format` | `MSHIP_LOG_FORMAT` | `text` | Log format (`text` or `json`) |
 | `--log-target` | `MSHIP_LOG_TARGET` | `console` | Log target: `console` or syslog URI (e.g. `syslog://host:514`, `syslog+tcp://host:514`) |
 | `--otel-endpoint` | `OTEL_EXPORTER_OTLP_ENDPOINT` | — | OpenTelemetry OTLP endpoint (e.g. `http://collector:4317`) |

--- a/modelship/logging.py
+++ b/modelship/logging.py
@@ -48,16 +48,66 @@ class ModelshipTextFormatter(logging.Formatter):
 TRACE = 5
 logging.addLevelName(TRACE, "TRACE")
 
-_LIB_LOGGERS = ("ray", "ray.serve", "vllm", "transformers", "diffusers", "llama_cpp")
+_LIB_LOGGERS = (
+    "ray",
+    "ray.serve",
+    "vllm",
+    "transformers",
+    "diffusers",
+    "llama_cpp",
+    "flashinfer",
+    "huggingface_hub",
+)
 
 # Env vars that libraries check internally when creating their own loggers.
 # Setting these ensures the level sticks even when a library re-configures
 # its loggers after our configure_logging() call (e.g. vLLM's init_logger).
 _LIB_ENV_VARS = {
     "RAY_LOG_LEVEL": "ray",
+    "RAY_SERVE_LOG_LEVEL": "ray",
     "VLLM_LOGGING_LEVEL": "vllm",
     "TRANSFORMERS_VERBOSITY": "transformers",
+    "DIFFUSERS_VERBOSITY": "diffusers",
+    "HF_HUB_VERBOSITY": "huggingface_hub",
 }
+
+# HuggingFace-style libraries expect lowercase verbosity values
+# ("debug"/"info"/"warning"/"error"/"critical") rather than the standard
+# logging-module names.
+_LOWERCASE_LEVEL_LIBS = frozenset({"transformers", "diffusers", "huggingface_hub"})
+
+_LEVELS = [TRACE, logging.DEBUG, logging.INFO, logging.WARNING, logging.ERROR, logging.CRITICAL]
+
+
+def _resolve_app_level(level_name: str) -> int:
+    name = level_name.upper()
+    return TRACE if name == "TRACE" else getattr(logging, name, logging.INFO)
+
+
+def compute_lib_level(app_level: int) -> tuple[int, str]:
+    """Library log level is one step above the app level (with CRITICAL as ceiling)."""
+    lib_level = next((lv for lv in _LEVELS if lv > app_level), logging.CRITICAL)
+    return lib_level, logging.getLevelName(lib_level)
+
+
+def get_lib_log_config() -> tuple[int, str]:
+    """Return (lib_level_int, lib_level_name) for the currently-configured app level."""
+    return compute_lib_level(logging.getLogger("modelship").getEffectiveLevel())
+
+
+def propagate_lib_log_env(level_name: str | None = None) -> None:
+    """Set library-native log env vars from MSHIP_LOG_LEVEL.
+
+    Must run BEFORE the libraries are imported so their module-level loggers
+    pick up the right level. Uses setdefault so explicit user overrides win.
+    Safe to call multiple times.
+    """
+    name = (level_name or os.environ.get("MSHIP_LOG_LEVEL", "INFO")).upper()
+    app_level = _resolve_app_level(name)
+    _, lib_level_name = compute_lib_level(app_level)
+    for env_var, lib_name in _LIB_ENV_VARS.items():
+        val = lib_level_name.lower() if lib_name in _LOWERCASE_LEVEL_LIBS else lib_level_name
+        os.environ.setdefault(env_var, val)
 
 
 def _parse_syslog_target(target: str) -> SysLogHandler:
@@ -87,10 +137,8 @@ def configure_logging() -> None:
     log_format = os.environ.get("MSHIP_LOG_FORMAT", "text").lower()
     log_target = os.environ.get("MSHIP_LOG_TARGET", "console").lower()
 
-    levels = [TRACE, logging.DEBUG, logging.INFO, logging.WARNING, logging.ERROR, logging.CRITICAL]
-    app_level = TRACE if level_name == "TRACE" else getattr(logging, level_name, logging.INFO)
-    lib_level = next((lv for lv in levels if lv > app_level), logging.CRITICAL)
-    lib_level_name = logging.getLevelName(lib_level)
+    app_level = _resolve_app_level(level_name)
+    lib_level, _ = compute_lib_level(app_level)
 
     root_logger = logging.getLogger("modelship")
     root_logger.setLevel(app_level)
@@ -120,9 +168,7 @@ def configure_logging() -> None:
     # re-configures its own loggers later, e.g. vLLM's init_logger).
     for name in _LIB_LOGGERS:
         logging.getLogger(name).setLevel(lib_level)
-    for env_var, lib_name in _LIB_ENV_VARS.items():
-        val = lib_level_name.lower() if lib_name == "transformers" else lib_level_name
-        os.environ.setdefault(env_var, val)
+    propagate_lib_log_env(level_name)
 
 
 # pyright: reportMissingImports=false

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,7 @@ dependencies = [
     "scipy>=1.16.1",
     "soundfile>=0.13.0",
     "requests>=2.32.5",
+    "pip>=25.0",
 ]
 
 [project.optional-dependencies]

--- a/start.py
+++ b/start.py
@@ -1,4 +1,5 @@
 import argparse
+import logging
 import os
 import random
 import signal
@@ -16,16 +17,26 @@ from pathlib import Path
 # worker. Keep the uv hook off so runtime_env.pip's py_executable survives.
 os.environ.setdefault("RAY_ENABLE_UV_RUN_RUNTIME_ENV", "false")
 
-import ray
-from pydantic_yaml import parse_yaml_raw_as
-from ray import serve
-from ray.serve.config import HTTPOptions
+# Set RAY_LOG_LEVEL/RAY_SERVE_LOG_LEVEL/VLLM_LOGGING_LEVEL/TRANSFORMERS_VERBOSITY
+# from MSHIP_LOG_LEVEL BEFORE `import ray` — Ray's loggers latch the env value
+# at import time, so configuring them later (in configure_logging) is too late
+# for the driver process. The level is env-var-only (no CLI flag) since argv
+# is parsed inside main(), well after `import ray`.
+from modelship.logging import propagate_lib_log_env
 
-from modelship.infer.deploy_coordinator import OperatorProbe, get_or_create_coordinator
-from modelship.infer.infer_config import ModelLoader, ModelshipConfig, ModelshipModelConfig
-from modelship.infer.model_deployment import ModelDeployment
-from modelship.logging import configure_logging, get_logger
-from modelship.openai.api import ModelshipAPI
+propagate_lib_log_env()
+
+import ray  # noqa: E402
+from pydantic_yaml import parse_yaml_raw_as  # noqa: E402
+from ray import serve  # noqa: E402
+from ray.serve.config import HTTPOptions  # noqa: E402
+from ray.serve.schema import LoggingConfig  # noqa: E402
+
+from modelship.infer.deploy_coordinator import OperatorProbe, get_or_create_coordinator  # noqa: E402
+from modelship.infer.infer_config import ModelLoader, ModelshipConfig, ModelshipModelConfig  # noqa: E402
+from modelship.infer.model_deployment import ModelDeployment  # noqa: E402
+from modelship.logging import configure_logging, get_lib_log_config, get_logger  # noqa: E402
+from modelship.openai.api import ModelshipAPI  # noqa: E402
 
 _DEPLOY_RETRY_SLEEP_S = 2.0
 _WAITING_LOG_EVERY_N_PASSES = 30  # with 2s sleep, log "still waiting" once per minute
@@ -64,11 +75,6 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         default=None,
         help="Connect to an existing Ray cluster (env: MSHIP_USE_EXISTING_RAY_CLUSTER)",
     )
-    parser.add_argument(
-        "--log-level",
-        choices=["TRACE", "DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"],
-        help="Log level (env: MSHIP_LOG_LEVEL)",
-    )
     parser.add_argument("--log-format", choices=["text", "json"], help="Log format (env: MSHIP_LOG_FORMAT)")
     parser.add_argument(
         "--log-target",
@@ -103,7 +109,6 @@ def _apply_args_to_env(args: argparse.Namespace) -> None:
         "ray_cluster_address": "RAY_CLUSTER_ADDRESS",
         "ray_redis_port": "RAY_REDIS_PORT",
         "cache_dir": "MSHIP_CACHE_DIR",
-        "log_level": "MSHIP_LOG_LEVEL",
         "log_format": "MSHIP_LOG_FORMAT",
         "log_target": "MSHIP_LOG_TARGET",
         "otel_endpoint": "OTEL_EXPORTER_OTLP_ENDPOINT",
@@ -257,14 +262,26 @@ def main(argv: list[str] | None = None):
     gateway_name = os.environ.get("MSHIP_GATEWAY_NAME", "modelship api")
     os.environ.setdefault("RAY_GCS_RPC_TIMEOUT_S", "30")
 
+    # Library log level (one step above app level). Used to silence Ray Serve's
+    # system actors (controller/proxy/replica access logs) and Ray's driver
+    # logger, which both ignore Python-level setLevel from the parent process.
+    lib_level, lib_level_name = get_lib_log_config()
+    serve_logging_config = LoggingConfig(log_level=lib_level_name)
+
     if args.redeploy:
         logger.info("--redeploy: tearing down existing deployments...")
         _shutdown_ray()
 
     ray_address = f"{ray_cluster_address}:{ray_redis_port}" if use_existing_cluster else "auto"
-    ray.init(address=ray_address, ignore_reinit_error=True)
+    ray.init(address=ray_address, ignore_reinit_error=True, logging_level=lib_level)
+    # ray.init re-sets ray.* loggers, so re-pin them after init.
+    logging.getLogger("ray").setLevel(lib_level)
+    logging.getLogger("ray._private.worker").setLevel(lib_level)
     openai_api_port = int(os.environ.get("MSHIP_OPENAI_API_PORT", "8000"))
-    serve.start(http_options=HTTPOptions(host="0.0.0.0", port=openai_api_port))
+    serve.start(
+        http_options=HTTPOptions(host="0.0.0.0", port=openai_api_port),
+        logging_config=serve_logging_config,
+    )
 
     existing_apps = set() if args.redeploy else _get_existing_apps()
     fresh_install = gateway_name not in existing_apps
@@ -333,6 +350,7 @@ def main(argv: list[str] | None = None):
                     name=gateway_name,
                     num_replicas=1,
                     ray_actor_options={"num_cpus": 0},
+                    logging_config=serve_logging_config,
                 ).bind(),
                 name=gateway_name,
                 route_prefix="/",
@@ -392,6 +410,7 @@ def main(argv: list[str] | None = None):
                             num_replicas=config.num_replicas,
                             ray_actor_options=actor_opts,
                             max_constructor_retry_count=1,
+                            logging_config=serve_logging_config,
                         ).bind(config),
                         name=deployment_name,
                         route_prefix=None,

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -12,6 +12,7 @@ import pytest
 from modelship.logging import (
     _LIB_ENV_VARS,
     _LIB_LOGGERS,
+    _LOWERCASE_LEVEL_LIBS,
     ModelshipJsonFormatter,
     ModelshipTextFormatter,
     RequestIdFilter,
@@ -35,6 +36,11 @@ def _reset_logging():
     root.propagate = True
     saved_lib_levels = {name: logging.getLogger(name).level for name in _LIB_LOGGERS}
     saved_env = {k: os.environ.get(k) for k in _LIB_ENV_VARS}
+    # Clear so each test exercises a clean setdefault path. Importing start.py
+    # in another test runs propagate_lib_log_env() and pollutes os.environ for
+    # the rest of the pytest session.
+    for k in _LIB_ENV_VARS:
+        os.environ.pop(k, None)
     token = request_id_var.set(None)
     yield
     request_id_var.reset(token)
@@ -84,7 +90,7 @@ class TestConfigureLogging:
         for name in _LIB_LOGGERS:
             assert logging.getLogger(name).level == logging.WARNING
         for env_var, lib_name in _LIB_ENV_VARS.items():
-            expected = "warning" if lib_name == "transformers" else "WARNING"
+            expected = "warning" if lib_name in _LOWERCASE_LEVEL_LIBS else "WARNING"
             assert os.environ.get(env_var) == expected
 
     @patch.dict(os.environ, {"MSHIP_LOG_LEVEL": "DEBUG"})
@@ -103,7 +109,7 @@ class TestConfigureLogging:
         for name in _LIB_LOGGERS:
             assert logging.getLogger(name).level == logging.DEBUG
         for env_var, lib_name in _LIB_ENV_VARS.items():
-            expected = "debug" if lib_name == "transformers" else "DEBUG"
+            expected = "debug" if lib_name in _LOWERCASE_LEVEL_LIBS else "DEBUG"
             assert os.environ.get(env_var) == expected
 
     @patch.dict(os.environ, {"MSHIP_LOG_FORMAT": "json"})

--- a/uv.lock
+++ b/uv.lock
@@ -1509,6 +1509,7 @@ dependencies = [
     { name = "httpx" },
     { name = "librosa" },
     { name = "numpy" },
+    { name = "pip" },
     { name = "pydantic" },
     { name = "pydantic-yaml" },
     { name = "python-multipart" },
@@ -1585,6 +1586,7 @@ requires-dist = [
     { name = "opentelemetry-exporter-otlp", marker = "extra == 'otel'", specifier = ">=1.20.0" },
     { name = "opentelemetry-sdk", marker = "extra == 'otel'", specifier = ">=1.20.0" },
     { name = "orpheus", marker = "extra == 'orpheus'", editable = "plugins/orpheus" },
+    { name = "pip", specifier = ">=25.0" },
     { name = "pre-commit", marker = "extra == 'dev'", specifier = ">=4.0.0" },
     { name = "pydantic", specifier = ">=2.12.0" },
     { name = "pydantic-yaml", specifier = ">=1.6.0" },
@@ -2482,6 +2484,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/be/42/025cfe05d1be22dbfdb4f264fe9de1ccda83f66e4fc3aac94748e784af04/pillow-12.2.0-cp312-cp312-win32.whl", hash = "sha256:58f62cc0f00fd29e64b29f4fd923ffdb3859c9f9e6105bfc37ba1d08994e8940", size = 6378489, upload-time = "2026-04-01T14:43:34.601Z" },
     { url = "https://files.pythonhosted.org/packages/5d/7b/25a221d2c761c6a8ae21bfa3874988ff2583e19cf8a27bf2fee358df7942/pillow-12.2.0-cp312-cp312-win_amd64.whl", hash = "sha256:7f84204dee22a783350679a0333981df803dac21a0190d706a50475e361c93f5", size = 7084129, upload-time = "2026-04-01T14:43:37.213Z" },
     { url = "https://files.pythonhosted.org/packages/10/e1/542a474affab20fd4a0f1836cb234e8493519da6b76899e30bcc5d990b8b/pillow-12.2.0-cp312-cp312-win_arm64.whl", hash = "sha256:af73337013e0b3b46f175e79492d96845b16126ddf79c438d7ea7ff27783a414", size = 2463612, upload-time = "2026-04-01T14:43:39.421Z" },
+]
+
+[[package]]
+name = "pip"
+version = "26.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/73/7e/d2b04004e1068ad4fdfa2f227b839b5d03e602e47cdbbf49de71137c9546/pip-26.1.tar.gz", hash = "sha256:81e13ebcca3ffa8cc85e4deff5c27e1ee26dea0aa7fc2f294a073ac208806ff3", size = 1840316, upload-time = "2026-04-26T21:00:05.406Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/70/7a/be4bd8bcbb24ea475856dd68159d78b03b2bb53dae369f69c9606b8888f5/pip-26.1-py3-none-any.whl", hash = "sha256:4e8486d821d814b77319acb7b9e8bf5a4ee7590a643e7cb21029f209be8573c1", size = 1812804, upload-time = "2026-04-26T21:00:03.194Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Two related startup fixes:

- Move library log-level resolution into modelship.logging (propagate_lib_log_env, compute_lib_level, get_lib_log_config) and call it before `import ray` in start.py. Ray, vLLM, transformers and friends latch their log levels at import time from env vars, so configuring them later via configure_logging() was a no-op for the driver. Drop --log-level (env-var-only now, since argv is parsed after ray import) and pass LoggingConfig to serve.start / each deployment so Ray Serve's system actors stop spamming INFO access logs.
- Add `pip>=25.0` to base dependencies. Ray's runtime_env.pip plugin detects an active venv and clones it via _clonevirtualenv.py instead of seeding a fresh one. uv-managed Pythons ship without pip, so the clone has no pip, and `python -m pip install <plugin.whl>` fails with "No module named pip" on every plugin deploy. Including pip in /.venv makes the clone usable.


