### PR TITLE
feat: auto-detect tool-call parser for transformers loader

### DIFF
--- a/modelship/deploy/config.py
+++ b/modelship/deploy/config.py
@@ -10,11 +10,6 @@ from modelship.logging import get_logger
 from modelship.openai.tool_calling.registry import available_parsers
 from modelship.openai.tool_calling.utils import detect_tool_parser
 
-# Tool-call formats `detect_tool_parser` can identify but for which a parser
-# may or may not yet be registered. Used to differentiate "format unknown" from
-# "format known but parser not implemented yet" in the auto-detect warning.
-_KNOWN_TOOL_FORMATS = frozenset({"hermes", "mistral", "llama3_json"})
-
 # Loaders that emit raw model text and rely on the tool_calling registry to
 # parse tool calls. vLLM and llama.cpp have native tool-call handling and are
 # excluded; diffusers/custom don't do chat completion through this path.
@@ -122,12 +117,10 @@ def resolve_all_tool_parsers(yml_conf: ModelshipConfig) -> None:
             )
             continue
         if detected not in registered:
-            known_note = "" if detected in _KNOWN_TOOL_FORMATS else " (format not in known list)"
             logger.warning(
-                "Model '%s' uses tool format %r%s but no parser is registered; tool calling disabled.",
+                "Model '%s' uses tool format %r but no parser is registered; tool calling disabled.",
                 cfg.name,
                 detected,
-                known_note,
             )
             continue
         cfg._resolved_tool_call_parser = detected

--- a/modelship/deploy/config.py
+++ b/modelship/deploy/config.py
@@ -4,9 +4,21 @@ from pathlib import Path
 from pydantic_yaml import parse_yaml_raw_as
 
 from modelship.deploy.actor_options import resolve_plugin_wheel
-from modelship.infer.infer_config import ModelLoader, ModelshipConfig
+from modelship.infer.infer_config import ModelLoader, ModelshipConfig, ModelUsecase
 from modelship.infer.model_resolver import resolve_model_source
 from modelship.logging import get_logger
+from modelship.openai.tool_calling.registry import available_parsers
+from modelship.openai.tool_calling.utils import detect_tool_parser
+
+# Tool-call formats `detect_tool_parser` can identify but for which a parser
+# may or may not yet be registered. Used to differentiate "format unknown" from
+# "format known but parser not implemented yet" in the auto-detect warning.
+_KNOWN_TOOL_FORMATS = frozenset({"hermes", "mistral", "llama3_json"})
+
+# Loaders that emit raw model text and rely on the tool_calling registry to
+# parse tool calls. vLLM and llama.cpp have native tool-call handling and are
+# excluded; diffusers/custom don't do chat completion through this path.
+_LOADERS_USING_TEXT_PARSER = frozenset({ModelLoader.transformers})
 
 logger = get_logger("startup")
 
@@ -59,3 +71,64 @@ def resolve_all_model_sources(yml_conf: ModelshipConfig) -> None:
         logger.info("Resolving model source for '%s': %s", cfg.name, cfg.model)
         cfg._resolved_path = resolve_model_source(cfg.model, trust_remote_code=trust_remote_code)
         logger.info("Resolved '%s' -> %s", cfg.name, cfg._resolved_path)
