### PR TITLE
feat: llama_cpp tool calling + cross-loader auto-detection

### DIFF
--- a/modelship/deploy/config.py
+++ b/modelship/deploy/config.py
@@ -8,14 +8,35 @@ from modelship.infer.infer_config import ModelLoader, ModelshipConfig, ModelUsec
 from modelship.infer.model_resolver import resolve_model_source
 from modelship.logging import get_logger
 from modelship.openai.tool_calling.registry import available_parsers
-from modelship.openai.tool_calling.utils import detect_tool_parser
-
-# Loaders that emit raw model text and rely on the tool_calling registry to
-# parse tool calls. vLLM and llama.cpp have native tool-call handling and are
-# excluded; diffusers/custom don't do chat completion through this path.
-_LOADERS_USING_TEXT_PARSER = frozenset({ModelLoader.transformers})
+from modelship.openai.tool_calling.utils import classify_template, read_chat_template
 
 logger = get_logger("startup")
+
+
+def _is_explicit_tool_opt_out(cfg) -> bool:
+    """Loader-specific explicit "no auto-detection" signal.
+
+    Auto-detection is skipped when the user has signalled an explicit choice
+    that excludes our parser:
+
+    - vllm: ``enable_auto_tool_choice: false`` — user disabled tool calling.
+    - transformers: ``tool_calls_enabled: false`` — user disabled tool calling.
+    - llama_cpp: ``tool_calls_enabled: false`` (disabled) OR ``chat_format`` set
+      (user wants llama-cpp-python's own function-calling handler — we must not
+      also wire up our parser).
+    """
+    if cfg.loader == ModelLoader.vllm:
+        return cfg.vllm_engine_kwargs is not None and cfg.vllm_engine_kwargs.enable_auto_tool_choice is False
+    if cfg.loader == ModelLoader.transformers:
+        return cfg.transformers_config is not None and cfg.transformers_config.tool_calls_enabled is False
+    if cfg.loader == ModelLoader.llama_cpp:
+        if cfg.llama_cpp_config is None:
+            return False
+        if cfg.llama_cpp_config.tool_calls_enabled is False:
+            return True
+        if cfg.llama_cpp_config.chat_format is not None:
+            return True
+    return False
 
 
 def resolve_config_path(arg_path: str | None) -> str:
@@ -69,17 +90,23 @@ def resolve_all_model_sources(yml_conf: ModelshipConfig) -> None:
 
 
 def resolve_all_tool_parsers(yml_conf: ModelshipConfig) -> None:
-    """Pre-flight: pick a tool-call parser for each text-parser loader model.
+    """Pre-flight: auto-detect a tool-call parser for each generative model.
 
     Runs after `resolve_all_model_sources` so `_resolved_path` is populated.
-    Inspects the model's `tokenizer_config.json` chat template and stores the
-    result on `_resolved_tool_call_parser`. Effective parser at request time
-    is `transformers_config.tool_call_parser or _resolved_tool_call_parser`,
-    so an explicit user setting always wins.
+    Reads the model's chat template once (from GGUF metadata or
+    `tokenizer_config.json`), stores it on `_resolved_chat_template`, and
+    classifies it onto `_resolved_tool_call_parser`. Per-loader code reads
+    these as a fallback when the loader-specific parser/format field is
+    unset, so an explicit user setting always wins.
 
-    Behavior:
-    - Explicit parser configured: validated against the registry; raises if
-      the name is unknown so misconfiguration fails startup, not mid-request.
+    Auto-detection runs for vllm, transformers, and llama_cpp. diffusers has
+    no chat path; custom is plugin-managed.
+
+    Behavior per model:
+    - Loader-specific opt-out (see `_is_explicit_tool_opt_out`): skipped.
+    - Explicit parser name configured (vllm/transformers `tool_call_parser`):
+      validated against the registry; raises if unknown so misconfiguration
+      fails startup, not mid-request.
     - Auto-detected, registered: stored on `_resolved_tool_call_parser`.
     - Auto-detected, known format but no parser implemented yet: warn, leave
       unset — tool calling will be disabled for this model.
