### PR TITLE
feat: add reconciliation logic for deployments based on models.yaml

### DIFF
--- a/modelship/infer/infer_config.py
+++ b/modelship/infer/infer_config.py
@@ -1,4 +1,5 @@
 import asyncio
+import hashlib
 from enum import StrEnum
 from typing import Any, Literal
 
@@ -6,6 +7,17 @@ import ray
 from fastapi import Request
 from pydantic import BaseModel, Field, model_validator
 from starlette.datastructures import Headers, State
+
+# Length (hex chars) of the per-deployment fingerprint suffix. 10 hex chars =
+# 40 bits, collision-resistant for the realistic universe of model configs.
+FINGERPRINT_LEN = 10
+
+# Fields excluded from the fingerprint hash. `name` is the deployment prefix,
+# not part of the fingerprint payload. `num_replicas` is excluded so scaling
+# replicas in/out doesn't force a full deployment replacement — Ray Serve
+# updates replica count in place when serve.run() is re-bound with the same
+# app name.
+_FINGERPRINT_EXCLUDED_FIELDS = {"name", "num_replicas"}
 
 ChatTemplateContentFormatOption = Literal["auto", "string", "openai"]
 
@@ -93,9 +105,33 @@ class ModelshipModelConfig(BaseModel):
             raise ValueError("loader='custom' requires plugin to be set")
         return self
 
+    def fingerprint(self) -> str:
+        """Stable hash of the config fields that determine actor placement and
+        runtime behavior. Used as the deployment-name suffix so reconcile can
+        detect drift via a pure name comparison against `serve.status()`."""
+        payload = self.model_dump_json(exclude=_FINGERPRINT_EXCLUDED_FIELDS)
+        return hashlib.sha256(payload.encode("utf-8")).hexdigest()[:FINGERPRINT_LEN]
+
+    def deployment_name(self) -> str:
+        return f"{self.name}-{self.fingerprint()}"
+
 
 class ModelshipConfig(BaseModel):
     models: list[ModelshipModelConfig]
+
+    @model_validator(mode="after")
+    def check_unique_deployment_names(self):
+        seen: dict[str, int] = {}
+        for cfg in self.models:
+            key = cfg.deployment_name()
+            seen[key] = seen.get(key, 0) + 1
+        dupes = [name for name, count in seen.items() if count > 1]
+        if dupes:
+            raise ValueError(
+                f"Duplicate model entries (same name + identical fingerprint): {dupes}. "
+                f"Each model name must be unique; for multiple identical replicas use num_replicas."
+            )
+        return self
 
 
 @ray.remote(num_cpus=0)

--- a/modelship/openai/api.py
+++ b/modelship/openai/api.py
@@ -117,7 +117,10 @@ def _error_response(result: ErrorResponse) -> JSONResponse:
 @serve.ingress(app)
 class ModelshipAPI:
     def __init__(self):
-        self.models: dict[str, list[DeploymentHandle]] = {}
+        # model_name -> (app_name -> handle). Keyed by app_name so
+        # remove_deployments can drop a specific deployment by its
+        # fingerprint-suffixed app name without scanning handles.
+        self.models: dict[str, dict[str, DeploymentHandle]] = {}
         self._round_robin: dict[str, int] = {}
         self.model_list: list[OpenAiModelCard] = []
         self.expected_models: list[str] = []
@@ -151,10 +154,10 @@ class ModelshipAPI:
 
             newly_added = model_name not in self.models
             if newly_added:
-                self.models[model_name] = []
+                self.models[model_name] = {}
                 self._round_robin[model_name] = 0
                 self.model_list.append(OpenAiModelCard(id=model_name))
-            self.models[model_name].append(handle)
+            self.models[model_name][app_name] = handle
             logger.info("Registered deployment: %s (model: %s)", app_name, model_name)
 
             if newly_added:
@@ -168,6 +171,41 @@ class ModelshipAPI:
 
         MODELS_LOADED.set(len(self.models))
 