+
+
+def resolve_all_tool_parsers(yml_conf: ModelshipConfig) -> None:
+    """Pre-flight: pick a tool-call parser for each text-parser loader model.
+
+    Runs after `resolve_all_model_sources` so `_resolved_path` is populated.
+    Inspects the model's `tokenizer_config.json` chat template and stores the
+    result on `_resolved_tool_call_parser`. Effective parser at request time
+    is `transformers_config.tool_call_parser or _resolved_tool_call_parser`,
+    so an explicit user setting always wins.
+
+    Behavior:
+    - Explicit parser configured: validated against the registry; raises if
+      the name is unknown so misconfiguration fails startup, not mid-request.
+    - Auto-detected, registered: stored on `_resolved_tool_call_parser`.
+    - Auto-detected, known format but no parser implemented yet: warn, leave
+      unset — tool calling will be disabled for this model.
+    - Auto-detected as `unknown` (template uses tools but no recognized
+      markers): warn, leave unset.
+    - Not detected: tool calling silently disabled (model has no template
+      tool-call affordance to begin with).
+    """
+    registered = set(available_parsers())
+    for cfg in yml_conf.models:
+        if cfg.loader not in _LOADERS_USING_TEXT_PARSER:
+            continue
+        if cfg.usecase != ModelUsecase.generate:
+            continue
+
+        explicit = cfg.transformers_config.tool_call_parser if cfg.transformers_config else None
+        if explicit is not None:
+            if explicit not in registered:
+                raise ValueError(
+                    f"Model '{cfg.name}' configures tool_call_parser={explicit!r} "
+                    f"which is not registered. Available: {sorted(registered) or '(none)'}."
+                )
+            logger.info("Using explicit tool_call_parser=%r for '%s'", explicit, cfg.name)
+            continue
+
+        assert cfg._resolved_path is not None  # populated by resolve_all_model_sources
+        detected = detect_tool_parser(cfg._resolved_path)
+        if detected is None:
+            logger.info("No tool-calling support detected for '%s'; tools disabled.", cfg.name)
+            continue
+        if detected == "unknown":
+            logger.warning(
+                "Model '%s' chat template references tools but uses unrecognized markers; tool calling disabled.",
+                cfg.name,
+            )
+            continue
+        if detected not in registered:
+            known_note = "" if detected in _KNOWN_TOOL_FORMATS else " (format not in known list)"
+            logger.warning(
+                "Model '%s' uses tool format %r%s but no parser is registered; tool calling disabled.",
+                cfg.name,
+                detected,
+                known_note,
+            )
+            continue
+        cfg._resolved_tool_call_parser = detected
+        logger.info("Auto-detected tool_call_parser=%r for '%s'", detected, cfg.name)

--- a/modelship/infer/infer_config.py
+++ b/modelship/infer/infer_config.py
@@ -67,7 +67,7 @@ class TransformersConfig(BaseModel):
     trust_remote_code: bool = False
     model_kwargs: dict[str, Any] = Field(default_factory=dict)
     pipeline_kwargs: dict[str, Any] = Field(default_factory=dict)
-    tool_call_parser: str = "hermes"
+    tool_call_parser: str | None = None
 
 
 class DiffusersConfig(BaseModel):
@@ -100,6 +100,7 @@ class ModelshipModelConfig(BaseModel):
     plugin_config: dict[str, Any] | None = None  # plugin devs parse this themselves
 
     _resolved_path: str | None = PrivateAttr(default=None)
+    _resolved_tool_call_parser: str | None = PrivateAttr(default=None)
 
     @model_validator(mode="after")
     def check_custom_requires_plugin(self):

--- a/modelship/infer/transformers/openai/serving_chat.py
+++ b/modelship/infer/transformers/openai/serving_chat.py
@@ -39,17 +39,22 @@ class OpenAIServingChat(OpenAIServing):
         model_name: str,
         config: TransformersConfig,
         capabilities: TransformersCapabilities,
+        tool_call_parser: str | None,
     ):
         self.pipeline = pipeline
         self.model_name = model_name
         self.config = config
         self.capabilities = capabilities
+        self.tool_call_parser = tool_call_parser
         assert pipeline.tokenizer is not None, "text-generation pipeline must have a tokenizer"
         self.tokenizer: PreTrainedTokenizerBase = pipeline.tokenizer
         self._lock = asyncio.Lock()
         # Validate the configured parser at startup so misconfiguration surfaces
-        # before the first request rather than mid-generation.
-        get_parser(self.config.tool_call_parser)
+        # before the first request rather than mid-generation. None means
+        # auto-detection found no usable parser; tool calls in requests will be
+        # dropped with a warning at request time.
+        if tool_call_parser is not None:
+            get_parser(tool_call_parser)
 
     async def warmup(self) -> None:
         logger.info("Warming up chat model: %s", self.model_name)