@@ -90,12 +117,20 @@ def resolve_all_tool_parsers(yml_conf: ModelshipConfig) -> None:
     """
     registered = set(available_parsers())
     for cfg in yml_conf.models:
-        if cfg.loader not in _LOADERS_USING_TEXT_PARSER:
+        if cfg.loader not in (ModelLoader.vllm, ModelLoader.transformers, ModelLoader.llama_cpp):
             continue
         if cfg.usecase != ModelUsecase.generate:
             continue
+        if _is_explicit_tool_opt_out(cfg):
+            logger.info("Tool-call auto-detection skipped for '%s' (explicit opt-out).", cfg.name)
+            continue
 
-        explicit = cfg.transformers_config.tool_call_parser if cfg.transformers_config else None
+        explicit = None
+        if cfg.loader == ModelLoader.transformers and cfg.transformers_config:
+            explicit = cfg.transformers_config.tool_call_parser
+        elif cfg.loader == ModelLoader.vllm and cfg.vllm_engine_kwargs:
+            explicit = cfg.vllm_engine_kwargs.tool_call_parser
+
         if explicit is not None:
             if explicit not in registered:
                 raise ValueError(
@@ -106,7 +141,12 @@ def resolve_all_tool_parsers(yml_conf: ModelshipConfig) -> None:
             continue
 
         assert cfg._resolved_path is not None  # populated by resolve_all_model_sources
-        detected = detect_tool_parser(cfg._resolved_path)
+        template = read_chat_template(cfg._resolved_path)
+        if template is None:
+            logger.info("No chat template found for '%s'; tool-call detection skipped.", cfg.name)
+            continue
+        cfg._resolved_chat_template = template
+        detected = classify_template(template)
         if detected is None:
             logger.info("No tool-calling support detected for '%s'; tools disabled.", cfg.name)
             continue

--- a/modelship/infer/infer_config.py
+++ b/modelship/infer/infer_config.py
@@ -68,6 +68,9 @@ class TransformersConfig(BaseModel):
     model_kwargs: dict[str, Any] = Field(default_factory=dict)
     pipeline_kwargs: dict[str, Any] = Field(default_factory=dict)
     tool_call_parser: str | None = None
+    # Explicit opt-out from auto-detected tool calling. None -> auto-detect; False -> disabled
+    # even if the model's chat template advertises tools; True is a no-op (auto runs anyway).
+    tool_calls_enabled: bool | None = None
 
 
 class DiffusersConfig(BaseModel):
@@ -82,6 +85,7 @@ class LlamaCppConfig(BaseModel):
     n_batch: int = 512
     chat_format: str | None = None
     model_kwargs: dict[str, Any] = Field(default_factory=dict)
+    tool_calls_enabled: bool | None = None
 
 
 class ModelshipModelConfig(BaseModel):
@@ -101,6 +105,7 @@ class ModelshipModelConfig(BaseModel):
 
     _resolved_path: str | None = PrivateAttr(default=None)
     _resolved_tool_call_parser: str | None = PrivateAttr(default=None)
+    _resolved_chat_template: str | None = PrivateAttr(default=None)
 
     @model_validator(mode="after")
     def check_custom_requires_plugin(self):

--- a/modelship/infer/llama_cpp/llama_cpp_infer.py
+++ b/modelship/infer/llama_cpp/llama_cpp_infer.py
@@ -9,6 +9,7 @@ from modelship.infer.infer_config import LlamaCppConfig, ModelshipModelConfig, M
 from modelship.infer.llama_cpp.capabilities import LlamaCppCapabilities
 from modelship.infer.llama_cpp.openai.serving_chat import OpenAIServingChat
 from modelship.infer.llama_cpp.openai.serving_embedding import OpenAIServingEmbedding
+from modelship.infer.llama_cpp.utils import build_tool_call_renderer
 from modelship.logging import get_logger
 from modelship.openai.protocol import (
     ChatCompletionRequest,
@@ -94,7 +95,20 @@ class LlamaCppInfer(BaseInfer):
             logger.info("Multimodal (vision) capability detected for model: %s", self.model_config.name)
 
         if self.model_config.usecase == ModelUsecase.generate:
-            self.serving_chat = OpenAIServingChat(self.llamacpp, self.model_config.name, capabilities)
+            parser_name = self.model_config._resolved_tool_call_parser
+            renderer = None
+            if parser_name is not None:
+                # Driver invariant: parser_name is only set when the template was
+                # successfully read, so _resolved_chat_template is non-None here.
+                assert self.model_config._resolved_chat_template is not None
+                renderer = build_tool_call_renderer(self.llamacpp, self.model_config._resolved_chat_template)
+            self.serving_chat = OpenAIServingChat(
+                self.llamacpp,
+                self.model_config.name,
+                capabilities,
+                tool_call_parser=parser_name,
+                renderer=renderer,
+            )
         elif self.model_config.usecase == ModelUsecase.embed:
             self.serving_embedding = OpenAIServingEmbedding(self.llamacpp, self.model_config.name)
 

--- a/modelship/infer/llama_cpp/openai/serving_chat.py
+++ b/modelship/infer/llama_cpp/openai/serving_chat.py
@@ -1,14 +1,16 @@
 import asyncio
 import inspect
 import json
-from collections.abc import AsyncGenerator, Iterator
-from typing import cast
+import time
+from collections.abc import AsyncGenerator, AsyncIterator, Iterator
+from typing import Any, cast
 
 from llama_cpp import Llama
 
 from modelship.infer.base_serving import OpenAIServing
 from modelship.infer.infer_config import RawRequestProxy
 from modelship.infer.llama_cpp.capabilities import LlamaCppCapabilities
+from modelship.infer.llama_cpp.utils import LlamaCppToolCallRenderer
 from modelship.logging import get_logger
 from modelship.openai.chat_utils import UnsupportedContentError, normalize_chat_messages
 from modelship.openai.protocol import (
@@ -16,6 +18,12 @@ from modelship.openai.protocol import (
     ChatCompletionResponse,
     ErrorResponse,
     create_error_response,
+)
+from modelship.openai.tool_calling import (
+    build_chat_completion_response,
+    get_parser,
+    resolve_tools_for_request,
+    stream_chat_completion,
 )
 from modelship.utils import base_request_id
 
@@ -25,12 +33,26 @@ logger = get_logger("infer.llama_cpp.chat")
 class OpenAIServingChat(OpenAIServing):
     request_id_prefix = "chat"
 
-    def __init__(self, llama: Llama, model_name: str, capabilities: LlamaCppCapabilities):
+    def __init__(
+        self,
+        llama: Llama,
+        model_name: str,
+        capabilities: LlamaCppCapabilities,
+        tool_call_parser: str | None = None,
+        renderer: LlamaCppToolCallRenderer | None = None,
+    ):
         self._llama = llama
         self.model_name = model_name
         self._caps = capabilities
         self._lock = asyncio.Lock()
         self._accepted_params = set(inspect.signature(llama.create_chat_completion).parameters)
+        self._completion_accepted_params = set(inspect.signature(llama.create_completion).parameters)
+        self.tool_call_parser = tool_call_parser
+        self._renderer = renderer
+        if tool_call_parser is not None:
+            assert renderer is not None, "renderer is required when tool_call_parser is set"
+            # Validate at startup so misconfiguration surfaces before the first request.
+            get_parser(tool_call_parser)
 
     async def warmup(self) -> None:
         logger.info("Warming up llama.cpp chat model: %s", self.model_name)
@@ -58,6 +80,32 @@ class OpenAIServingChat(OpenAIServing):
             logger.warning("chat request %s rejected: %s", request_id, e)
             return create_error_response(e)
 
+        tools = resolve_tools_for_request(request.tools, request.tool_choice)
+        if tools and self.tool_call_parser is None:
+            logger.warning(
+                "chat request %s asks for %d tool(s) but model %r has no usable tool-call parser; ignoring tools",
+                request_id,
+                len(tools),
+                self.model_name,
+            )
+            tools = None
+
+        if tools and self.tool_call_parser is not None:
+            return await self._handle_with_tools(request, request_id, messages, tools)
+        return await self._handle_without_tools(request, request_id, messages)
+
+    async def _handle_without_tools(
+        self,
+        request: ChatCompletionRequest,
+        request_id: str,
+        messages: list[dict],
+    ) -> ErrorResponse | ChatCompletionResponse | AsyncGenerator[str, None]:
+        """Pass-through to ``llama.create_chat_completion`` — no parser involved.
+
+        This path is used when no tools are requested, or when the user
+        configured ``chat_format`` (in which case our parser is intentionally
+        bypassed and llama-cpp-python handles tool calling itself if at all).
+        """
         kwargs = self._build_kwargs(request, messages)
         loop = asyncio.get_event_loop()
         llama = self._llama
@@ -92,6 +140,119 @@ class OpenAIServingChat(OpenAIServing):
                 logger.warning("llama_cpp chat inference failed: %s", e)
                 return create_error_response(e)
 
+    async def _handle_with_tools(
+        self,
+        request: ChatCompletionRequest,
+        request_id: str,
+        messages: list[dict],
+        tools: list[dict[str, Any]],
+    ) -> ErrorResponse | ChatCompletionResponse | AsyncGenerator[str, None]:
+        """Render prompt with tools, run raw completion, parse via shared streamer.
+
+        Bypasses ``llama.create_chat_completion`` because that re-runs llama-cpp's
+        own chat templating (which produces tokens conditioned on a different
+        template than the one our parser expects).
+        """
+        assert self._renderer is not None  # guarded at __init__
+        assert self.tool_call_parser is not None
+        parser_name = self.tool_call_parser
+        renderer = self._renderer
+
+        try:
+            prompt = renderer.render(messages, tools)
+        except Exception as e:
+            logger.warning("llama_cpp tool-call prompt rendering failed for %s: %s", request_id, e)
+            return create_error_response(e)
+
+        max_tokens = request.max_tokens
+        if max_tokens is None and request.max_completion_tokens is not None:
+            max_tokens = request.max_completion_tokens
+
+        completion_kwargs = self._build_completion_kwargs(request, prompt)
+        prompt_tokens = renderer.count_tokens(prompt)
+        loop = asyncio.get_event_loop()
+        llama = self._llama
+
+        if request.stream:
+            include_usage = bool(request.stream_options and request.stream_options.include_usage)
+            return self._locked_stream_with_tools(
+                request_id=request_id,
+                completion_kwargs=completion_kwargs,
+                parser_name=parser_name,
+                prompt_tokens=prompt_tokens,
+                max_tokens=max_tokens,
+                include_usage=include_usage,
+            )
+
+        async with self._lock:
+            try:
+                raw = await loop.run_in_executor(
+                    None,
+                    lambda: llama.create_completion(**completion_kwargs, stream=False),  # type: ignore[arg-type]
+                )
+                result = cast(dict, raw)
+            except Exception as e:
+                logger.warning("llama_cpp tool-call inference failed for %s: %s", request_id, e)
+                return create_error_response(e)
+
+        completion_text = result["choices"][0]["text"] if result.get("choices") else ""
+        usage = result.get("usage") or {}
+        completion_tokens = int(usage.get("completion_tokens") or renderer.count_tokens(completion_text))
+
+        return build_chat_completion_response(
+            request_id=request_id,
+            model_name=self.model_name,
+            text=completion_text,
+            parser_name=parser_name,
+            prompt_tokens=int(usage.get("prompt_tokens") or prompt_tokens),
+            completion_tokens=completion_tokens,
+            max_tokens=max_tokens,
+            created=int(time.time()),
+        )
+
+    async def _locked_stream_with_tools(
+        self,
+        *,
+        request_id: str,
+        completion_kwargs: dict,
+        parser_name: str,
+        prompt_tokens: int,
+        max_tokens: int | None,
+        include_usage: bool,
+    ) -> AsyncGenerator[str, None]:
+        assert self._renderer is not None
+        renderer = self._renderer
+        async with self._lock:
+            async for chunk in stream_chat_completion(
+                request_id=request_id,
+                model_name=self.model_name,
+                text_chunks=self._raw_text_chunks(completion_kwargs),
+                parser_name=parser_name,
+                count_tokens=renderer.count_tokens,
+                prompt_tokens=prompt_tokens,
+                max_tokens=max_tokens,
+                include_usage=include_usage,
+                created=int(time.time()),
+            ):
+                yield chunk
+
+    async def _raw_text_chunks(self, completion_kwargs: dict) -> AsyncIterator[str]:
+        """Drive ``llama.create_completion(stream=True)`` and yield text pieces."""
+        loop = asyncio.get_event_loop()
+        llama = self._llama
+        raw = await loop.run_in_executor(
+            None,
+            lambda: llama.create_completion(**completion_kwargs, stream=True),  # type: ignore[arg-type]
+        )
+        iterator = cast(Iterator[dict], raw)
+        while True:
+            chunk = await loop.run_in_executor(None, lambda: next(iterator, None))
+            if chunk is None:
+                return
+            text = (chunk.get("choices") or [{}])[0].get("text") or ""
+            if text:
+                yield text
+
     def _build_kwargs(self, request: ChatCompletionRequest, messages: list[dict]) -> dict:
         params = request.model_dump(exclude_none=True)
         params["messages"] = messages
@@ -113,3 +274,16 @@ class OpenAIServingChat(OpenAIServing):
                 dropped,
             )
         return kwargs
+
+    def _build_completion_kwargs(self, request: ChatCompletionRequest, prompt: str) -> dict:
+        params = request.model_dump(exclude_none=True)
+        params["prompt"] = prompt
+        if "max_tokens" not in params and "max_completion_tokens" in params:
+            params["max_tokens"] = params["max_completion_tokens"]
+        # These are consumed by our renderer/parser, not by `create_completion`.
+        for k in ("messages", "tools", "tool_choice", "stream", "stream_options"):
+            params.pop(k, None)
+        for k in ("logprobs", "top_logprobs"):
+            params.pop(k, None)
+
+        return {k: v for k, v in params.items() if k in self._completion_accepted_params}

--- a/modelship/infer/llama_cpp/utils.py
+++ b/modelship/infer/llama_cpp/utils.py
@@ -1,0 +1,76 @@
+"""Utilities for the llama_cpp loader."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+from modelship.logging import get_logger
+
+if TYPE_CHECKING:
+    from llama_cpp import Llama
+
+logger = get_logger("infer.llama_cpp.utils")
+
+
+@dataclass
+class LlamaCppToolCallRenderer:
+    """Renders tool-aware chat prompts and counts tokens for a llama_cpp model.
+
+    The chat template is pre-resolved on the driver (``_resolved_chat_template``)
+    so detection and rendering see the exact same string — no chance of drift
+    if the GGUF reader and llama-cpp-python's metadata loader interpret the
+    field differently.
+
+    Rendering uses ``transformers.utils.chat_template_utils.render_jinja_template``
+    so we inherit the polyfills HF templates rely on (``raise_exception``,
+    ``tojson``, ``strftime_now``, ``ChainableUndefined``).
+
+    Token counting goes through ``Llama.tokenize`` so it reflects the actual
+    GGUF vocab — no second tokenizer to keep in sync.
+    """
+
+    chat_template: str
+    bos_token: str
+    eos_token: str
+    _llama: Llama
+
+    def render(self, messages: list[dict], tools: list[dict] | None) -> str:
+        from transformers.utils.chat_template_utils import render_jinja_template
+
+        rendered, _ = render_jinja_template(
+            conversations=[messages],
+            tools=tools,  # type: ignore[arg-type]  # HF types it as list[dict | Callable]; we only pass dicts
+            chat_template=self.chat_template,
+            add_generation_prompt=True,
+            bos_token=self.bos_token,
+            eos_token=self.eos_token,
+        )
+        return rendered[0]
+
+    def count_tokens(self, text: str) -> int:
+        try:
+            tokens = self._llama.tokenize(text.encode("utf-8"), add_bos=False, special=True)
+            return len(tokens)
+        except Exception as e:
+            logger.warning("llama_cpp tokenize failed (%s); returning 0", e)
+            return 0
+
+
+def build_tool_call_renderer(llama: Llama, chat_template: str) -> LlamaCppToolCallRenderer:
+    """Build a renderer from a loaded ``Llama`` and the pre-resolved template."""
+    return LlamaCppToolCallRenderer(
+        chat_template=chat_template,
+        bos_token=_detokenize_special(llama, llama.token_bos()),
+        eos_token=_detokenize_special(llama, llama.token_eos()),
+        _llama=llama,
+    )
+
+
+def _detokenize_special(llama: Llama, token_id: int) -> str:
+    if token_id < 0:
+        return ""
+    try:
+        return llama.detokenize([token_id], special=True).decode("utf-8", errors="replace")
+    except Exception:
+        return ""