+    async def remove_deployments(self, app_names: list[str]) -> list[str]:
+        """Drop the given deployment app names from the routing tables.
+
+        Deployment names follow `{model_name}-{fingerprint}`, so the owning
+        model name is derived by stripping the fingerprint suffix. If a model
+        has no remaining deployments after removal, the model entry, model
+        card, round-robin counter, expected-models entry, and load-time entry
+        are also dropped. Returns the names of fully-removed models.
+        """
+        removed_models: list[str] = []
+        for app_name in app_names:
+            model_name = app_name.rsplit("-", 1)[0]
+            handles = self.models.get(model_name)
+            if handles is None or app_name not in handles:
+                logger.warning("remove_deployments: no deployment named %s", app_name)
+                continue
+
+            del handles[app_name]
+            logger.info("Unregistered deployment: %s (model: %s)", app_name, model_name)
+
+            if not handles:
+                del self.models[model_name]
+                self._round_robin.pop(model_name, None)
+                self.model_list = [c for c in self.model_list if c.id != model_name]
+                self._model_load_times.pop(model_name, None)
+                self.expected_models = [m for m in self.expected_models if m != model_name]
+                removed_models.append(model_name)
+
+        MODELS_LOADED.set(len(self.models))
+        return removed_models
+
+    async def list_deployments(self) -> dict[str, list[str]]:
+        """Return model_name -> list of deployment app_names currently registered."""
+        return {model_name: list(handles.keys()) for model_name, handles in self.models.items()}
+
     @staticmethod
     def _set_request_id(request_id: str) -> None:
         from modelship.logging import request_id_var
@@ -177,7 +215,7 @@ class ModelshipAPI:
     def _get_handle(self, model_name: str | None) -> DeploymentHandle:
         if model_name is None or model_name not in self.models:
             raise HTTPException(status_code=HTTPStatus.NOT_FOUND.value, detail="model not found")
-        handles = self.models[model_name]
+        handles = list(self.models[model_name].values())
         idx = self._round_robin[model_name] % len(handles)
         self._round_robin[model_name] += 1
         return handles[idx]

--- a/plugins/kokoroonnx/kokoroonnx/kokoroonnx.py
+++ b/plugins/kokoroonnx/kokoroonnx/kokoroonnx.py
@@ -73,8 +73,8 @@ class ModelPlugin(BasePlugin):
                 "Install it with: apt-get install -y espeak-ng (Debian/Ubuntu) "
                 "or brew install espeak (macOS)"
             )
-        logger.info("onnxruntime device: %s", ort.get_device())
-        logger.info("available providers: %s", ort.get_available_providers())
+        logger.info("onnxruntime device: %s", ort.get_device())  # pyright: ignore[reportAttributeAccessIssue]
+        logger.info("available providers: %s", ort.get_available_providers())  # pyright: ignore[reportAttributeAccessIssue]
 
         plugin_dir = f"{plugins_dir()}/kokoroonnx"
         os.makedirs(plugin_dir, exist_ok=True)

--- a/start.py
+++ b/start.py
@@ -100,7 +100,30 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         default=False,
         help="Tear down all existing deployments before deploying (default: additive)",
     )
-    return parser.parse_args(argv)
+    parser.add_argument(
+        "--reconcile",
+        action="store_true",
+        default=False,
+        help=(
+            "Diff models.yaml against the cluster: add new models, remove dropped ones, "
+            "replace those whose config changed (matched by name + fingerprint). "
+            "Mutually exclusive with --redeploy."
+        ),
+    )
+    parser.add_argument(
+        "--replace-strategy",
+        choices=["blue_green", "stop_start"],
+        default="blue_green",
+        help=(
+            "How to replace a model whose config changed. blue_green (default): deploy "
+            "new alongside old, then drop old (no request loss, peak resource = old+new). "
+            "stop_start: drop old first, then deploy new (brief unavailability, no overlap)."
+        ),
+    )
+    args = parser.parse_args(argv)
+    if args.redeploy and args.reconcile:
+        parser.error("--redeploy and --reconcile are mutually exclusive")
+    return args
 
 
 def _apply_args_to_env(args: argparse.Namespace) -> None:
@@ -251,6 +274,26 @@ def _shutdown_ray():
         logger.exception("ray.shutdown() failed")
 
 
+def _remove_apps(gateway_handle, app_names: list[str]) -> None:
+    """Unregister the given deployment apps from the gateway (so new requests
+    stop routing) and then delete them from Ray Serve. `serve.delete` drains
+    in-flight requests before tearing the deployment down. The deploy
+    coordinator is intentionally not involved — it gates admission, not
+    teardown; freed resources show up on the next try_reserve."""
+    if not app_names:
+        return
+    try:
+        gateway_handle.remove_deployments.remote(app_names).result()
+    except Exception:
+        logger.exception("Failed to unregister deployments from gateway: %s", app_names)
+    for app_name in app_names:
+        try:
+            logger.info("Deleting deployment: %s", app_name)
+            serve.delete(app_name)
+        except Exception:
+            logger.exception("Failed to delete deployment: %s", app_name)
+
+
 def main(argv: list[str] | None = None):
     args = parse_args(argv)
     _apply_args_to_env(args)