@@ -81,6 +86,14 @@ class OpenAIServingChat(OpenAIServing):
             return create_error_response(e)
 
         tools = resolve_tools_for_request(request.tools, request.tool_choice)
+        if tools and self.tool_call_parser is None:
+            logger.warning(
+                "chat request %s asks for %d tool(s) but model %r has no usable tool-call parser; ignoring tools",
+                request_id,
+                len(tools),
+                self.model_name,
+            )
+            tools = None
 
         max_tokens = request.max_tokens
         if max_tokens is None and request.max_completion_tokens is not None:
@@ -137,7 +150,9 @@ class OpenAIServingChat(OpenAIServing):
         return response
 
     def _parse_tool_calls(self, text: str) -> ParsedToolCalls:
-        return get_parser(self.config.tool_call_parser).parse(text)
+        parser_name = self.tool_call_parser
+        assert parser_name is not None  # guarded by the tools-drop in create_chat_completion
+        return get_parser(parser_name).parse(text)
 
     @staticmethod
     def _finish_reason(parsed: ParsedToolCalls, completion_tokens: int, max_tokens: int | None) -> str:
@@ -214,8 +229,10 @@ class OpenAIServingChat(OpenAIServing):
             kwargs["max_new_tokens"] = max_tokens
 
         if tools:
+            parser_name = self.tool_call_parser
+            assert parser_name is not None  # guarded by the tools-drop in create_chat_completion
             prompt: Any = self._render_prompt(messages, tools)
-            tool_call_streamer: ToolCallStreamer | None = ToolCallStreamer(get_parser(self.config.tool_call_parser))
+            tool_call_streamer: ToolCallStreamer | None = ToolCallStreamer(get_parser(parser_name))
         else:
             prompt = messages
             tool_call_streamer = None

--- a/modelship/infer/transformers/transformers_infer.py
+++ b/modelship/infer/transformers/transformers_infer.py
@@ -84,7 +84,10 @@ class TransformersInfer(BaseInfer):
             capabilities = TransformersCapabilities.detect(pipe)
             if capabilities.supports_image:
                 logger.info("Multimodal (vision) capability detected for model: %s", self.model_config.name)
-            self.serving_chat = OpenAIServingChat(pipe, self.model_config.name, self.config, capabilities)
+            tool_call_parser = self.config.tool_call_parser or self.model_config._resolved_tool_call_parser
+            self.serving_chat = OpenAIServingChat(
+                pipe, self.model_config.name, self.config, capabilities, tool_call_parser
+            )
             self._serving.append(self.serving_chat)
 
         elif usecase is ModelUsecase.embed:

--- a/modelship/openai/tool_calling/utils.py
+++ b/modelship/openai/tool_calling/utils.py
@@ -1,0 +1,63 @@
+"""Utility functions for tool-calling.
+
+Includes logic for detecting tool-calling support and format from model
+configuration by inspecting ``tokenizer_config.json``.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from modelship.logging import get_logger
+
+logger = get_logger("tool_calling.utils")
+
+
+def detect_tool_parser(model_path: str | Path) -> str | None:
+    """Return the name of the tool-call parser required by the model or None.
+
+    Inspects ``tokenizer_config.json`` in ``model_path``.
+
+    - Returns "hermes" if `<tool_call>` markers are found.
+    - Returns "mistral" if `[TOOL_CALLS]` markers are found.
+    - Returns "llama3_json" if `<|python_tag|>` markers are found.
+    - Returns "unknown" if tool logic is found but format markers are not recognized.
+    """
+    path = Path(model_path)
+    # If model_path is a file (e.g. a GGUF), the config is in its parent dir.
+    config_dir = path.parent if path.is_file() else path
+    config_path = config_dir / "tokenizer_config.json"
+
+    if not config_path.exists():
+        return None
+
+    try:
+        with open(config_path) as f:
+            config = json.load(f)
+    except Exception as e:
+        logger.warning("Failed to load %s for tool detection: %s", config_path, e)
+        return None
+
+    template = config.get("chat_template")
+    if not template or not isinstance(template, str):
+        return None
+
+    # 1. Check for tool-calling support at all.
+    # Most templates use `tools` or `tool_calls` variables in Jinja2 logic.
+    if "tools" not in template and "tool_calls" not in template:
+        return None
+
+    # 2. Identify the specific format/parser.
+    if "<tool_call>" in template:
+        return "hermes"
+
+    if "[TOOL_CALLS]" in template:
+        return "mistral"
+
+    if "<|python_tag|>" in template or "<|eom_id|>" in template:
+        # Llama 3.1+ specific markers.
+        return "llama3_json"
+
+    # Tool logic found but no recognized markers.
+    return "unknown"

--- a/modelship/openai/tool_calling/utils.py
+++ b/modelship/openai/tool_calling/utils.py
@@ -33,9 +33,9 @@ def detect_tool_parser(model_path: str | Path) -> str | None:
         return None
 
     try:
-        with open(config_path) as f:
+        with open(config_path, encoding="utf-8") as f:
             config = json.load(f)
-    except Exception as e:
+    except (OSError, json.JSONDecodeError) as e:
         logger.warning("Failed to load %s for tool detection: %s", config_path, e)
         return None
 

--- a/mship_deploy.py
+++ b/mship_deploy.py
@@ -36,6 +36,7 @@ from modelship.deploy.config import (  # noqa: E402
     load_yaml_config,
     resolve_all_model_sources,
     resolve_all_plugin_wheels,
+    resolve_all_tool_parsers,
 )
 from modelship.deploy.serve_utils import (  # noqa: E402
     connect_ray,
@@ -118,6 +119,7 @@ def main(argv: list[str] | None = None) -> None:
         # missing-file errors here instead of inside an UNHEALTHY replica. Runs
         # AFTER the gateway is up so /health and /readyz answer during downloads.
         resolve_all_model_sources(yml_conf)
+        resolve_all_tool_parsers(yml_conf)
 
         gateway_handle = serve.get_app_handle(gateway_name)
         seed_expected_models(gateway_handle, yml_conf)

--- a/tests/test_transformers_chat_tools.py
+++ b/tests/test_transformers_chat_tools.py
@@ -46,13 +46,14 @@ class _FakePipeline:
         return [{"generated_text": self.generated_text}]
 
 
-def _make_serving(generated: str) -> tuple[OpenAIServingChat, _FakePipeline]:
+def _make_serving(generated: str, tool_call_parser: str | None = "hermes") -> tuple[OpenAIServingChat, _FakePipeline]:
     pipe = _FakePipeline(generated)
     serving = OpenAIServingChat(
         pipeline=pipe,  # type: ignore[arg-type]
         model_name="test-model",
         config=TransformersConfig(),
         capabilities=TransformersCapabilities(supports_image=False, supports_audio=False),
+        tool_call_parser=tool_call_parser,
     )
     return serving, pipe
 
@@ -158,6 +159,7 @@ async def test_unknown_parser_at_init_raises():
         OpenAIServingChat(
             pipeline=pipe,  # type: ignore[arg-type]
             model_name="test-model",
-            config=TransformersConfig(tool_call_parser="not-a-real-parser"),
+            config=TransformersConfig(),
             capabilities=TransformersCapabilities(supports_image=False, supports_audio=False),
+            tool_call_parser="not-a-real-parser",
         )


### PR DESCRIPTION
Inspect each generative transformers model's tokenizer_config.json chat template at startup, pick a registered tool-call parser when one matches, and fall back to disabling tool calling (with a warning) when the format is unknown or no parser is registered. Explicit `transformers_config.tool_call_parser` still wins and is validated against the registry at startup so misconfiguration fails fast.

Resolved parser is stored on a `_resolved_tool_call_parser` PrivateAttr so the deployment fingerprint stays stable. Requests that ask for tools against a model with no parser have their `tools` dropped with a warning instead of erroring.