--- a/modelship/infer/transformers/openai/serving_chat.py
+++ b/modelship/infer/transformers/openai/serving_chat.py
@@ -1,7 +1,6 @@
 import asyncio
-import json
 import time
-from collections.abc import AsyncGenerator
+from collections.abc import AsyncGenerator, AsyncIterator
 from threading import Thread
 from typing import Any
 
@@ -15,16 +14,15 @@ from modelship.openai.chat_utils import UnsupportedContentError, normalize_chat_
 from modelship.openai.protocol import (
     ChatCompletionRequest,
     ChatCompletionResponse,
-    ChatCompletionResponseChoice,
-    ChatCompletionResponseStreamChoice,
-    ChatCompletionStreamResponse,
-    ChatMessage,
-    DeltaMessage,
     ErrorResponse,
-    UsageInfo,
     create_error_response,
 )
-from modelship.openai.tool_calling import ParsedToolCalls, ToolCallStreamer, get_parser, resolve_tools_for_request
+from modelship.openai.tool_calling import (
+    build_chat_completion_response,
+    get_parser,
+    resolve_tools_for_request,
+    stream_chat_completion,
+)
 from modelship.utils import base_request_id
 
 logger = get_logger("infer.transformers.chat")
@@ -99,9 +97,13 @@ class OpenAIServingChat(OpenAIServing):
         if max_tokens is None and request.max_completion_tokens is not None:
             max_tokens = request.max_completion_tokens
 