@@ -320,6 +363,30 @@ def main(argv: list[str] | None = None):
         reverse=True,
     )
 
+    # Diff desired (models.yaml) against deployed (serve.status). Deployment
+    # names are `{model_name}-{fingerprint}`, so a pure set comparison detects
+    # both renames and config drift: a model whose num_gpus changed gets a new
+    # fingerprint -> new deployment_name -> shows up as both an add and a
+    # remove (handled as a replace below).
+    #
+    # `existing_apps` includes the gateway app itself; exclude it so reconcile
+    # never targets the gateway for removal.
+    desired_apps = {c.deployment_name(): c for c in sorted_models}
+    currently_deployed_apps = existing_apps - {gateway_name}
+    if args.reconcile:
+        if fresh_install:
+            logger.info("--reconcile: no existing gateway — equivalent to a fresh deploy.")
+        apps_to_remove: list[str] = sorted(currently_deployed_apps - desired_apps.keys())
+        if apps_to_remove:
+            logger.info("--reconcile: %d deployment(s) to remove: %s", len(apps_to_remove), apps_to_remove)
+    else:
+        apps_to_remove = []
+    # In all modes, skip configs already deployed under their fingerprint —
+    # makes plain `start.py` idempotent on re-run instead of double-deploying.
+    sorted_models = [c for c in sorted_models if c.deployment_name() not in currently_deployed_apps]
+    if sorted_models:
+        logger.info("%d deployment(s) to add: %s", len(sorted_models), [c.deployment_name() for c in sorted_models])
+
     # Track deployments created by this invocation: deployment_name -> model_name.
     # Used for both model registration with the gateway and cleanup on interrupt.
     deployed_this_run: dict[str, str] = {}
@@ -359,9 +426,18 @@ def main(argv: list[str] | None = None):
 
         gateway_handle = serve.get_app_handle(gateway_name)
         try:
-            gateway_handle.set_expected_models.remote([c.name for c in sorted_models]).result()
+            # Pass the full desired set, not the filtered sorted_models —
+            # kept (already-deployed) models also count toward "ready".
+            gateway_handle.set_expected_models.remote([c.name for c in yml_conf.models]).result()
         except Exception:
             logger.exception("Failed to seed expected model list on gateway (non-fatal).")
+
+        # stop_start: drop old deployments BEFORE deploying new ones, so the
+        # freed resources are available for the deploy loop. Used when the
+        # cluster can't fit old + new at the same time.
+        if args.replace_strategy == "stop_start":
+            _remove_apps(gateway_handle, apps_to_remove)
+            apps_to_remove = []
 
         # Coordinator actor serialises deploys across operators on the same
         # cluster; the probe is driver-owned so Ray force-releases the lock
@@ -387,7 +463,7 @@ def main(argv: list[str] | None = None):
             for config in list(remaining):
                 wheel = plugin_wheels.get(config.plugin) if config.plugin else None
                 actor_opts = build_actor_options(config, plugin_wheel=wheel)