+        parser_name = self.tool_call_parser if tools else None
+
         if request.stream:
             include_usage = bool(request.stream_options and request.stream_options.include_usage)
-            return self._locked_stream(request_id, messages, tools, max_tokens, include_usage=include_usage)
+            return self._locked_stream(
+                request_id, messages, tools, max_tokens, parser_name=parser_name, include_usage=include_usage
+            )
 
         async with self._lock:
             try:
@@ -114,28 +116,14 @@ class OpenAIServingChat(OpenAIServing):
         completion_text = self._extract_completion_text(result)
         completion_tokens = len(self.tokenizer.encode(completion_text, add_special_tokens=False))
 
-        parsed = self._parse_tool_calls(completion_text) if tools else ParsedToolCalls(completion_text, [])
-        finish_reason = self._finish_reason(parsed, completion_tokens, max_tokens)
-
-        response = ChatCompletionResponse(
-            id=request_id,
-            model=self.model_name,
-            choices=[
-                ChatCompletionResponseChoice(
-                    index=0,
-                    message=ChatMessage(
-                        role="assistant",
-                        content=parsed.content,
-                        tool_calls=parsed.tool_calls,
-                    ),
-                    finish_reason=finish_reason,
-                )
-            ],
-            usage=UsageInfo(
-                prompt_tokens=prompt_tokens,
-                completion_tokens=completion_tokens,
-                total_tokens=prompt_tokens + completion_tokens,
-            ),
+        response = build_chat_completion_response(
+            request_id=request_id,
+            model_name=self.model_name,
+            text=completion_text,
+            parser_name=parser_name,
+            prompt_tokens=prompt_tokens,
+            completion_tokens=completion_tokens,
+            max_tokens=max_tokens,
             created=int(time.time()),
         )
         logger.log(
@@ -143,24 +131,11 @@ class OpenAIServingChat(OpenAIServing):
             "chat response %s: text=%r, tool_calls=%d, prompt_tokens=%d, completion_tokens=%d",
             request_id,
             completion_text,
-            len(parsed.tool_calls),
+            len(response.choices[0].message.tool_calls),
             prompt_tokens,
             completion_tokens,
         )
         return response
-
-    def _parse_tool_calls(self, text: str) -> ParsedToolCalls:
-        parser_name = self.tool_call_parser
-        assert parser_name is not None  # guarded by the tools-drop in create_chat_completion
-        return get_parser(parser_name).parse(text)
-
-    @staticmethod
-    def _finish_reason(parsed: ParsedToolCalls, completion_tokens: int, max_tokens: int | None) -> str:
-        if parsed.has_tool_calls:
-            return "tool_calls"
-        if max_tokens is not None and completion_tokens >= max_tokens:
-            return "length"
-        return "stop"
 
     @staticmethod
     def _extract_completion_text(result: list) -> str:
@@ -206,10 +181,13 @@ class OpenAIServingChat(OpenAIServing):
         tools: list[dict[str, Any]] | None,
         max_tokens: int | None,
         *,
+        parser_name: str | None,
         include_usage: bool,
     ) -> AsyncGenerator[str, None]:
         async with self._lock:
-            async for chunk in self._stream(request_id, messages, tools, max_tokens, include_usage=include_usage):
+            async for chunk in self._stream(
+                request_id, messages, tools, max_tokens, parser_name=parser_name, include_usage=include_usage
+            ):
                 yield chunk
 
     async def _stream(
@@ -219,9 +197,9 @@ class OpenAIServingChat(OpenAIServing):
         tools: list[dict[str, Any]] | None,
         max_tokens: int | None,
         *,
+        parser_name: str | None,
         include_usage: bool,
     ) -> AsyncGenerator[str, None]:
-        created_time = int(time.time())
         streamer = TextIteratorStreamer(self.tokenizer, skip_prompt=True, skip_special_tokens=True)  # type: ignore[arg-type]
 
         kwargs = {**self.config.pipeline_kwargs}
@@ -229,106 +207,44 @@ class OpenAIServingChat(OpenAIServing):
             kwargs["max_new_tokens"] = max_tokens
 
         if tools:
-            parser_name = self.tool_call_parser
-            assert parser_name is not None  # guarded by the tools-drop in create_chat_completion
             prompt: Any = self._render_prompt(messages, tools)
-            tool_call_streamer: ToolCallStreamer | None = ToolCallStreamer(get_parser(parser_name))
         else:
             prompt = messages
-            tool_call_streamer = None
 
         thread = Thread(
             target=self.pipeline,
             args=(prompt,),
-            kwargs={
-                "streamer": streamer,
-                "return_full_text": False,
-                **kwargs,
-            },
+            kwargs={"streamer": streamer, "return_full_text": False, **kwargs},
         )
         thread.start()
 
-        accumulated: list[str] = []
-        accumulated_str = ""
         try:
-            # Per OpenAI spec, the first delta carries `role` only.
-            yield self._delta_chunk(request_id, DeltaMessage(role="assistant"), created_time)
-
-            for text_chunk in streamer:
-                if not text_chunk:
-                    continue
-                accumulated.append(text_chunk)
-                accumulated_str += text_chunk
-                if tool_call_streamer is None:
-                    yield self._delta_chunk(request_id, DeltaMessage(content=text_chunk), created_time)
-                    await asyncio.sleep(0)
-                    continue
-                # Re-parse the cumulative text and emit any new content / tool-call
-                # fragments. Bounded held-back tail (length of the start marker) so
-                # the client never sees a half-formed `<tool_call>` opening tag.
-                delta = tool_call_streamer.extract_streaming(accumulated_str)
-                if delta is not None:
-                    yield self._delta_chunk(request_id, delta, created_time)
-                await asyncio.sleep(0)
-
-            if tool_call_streamer is not None:
-                final = tool_call_streamer.finalize()
-                if final is not None:
-                    yield self._delta_chunk(request_id, final, created_time)
-                parsed = tool_call_streamer.result
-            else:
-                parsed = ParsedToolCalls(accumulated_str, [])
-
-            completion_tokens = len(self.tokenizer.encode(accumulated_str, add_special_tokens=False))
-            finish_reason = self._finish_reason(parsed, completion_tokens, max_tokens)
-
-            yield self._encode_chunk(
-                ChatCompletionStreamResponse(
-                    id=request_id,
-                    model=self.model_name,
-                    choices=[
-                        ChatCompletionResponseStreamChoice(
-                            index=0,
-                            delta=DeltaMessage(),
-                            finish_reason=finish_reason,
-                        )
-                    ],
-                    created=created_time,
-                )
-            )
-
-            if include_usage:
-                prompt_tokens = self._count_prompt_tokens(messages, tools)
-                yield self._encode_chunk(
-                    ChatCompletionStreamResponse(
-                        id=request_id,
-                        model=self.model_name,
-                        choices=[],
-                        usage=UsageInfo(
-                            prompt_tokens=prompt_tokens,
-                            completion_tokens=completion_tokens,
-                            total_tokens=prompt_tokens + completion_tokens,
-                        ),
-                        created=created_time,
-                    )
-                )
-
-            yield "data: [DONE]\n\n"
+            async for chunk in stream_chat_completion(
+                request_id=request_id,
+                model_name=self.model_name,
+                text_chunks=_async_iter(streamer),
+                parser_name=parser_name,
+                count_tokens=lambda text: len(self.tokenizer.encode(text, add_special_tokens=False)),
+                prompt_tokens=self._count_prompt_tokens(messages, tools),
+                max_tokens=max_tokens,
+                include_usage=include_usage,
+                created=int(time.time()),
+            ):
+                yield chunk
         finally:
             thread.join()
 
-    def _delta_chunk(self, request_id: str, delta: DeltaMessage, created_time: int) -> str:
-        return self._encode_chunk(
-            ChatCompletionStreamResponse(
-                id=request_id,
-                model=self.model_name,
-                choices=[
-                    ChatCompletionResponseStreamChoice(index=0, delta=delta),
-                ],
-                created=created_time,
-            )
-        )
 
-    @staticmethod
-    def _encode_chunk(chunk: ChatCompletionStreamResponse) -> str:
-        return f"data: {json.dumps(chunk.model_dump(mode='json'))}\n\n"
+async def _async_iter(streamer: TextIteratorStreamer) -> AsyncIterator[str]:
+    """Adapt a synchronous ``TextIteratorStreamer`` to an async iterator.
+
+    HF's streamer is driven by a background thread and exposes a blocking
+    ``__next__``. We hop to a thread per pull so the event loop keeps spinning
+    (cancellation, request-watcher polls) while tokens are produced.
+    """
+    sentinel = object()
+    while True:
+        item = await asyncio.to_thread(next, streamer, sentinel)
+        if item is sentinel:
+            return
+        yield item  # type: ignore[misc]

--- a/modelship/infer/transformers/transformers_infer.py
+++ b/modelship/infer/transformers/transformers_infer.py
@@ -84,7 +84,10 @@ class TransformersInfer(BaseInfer):
             capabilities = TransformersCapabilities.detect(pipe)
             if capabilities.supports_image:
                 logger.info("Multimodal (vision) capability detected for model: %s", self.model_config.name)
-            tool_call_parser = self.config.tool_call_parser or self.model_config._resolved_tool_call_parser
+            if self.config.tool_calls_enabled is False:
+                tool_call_parser = None
+            else:
+                tool_call_parser = self.config.tool_call_parser or self.model_config._resolved_tool_call_parser
             self.serving_chat = OpenAIServingChat(
                 pipe, self.model_config.name, self.config, capabilities, tool_call_parser
             )

--- a/modelship/infer/vllm/vllm_infer.py
+++ b/modelship/infer/vllm/vllm_infer.py
@@ -214,6 +214,20 @@ class VllmInfer(BaseInfer):
             base_model_paths=[BaseModelPath(name=self.model_config.name, model_path=self.vllm_engine_kwargs.model)],
         )
 
+        enable_tools = False
+        tool_parser_name = None
+        if self.vllm_engine_kwargs.enable_auto_tool_choice is True:
+            enable_tools = True
+            tool_parser_name = self.vllm_engine_kwargs.tool_call_parser
+        elif self.vllm_engine_kwargs.enable_auto_tool_choice is not False:  # None implies auto
+            if self.model_config._resolved_tool_call_parser:
+                enable_tools = True
+                tool_parser_name = self.model_config._resolved_tool_call_parser
+            elif self.vllm_engine_kwargs.tool_call_parser:
+                # fallback if user sets parser but leaves enable_auto_tool_choice as None
+                enable_tools = True
+                tool_parser_name = self.vllm_engine_kwargs.tool_call_parser
+
         openai_serving_render = OpenAIServingRender(
             model_config=self.engine.model_config,
             renderer=self.engine.renderer,
@@ -221,10 +235,8 @@ class VllmInfer(BaseInfer):
             request_logger=RequestLogger(max_log_len=None),
             chat_template=None,
             chat_template_content_format=self.vllm_engine_kwargs.chat_template_content_format,
-            enable_auto_tools=self.vllm_engine_kwargs.enable_auto_tool_choice is not None,
-            tool_parser=self.vllm_engine_kwargs.tool_call_parser
-            if self.vllm_engine_kwargs.tool_call_parser is not None
-            else None,
+            enable_auto_tools=enable_tools,
+            tool_parser=tool_parser_name,
         )
 
         return OpenAIServingChat(
@@ -235,10 +247,8 @@ class VllmInfer(BaseInfer):
             request_logger=RequestLogger(max_log_len=None),
             chat_template=None,
             chat_template_content_format=self.vllm_engine_kwargs.chat_template_content_format,
-            enable_auto_tools=self.vllm_engine_kwargs.enable_auto_tool_choice is not None,
-            tool_parser=self.vllm_engine_kwargs.tool_call_parser
-            if self.vllm_engine_kwargs.tool_call_parser is not None
-            else None,
+            enable_auto_tools=enable_tools,
+            tool_parser=tool_parser_name,
         )
 
     async def init_serving_embeding(self) -> ServingEmbedding | None:

--- a/modelship/openai/tool_calling/__init__.py
+++ b/modelship/openai/tool_calling/__init__.py
@@ -10,13 +10,21 @@ chat handler) bypass it.
 from modelship.openai.tool_calling.input import resolve_tools_for_request
 from modelship.openai.tool_calling.parsers import ParsedToolCalls, ToolCallParser, ToolCallStreamer
 from modelship.openai.tool_calling.registry import available_parsers, get_parser, register_parser
+from modelship.openai.tool_calling.streaming import (
+    build_chat_completion_response,
+    finish_reason_for,
+    stream_chat_completion,
+)
 
 __all__ = [
     "ParsedToolCalls",
     "ToolCallParser",
     "ToolCallStreamer",
     "available_parsers",
+    "build_chat_completion_response",
+    "finish_reason_for",
     "get_parser",
     "register_parser",
     "resolve_tools_for_request",
+    "stream_chat_completion",
 ]

--- a/modelship/openai/tool_calling/streaming.py
+++ b/modelship/openai/tool_calling/streaming.py
@@ -1,0 +1,186 @@
+"""Loader-agnostic chat-completion helpers for tool-call-aware responses.
+
+Loaders produce text differently — HF ``Pipeline`` for transformers, raw
+``llama.create_completion`` for llama_cpp, async iterators from plugins — but
+the OpenAI response shapes (streaming and non-streaming) are the same. This
+module owns those shapes plus the `ToolCallStreamer` driving loop, so the
+loaders only deal in plain text.
+
+Two helpers:
+
+- :func:`build_chat_completion_response` — non-streaming. Loader hands in the
+  full completion text and token counts; we parse tool calls and pack the
+  OpenAI ``ChatCompletionResponse``.
+- :func:`stream_chat_completion` — streaming. Loader hands in an
+  ``AsyncIterator[str]`` of new text pieces; we emit the SSE byte stream.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from collections.abc import AsyncIterator, Callable
+
+from modelship.openai.protocol import (
+    ChatCompletionResponse,
+    ChatCompletionResponseChoice,
+    ChatCompletionResponseStreamChoice,
+    ChatCompletionStreamResponse,
+    ChatMessage,
+    DeltaMessage,
+    UsageInfo,
+)
+from modelship.openai.tool_calling.parsers import ParsedToolCalls, ToolCallStreamer
+from modelship.openai.tool_calling.registry import get_parser
+
+
+def finish_reason_for(parsed: ParsedToolCalls, completion_tokens: int, max_tokens: int | None) -> str:
+    """Compute the OpenAI ``finish_reason`` for a chat completion."""
+    if parsed.has_tool_calls:
+        return "tool_calls"
+    if max_tokens is not None and completion_tokens >= max_tokens:
+        return "length"
+    return "stop"
+
+
+def build_chat_completion_response(
+    *,
+    request_id: str,
+    model_name: str,
+    text: str,
+    parser_name: str | None,
+    prompt_tokens: int,
+    completion_tokens: int,
+    max_tokens: int | None,
+    created: int,
+) -> ChatCompletionResponse:
+    """Parse ``text`` and pack it into an OpenAI ``ChatCompletionResponse``.
+
+    Non-streaming counterpart of :func:`stream_chat_completion`. When
+    ``parser_name`` is ``None``, ``text`` becomes the message content as-is
+    with no tool-call extraction.
+    """
+    parsed = get_parser(parser_name).parse(text) if parser_name else ParsedToolCalls(text, [])
+    finish_reason = finish_reason_for(parsed, completion_tokens, max_tokens)
+    return ChatCompletionResponse(
+        id=request_id,
+        model=model_name,
+        choices=[
+            ChatCompletionResponseChoice(
+                index=0,
+                message=ChatMessage(
+                    role="assistant",
+                    content=parsed.content,
+                    tool_calls=parsed.tool_calls,
+                ),
+                finish_reason=finish_reason,
+            )
+        ],
+        usage=UsageInfo(
+            prompt_tokens=prompt_tokens,
+            completion_tokens=completion_tokens,
+            total_tokens=prompt_tokens + completion_tokens,
+        ),
+        created=created,
+    )
+
+
+async def stream_chat_completion(
+    *,
+    request_id: str,
+    model_name: str,
+    text_chunks: AsyncIterator[str],
+    parser_name: str | None,
+    count_tokens: Callable[[str], int],
+    prompt_tokens: int,
+    max_tokens: int | None,
+    include_usage: bool,
+    created: int,
+) -> AsyncIterator[str]:
+    """Drive the OpenAI streaming-response protocol from a stream of text pieces.
+
+    Yields SSE strings ready to be forwarded to the client. When
+    ``parser_name`` is set, the cumulative buffer is fed to a
+    :class:`ToolCallStreamer` so newly-emittable content/tool-call fragments
+    show up in deltas without a half-formed marker ever reaching the client.
+    When it's ``None``, each chunk is forwarded as a content delta unchanged.
+
+    ``count_tokens`` is consulted only at end-of-stream to compute the
+    completion-token count for ``finish_reason`` and (optionally) usage; pass
+    ``lambda _: 0`` if the loader doesn't have a tokenizer handy.
+    """
+    tool_call_streamer = ToolCallStreamer(get_parser(parser_name)) if parser_name else None
+    accumulated = ""
+
+    yield _delta_chunk(request_id, model_name, DeltaMessage(role="assistant"), created)
+
+    async for piece in text_chunks:
+        if not piece:
+            continue
+        accumulated += piece
+        if tool_call_streamer is None:
+            yield _delta_chunk(request_id, model_name, DeltaMessage(content=piece), created)
+            await asyncio.sleep(0)
+            continue
+        delta = tool_call_streamer.extract_streaming(accumulated)
+        if delta is not None:
+            yield _delta_chunk(request_id, model_name, delta, created)
+        await asyncio.sleep(0)
+
+    if tool_call_streamer is not None:
+        final = tool_call_streamer.finalize()
+        if final is not None:
+            yield _delta_chunk(request_id, model_name, final, created)
+        parsed = tool_call_streamer.result
+    else:
+        parsed = ParsedToolCalls(accumulated, [])
+
+    completion_tokens = count_tokens(accumulated)
+    finish_reason = finish_reason_for(parsed, completion_tokens, max_tokens)
+
+    yield _encode_chunk(
+        ChatCompletionStreamResponse(
+            id=request_id,
+            model=model_name,
+            choices=[
+                ChatCompletionResponseStreamChoice(
+                    index=0,
+                    delta=DeltaMessage(),
+                    finish_reason=finish_reason,
+                )
+            ],
+            created=created,
+        )
+    )
+
+    if include_usage:
+        yield _encode_chunk(
+            ChatCompletionStreamResponse(
+                id=request_id,
+                model=model_name,
+                choices=[],
+                usage=UsageInfo(
+                    prompt_tokens=prompt_tokens,
+                    completion_tokens=completion_tokens,
+                    total_tokens=prompt_tokens + completion_tokens,
+                ),
+                created=created,
+            )
+        )
+
+    yield "data: [DONE]\n\n"
+
+
+def _delta_chunk(request_id: str, model_name: str, delta: DeltaMessage, created: int) -> str:
+    return _encode_chunk(
+        ChatCompletionStreamResponse(
+            id=request_id,
+            model=model_name,
+            choices=[ChatCompletionResponseStreamChoice(index=0, delta=delta)],
+            created=created,
+        )
+    )
+
+
+def _encode_chunk(chunk: ChatCompletionStreamResponse) -> str:
+    return f"data: {json.dumps(chunk.model_dump(mode='json'))}\n\n"

--- a/modelship/openai/tool_calling/utils.py
+++ b/modelship/openai/tool_calling/utils.py
@@ -1,7 +1,10 @@
 """Utility functions for tool-calling.
 