-                deployment_name = f"{config.name}-{_rand_suffix()}"
+                deployment_name = config.deployment_name()
 
                 reserved, _reason = ray.get(
                     coordinator.try_reserve.remote(
@@ -481,6 +557,14 @@ def main(argv: list[str] | None = None):
             len(deployed_this_run),
             pass_count,
         )
+
+        # blue_green: drop old deployments AFTER new ones are live and
+        # registered with the gateway. During the brief overlap the gateway
+        # round-robins across both old and new handles for the same model,
+        # so no requests are lost.
+        if apps_to_remove:
+            _remove_apps(gateway_handle, apps_to_remove)
+            apps_to_remove = []
 
         if fatally_failed:
             logger.error(

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -59,8 +59,8 @@ class TestAddModels:
             await api.add_models({"qwen-b7x2p": "qwen"})
 
         assert len(api.models["qwen"]) == 2
-        assert api.models["qwen"][0] is handle_1
-        assert api.models["qwen"][1] is handle_2
+        assert api.models["qwen"]["qwen-a3f9k"] is handle_1
+        assert api.models["qwen"]["qwen-b7x2p"] is handle_2
         # Only one model card despite two deployments
         assert len(api.model_list) == 1
 
@@ -106,6 +106,69 @@ class TestAddModels:
         assert body["models_pending"] == []
         assert body["time_to_ready_s"] is not None
         assert "qwen" in body["model_load_times_s"]
+
+
+class TestRemoveDeployments:
+    @pytest.mark.asyncio
+    async def test_remove_last_deployment_drops_model(self, api):
+        with patch("modelship.openai.api.serve.get_app_handle", return_value=MagicMock()):
+            await api.add_models({"qwen-a3f9k1b2c4": "qwen"})
+        assert "qwen" in api.models
+
+        removed = await api.remove_deployments(["qwen-a3f9k1b2c4"])
+
+        assert removed == ["qwen"]
+        assert "qwen" not in api.models
+        assert api.model_list == []
+        assert "qwen" not in api._round_robin
+
+    @pytest.mark.asyncio
+    async def test_remove_one_of_many_keeps_model(self, api):
+        h1, h2 = MagicMock(), MagicMock()
+        with patch("modelship.openai.api.serve.get_app_handle", side_effect=[h1, h2]):
+            await api.add_models({"qwen-aaaaaaaaaa": "qwen", "qwen-bbbbbbbbbb": "qwen"})
+
+        removed = await api.remove_deployments(["qwen-aaaaaaaaaa"])
+
+        assert removed == []  # model still has a deployment
+        assert "qwen" in api.models
+        assert list(api.models["qwen"].keys()) == ["qwen-bbbbbbbbbb"]
+        assert len(api.model_list) == 1
+
+    @pytest.mark.asyncio
+    async def test_remove_unknown_deployment_is_warning(self, api):
+        # Should not raise; just logs a warning.
+        removed = await api.remove_deployments(["nonexistent-1234567890"])
+        assert removed == []
+
+    @pytest.mark.asyncio
+    async def test_remove_drops_from_expected_models(self, api):
+        await api.set_expected_models(["qwen", "kokoro"])
+        with patch("modelship.openai.api.serve.get_app_handle", return_value=MagicMock()):
+            await api.add_models({"qwen-a3f9k1b2c4": "qwen"})
+
+        await api.remove_deployments(["qwen-a3f9k1b2c4"])
+
+        assert api.expected_models == ["kokoro"]
+
+
+class TestListDeployments:
+    @pytest.mark.asyncio
+    async def test_returns_app_names_per_model(self, api):
+        h1, h2, h3 = MagicMock(), MagicMock(), MagicMock()
+        with patch("modelship.openai.api.serve.get_app_handle", side_effect=[h1, h2, h3]):
+            await api.add_models(
+                {
+                    "qwen-aaaaaaaaaa": "qwen",
+                    "qwen-bbbbbbbbbb": "qwen",
+                    "kokoro-cccccccccc": "kokoro",
+                }
+            )
+
+        listed = await api.list_deployments()
+
+        assert set(listed["qwen"]) == {"qwen-aaaaaaaaaa", "qwen-bbbbbbbbbb"}
+        assert listed["kokoro"] == ["kokoro-cccccccccc"]
 
 
 class TestGetHandle:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -213,6 +213,65 @@ class TestModelshipConfig:
         assert len(config.models) == 2
         assert config.models[0].name == config.models[1].name == "kokoro"
 
+    def test_duplicate_name_and_fingerprint_rejected(self):
+        with pytest.raises(ValidationError, match="Duplicate model entries"):
+            ModelshipConfig(
+                models=[
+                    ModelshipModelConfig(
+                        name="qwen",
+                        model="Qwen/Qwen-7B",
+                        usecase=ModelUsecase.generate,
+                        loader=ModelLoader.vllm,
+                        num_gpus=0.5,
+                    ),
+                    ModelshipModelConfig(
+                        name="qwen",
+                        model="Qwen/Qwen-7B",
+                        usecase=ModelUsecase.generate,
+                        loader=ModelLoader.vllm,
+                        num_gpus=0.5,
+                    ),
+                ]
+            )
+
+
+class TestFingerprint:
+    def _cfg(self, **overrides):
+        base = dict(
+            name="qwen",
+            model="Qwen/Qwen-7B",
+            usecase=ModelUsecase.generate,
+            loader=ModelLoader.vllm,
+            num_gpus=0.5,
+        )
+        base.update(overrides)
+        return ModelshipModelConfig(**base)
+
+    def test_stable_across_instances(self):
+        assert self._cfg().fingerprint() == self._cfg().fingerprint()
+
+    def test_changes_when_num_gpus_differs(self):
+        assert self._cfg(num_gpus=0.7).fingerprint() != self._cfg(num_gpus=0.8).fingerprint()
+
+    def test_unaffected_by_name(self):
+        # Same config under a different name should fingerprint identically;
+        # the name is the deployment-name prefix, not part of the hash.
+        assert self._cfg(name="a").fingerprint() == self._cfg(name="b").fingerprint()
+
+    def test_unaffected_by_num_replicas(self):
+        # Replica count is a Ray Serve in-place rebind, not a config drift.
+        assert self._cfg(num_replicas=1).fingerprint() == self._cfg(num_replicas=4).fingerprint()
+
+    def test_changes_when_loader_differs(self):
+        assert (
+            self._cfg(loader=ModelLoader.vllm).fingerprint() != self._cfg(loader=ModelLoader.transformers).fingerprint()
+        )
+
+    def test_deployment_name_combines_name_and_fingerprint(self):
+        cfg = self._cfg()
+        assert cfg.deployment_name() == f"{cfg.name}-{cfg.fingerprint()}"
+        assert len(cfg.fingerprint()) == 10
+
 
 class TestTransformersConfig:
     def test_defaults(self):

--- a/tests/test_start.py
+++ b/tests/test_start.py
@@ -2,9 +2,10 @@
 
 import os
 from pathlib import Path
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
-from start import _rand_suffix, build_actor_options, parse_args, resolve_plugin_wheel
+import pytest
+from start import _rand_suffix, _remove_apps, build_actor_options, parse_args, resolve_plugin_wheel
 
 from modelship.infer.infer_config import ModelLoader, ModelshipModelConfig, ModelUsecase
 
@@ -22,6 +23,20 @@ class TestParseArgs:
     def test_redeploy_flag(self):
         args = parse_args(["--redeploy"])
         assert args.redeploy is True
+
+    def test_reconcile_flag(self):
+        args = parse_args(["--reconcile"])
+        assert args.reconcile is True
+        assert args.replace_strategy == "blue_green"
+
+    def test_reconcile_with_stop_start_strategy(self):
+        args = parse_args(["--reconcile", "--replace-strategy", "stop_start"])
+        assert args.reconcile is True
+        assert args.replace_strategy == "stop_start"
+
+    def test_redeploy_and_reconcile_mutually_exclusive(self):
+        with pytest.raises(SystemExit):
+            parse_args(["--redeploy", "--reconcile"])
 
     def test_config_path(self):
         args = parse_args(["--config", "/some/path/models.yaml"])
@@ -107,6 +122,35 @@ class TestBuildActorOptions:
         )
         opts = build_actor_options(config)
         assert opts["num_gpus"] == 0
+
+
+class TestRemoveApps:
+    def test_noop_on_empty_list(self):
+        gateway = MagicMock()
+        with patch("start.serve.delete") as mock_delete:
+            _remove_apps(gateway, [])
+        gateway.remove_deployments.remote.assert_not_called()
+        mock_delete.assert_not_called()
+
+    def test_unregisters_then_deletes(self):
+        gateway = MagicMock()
+        gateway.remove_deployments.remote.return_value.result.return_value = ["qwen"]
+        apps = ["qwen-aaaaaaaaaa", "kokoro-bbbbbbbbbb"]
+        with patch("start.serve.delete") as mock_delete:
+            _remove_apps(gateway, apps)
+
+        # Unregister from gateway happens before serve.delete so new requests
+        # stop routing before the deployment is torn down.
+        gateway.remove_deployments.remote.assert_called_once_with(apps)
+        assert mock_delete.call_args_list == [(("qwen-aaaaaaaaaa",),), (("kokoro-bbbbbbbbbb",),)]
+
+    def test_continues_on_serve_delete_error(self):
+        gateway = MagicMock()
+        gateway.remove_deployments.remote.return_value.result.return_value = []
+        with patch("start.serve.delete", side_effect=[Exception("gone"), None]) as mock_delete:
+            _remove_apps(gateway, ["a-1234567890", "b-1234567890"])
+        # Both deletes attempted even though the first raised.
+        assert mock_delete.call_count == 2
 
 
 class TestResolvePluginWheel:


### PR DESCRIPTION
Introduces configuration fingerprinting for models to detect drift. Adds --reconcile flag to start.py to synchronize cluster state with models.yaml. Supports blue-green and stop-start replacement strategies. Updates gateway API to handle multiple deployments per model and dynamic removal.