-Includes logic for detecting tool-calling support and format from model
-configuration by inspecting ``tokenizer_config.json``.
+Detects the tool-call parser a model needs by inspecting its chat template.
+For GGUF files, the template is read from embedded metadata (authoritative —
+it ships with the weights). For HF directories (and as a fallback for GGUF
+dirs that also ship HF tokenizer files), the template is read from
+``tokenizer_config.json``.
 """
 
 from __future__ import annotations
@@ -14,35 +17,43 @@ from modelship.logging import get_logger
 logger = get_logger("tool_calling.utils")
 
 
+def read_chat_template(model_path: str | Path) -> str | None:
+    """Read a model's chat template string from disk.
+
+    For GGUF files, prefers ``tokenizer.chat_template`` in the file's
+    embedded metadata (authoritative — it's what shipped with the weights).
+    Falls back to ``tokenizer_config.json`` in the same directory if the
+    GGUF read fails or the key is absent. For non-GGUF paths, reads
+    ``tokenizer_config.json`` directly.
+    """
+    path = Path(model_path)
+    if path.is_file() and path.suffix == ".gguf":
+        template = _read_chat_template_from_gguf(path)
+        if template is not None:
+            return template
+        config_dir = path.parent
+    else:
+        config_dir = path
+    return _read_chat_template_from_tokenizer_config(config_dir)
+
+
 def detect_tool_parser(model_path: str | Path) -> str | None:
     """Return the name of the tool-call parser required by the model or None.
-
-    Inspects ``tokenizer_config.json`` in ``model_path``.
 
     - Returns "hermes" if `<tool_call>` markers are found.
     - Returns "mistral" if `[TOOL_CALLS]` markers are found.
     - Returns "llama3_json" if `<|python_tag|>` markers are found.
     - Returns "unknown" if tool logic is found but format markers are not recognized.
+    - Returns ``None`` if no chat template / no tool logic is detected.
     """
-    path = Path(model_path)
-    # If model_path is a file (e.g. a GGUF), the config is in its parent dir.
-    config_dir = path.parent if path.is_file() else path
-    config_path = config_dir / "tokenizer_config.json"
-
-    if not config_path.exists():
+    template = read_chat_template(model_path)
+    if template is None:
         return None
+    return classify_template(template)
 
-    try:
-        with open(config_path, encoding="utf-8") as f:
-            config = json.load(f)
-    except (OSError, json.JSONDecodeError) as e:
-        logger.warning("Failed to load %s for tool detection: %s", config_path, e)
-        return None
 
-    template = config.get("chat_template")
-    if not template or not isinstance(template, str):
-        return None
-
+def classify_template(template: str) -> str | None:
+    """Map a chat-template string to a parser name based on tool-call markers."""
     # 1. Check for tool-calling support at all.
     # Most templates use `tools` or `tool_calls` variables in Jinja2 logic.
     if "tools" not in template and "tool_calls" not in template:
@@ -61,3 +72,50 @@ def detect_tool_parser(model_path: str | Path) -> str | None:
 
     # Tool logic found but no recognized markers.
     return "unknown"
+
+
+def _read_chat_template_from_tokenizer_config(config_dir: Path) -> str | None:
+    config_path = config_dir / "tokenizer_config.json"
+    if not config_path.exists():
+        return None
+    try:
+        with open(config_path, encoding="utf-8") as f:
+            config = json.load(f)
+    except (OSError, json.JSONDecodeError) as e:
+        logger.warning("Failed to load %s for tool detection: %s", config_path, e)
+        return None
+    template = config.get("chat_template")
+    if not template or not isinstance(template, str):
+        return None
+    return template
+
+
+def _read_chat_template_from_gguf(gguf_path: Path) -> str | None:
+    """Read ``tokenizer.chat_template`` from a GGUF file's metadata.
+
+    Returns ``None`` if the key is absent, the file isn't readable as GGUF,
+    or the gguf package is unavailable.
+    """
+    try:
+        from gguf import GGUFReader
+    except ImportError:
+        logger.debug("gguf package not available; skipping GGUF metadata read for %s", gguf_path)
+        return None
+    try:
+        reader = GGUFReader(str(gguf_path))
+    except Exception as e:
+        logger.warning("Failed to open %s as GGUF for tool detection: %s", gguf_path, e)
+        return None
+    field = reader.get_field("tokenizer.chat_template")
+    if field is None:
+        return None
+    try:
+        # GGUF string fields expose `.parts` (numpy arrays of bytes) selected by `.data` indices.
+        parts = [bytes(field.parts[i]).decode("utf-8") for i in field.data]
+    except Exception as e:
+        logger.warning("Failed to decode chat_template from %s: %s", gguf_path, e)
+        return None
+    template = "".join(parts)
+    if not template:
+        return None
+    return template

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -13,6 +13,7 @@ OPENAI_API_BASE = "http://localhost:8000/v1"
 EXPECTED_MODELS = {
     "chat-capable",
     "chat-limited",
+    "chat-llama-mship",
     "chat-transformers",
     "embed-model",
     "stt-model",
@@ -52,11 +53,18 @@ def mship_cluster(tmp_path_factory):
                 "usecase": "generate",
                 "loader": "llama_cpp",
                 "num_cpus": 1,
+                "llama_cpp_config": {
+                    "tool_calls_enabled": False,
+                },
             },
             {
-                # Same Qwen2.5-Instruct family as `chat-capable` so we exercise
-                # the transformers loader against a model trained to emit
-                # Hermes-style `<tool_call>{...}</tool_call>` markers.
+                "name": "chat-llama-mship",
+                "model": "lmstudio-community/Qwen2.5-0.5B-Instruct-GGUF:*Q4_K_M.gguf",
+                "usecase": "generate",
+                "loader": "llama_cpp",
+                "num_cpus": 1,
+            },
+            {
                 "name": "chat-transformers",
                 "model": "Qwen/Qwen2.5-0.5B-Instruct",
                 "usecase": "generate",
@@ -391,8 +399,8 @@ def test_tool_calling_streaming_vllm_loader(client):
 
 
 @pytest.mark.integration
-def test_tool_calling_unsupported_loader(client):
-    """Verifies that loaders without tool support (like llama_cpp) don't return tool calls."""
+def test_tool_calling_explicit_opt_out(client):
+    """Verifies that ``tool_calls_enabled: false`` disables tools even when the model's chat template supports them."""
     tools = [
         {
             "type": "function",
@@ -402,11 +410,95 @@ def test_tool_calling_unsupported_loader(client):
             },
         }
     ]
-    # Loader currently ignores the tools param
     completion = client.chat.completions.create(
         model="chat-limited", messages=[{"role": "user", "content": "Weather in London?"}], tools=tools
     )
     assert not completion.choices[0].message.tool_calls
+
+
+@pytest.mark.integration
+def test_tool_calling_llama_cpp_loader(client):
+    """Round-trip a Hermes-style tool call through the llama_cpp loader.
+
+    Same Qwen2.5-0.5B-Instruct weights as `chat-capable` (vLLM) and
+    `chat-transformers`, but in GGUF form via llama-cpp-python. Auto-detected
+    hermes parser renders the prompt with `tools=...` and parses the
+    `<tool_call>{...}</tool_call>` markers out of raw completion output.
+    """
+    tools = [
+        {
+            "type": "function",
+            "function": {
+                "name": "get_weather",
+                "description": "Get weather for a city",
+                "parameters": {
+                    "type": "object",
+                    "properties": {"city": {"type": "string"}},
+                    "required": ["city"],
+                },
+            },
+        }
+    ]
+    completion = client.chat.completions.create(
+        model="chat-llama-mship",
+        messages=[{"role": "user", "content": "What is the weather in Paris?"}],
+        tools=tools,
+        tool_choice="auto",
+        max_tokens=128,
+    )
+    tool_calls = completion.choices[0].message.tool_calls
+    assert tool_calls, f"expected a tool call, got content={completion.choices[0].message.content!r}"
+    assert tool_calls[0].function.name == "get_weather"
+    assert "Paris" in tool_calls[0].function.arguments
+    assert completion.choices[0].finish_reason == "tool_calls"
+
+
+@pytest.mark.integration
+def test_tool_calling_streaming_llama_cpp_loader(client):
+    """Stream a tool call through the llama_cpp loader and verify the
+    delta sequence matches the OpenAI streaming contract.
+
+    Same shape as `test_tool_calling_streaming_transformers_loader` —
+    asserts a single name delta, multiple incremental argument deltas,
+    valid JSON on concatenation, and final ``finish_reason="tool_calls"``.
+    """
+    tools = [
+        {
+            "type": "function",
+            "function": {
+                "name": "get_weather",
+                "description": "Get weather for a city",
+                "parameters": {
+                    "type": "object",
+                    "properties": {"city": {"type": "string"}},
+                    "required": ["city"],
+                },
+            },
+        }
+    ]
+    stream = client.chat.completions.create(
+        model="chat-llama-mship",
+        messages=[{"role": "user", "content": "What is the weather in Paris?"}],
+        tools=tools,
+        tool_choice="auto",
+        max_tokens=128,
+        stream=True,
+    )
+
+    collected = _collect_streaming_tool_call(stream)
+
+    assert collected["tool_calls"], f"expected at least one streamed tool call; got content={collected['content']!r}"
+    call_0 = collected["tool_calls"][0]
+    assert call_0["id"], "expected an id on the first tool-call delta"
+    assert call_0["name"] == "get_weather"
+    assert collected["name_deltas"] == 1, f"expected one name delta, got {collected['name_deltas']}"
+    assert collected["args_deltas"] >= 2, (
+        f"expected arguments to stream incrementally, got {collected['args_deltas']} args delta(s)"
+    )
+    parsed_args = json.loads(call_0["arguments"])
+    assert parsed_args.get("city")
+    assert "Paris" in parsed_args["city"]
+    assert collected["finish_reason"] == "tool_calls"
 
 
 @pytest.mark.integration


### PR DESCRIPTION
Generalizes tool-call auto-detection from transformers-only to all three generative loaders (vllm, transformers, llama_cpp) and adds a real tool-calling path for llama_cpp on top of raw create_completion + the shared modelship parser.

Driver-side
- read_chat_template reads chat templates from GGUF metadata (via gguf.GGUFReader) with a tokenizer_config.json fallback.
- classify_template factored out so detection and rendering use the same source string.
- Pre-resolve the template on _resolved_chat_template alongside the parser name; eliminates drift between detection and actor-side rendering.
- Loader-specific opt-outs: tool_calls_enabled: false (transformers, llama_cpp), enable_auto_tool_choice: false (vllm), chat_format set on llama_cpp also opts out so llama-cpp-python's native handler takes over.

llama_cpp loader
- New LlamaCppToolCallRenderer renders prompts via transformers.utils.chat_template_utils.render_jinja_template (HF's standalone function — polyfills baked in) and counts tokens via Llama.tokenize.
- serving_chat splits into _handle_with_tools (raw completion + parser) and _handle_without_tools (pass-through to create_chat_completion). chat_format requests stay on the pass-through path.

Shared streaming/non-streaming helpers
- tool_calling/streaming.py exposes stream_chat_completion and build_chat_completion_response — used by both transformers and llama_cpp serving paths.

vLLM
- Auto-enable tool calling from _resolved_tool_call_parser when enable_auto_tool_choice is unset (None); explicit True/False still wins.

Tests
- Reframe test_tool_calling_unsupported_loader → test_tool_calling_explicit_opt_out (Qwen2.5 GGUF now auto-detects as hermes; the test now verifies tool_calls_enabled: false works).
- Add test_tool_calling_llama_cpp_loader and test_tool_calling_streaming_llama_cpp_loader mirroring the existing transformers tests.


