### PR TITLE
feat: vllm reasoning content + auto-detect

### DIFF
--- a/modelship/deploy/config.py
+++ b/modelship/deploy/config.py
@@ -7,6 +7,7 @@ from modelship.deploy.actor_options import resolve_plugin_wheel
 from modelship.infer.infer_config import ModelLoader, ModelshipConfig, ModelUsecase
 from modelship.infer.model_resolver import resolve_model_source
 from modelship.logging import get_logger
+from modelship.openai.parsers.reasoning.utils import classify_template as classify_reasoning_template
 from modelship.openai.parsers.tool_calling.registry import available_parsers
 from modelship.openai.parsers.tool_calling.utils import classify_template
 from modelship.openai.parsers.utils import read_chat_template
@@ -91,30 +92,24 @@ def resolve_all_model_sources(yml_conf: ModelshipConfig) -> None:
 
 
 def resolve_all_tool_parsers(yml_conf: ModelshipConfig) -> None:
-    """Pre-flight: auto-detect a tool-call parser for each generative model.
+    """Pre-flight: resolve the final tool-call parser name per generative model.
 
     Runs after `resolve_all_model_sources` so `_resolved_path` is populated.
-    Reads the model's chat template once (from GGUF metadata or
-    `tokenizer_config.json`), stores it on `_resolved_chat_template`, and
-    classifies it onto `_resolved_tool_call_parser`. Per-loader code reads
-    these as a fallback when the loader-specific parser/format field is
-    unset, so an explicit user setting always wins.
+    Captures the FINAL parser name (explicit user setting or auto-detection)
+    onto `_resolved_tool_call_parser` so loader code has a single source of
+    truth and never re-implements the precedence.
 
     Auto-detection runs for vllm, transformers, and llama_cpp. diffusers has
     no chat path; custom is plugin-managed.
 
     Behavior per model:
-    - Loader-specific opt-out (see `_is_explicit_tool_opt_out`): skipped.
-    - Explicit parser name configured (vllm/transformers `tool_call_parser`):
-      validated against the registry; raises if unknown so misconfiguration
-      fails startup, not mid-request.
+    - Loader-specific opt-out (see `_is_explicit_tool_opt_out`): leaves
+      `_resolved_tool_call_parser` as None.
+    - Explicit parser name configured: validated against the registry,
+      stored on `_resolved_tool_call_parser`. Raises if unknown.
     - Auto-detected, registered: stored on `_resolved_tool_call_parser`.
-    - Auto-detected, known format but no parser implemented yet: warn, leave
-      unset — tool calling will be disabled for this model.
-    - Auto-detected as `unknown` (template uses tools but no recognized
-      markers): warn, leave unset.
-    - Not detected: tool calling silently disabled (model has no template
-      tool-call affordance to begin with).
+    - Auto-detected as `unknown` / known-but-unregistered: warn, leave None.
+    - Not detected: leave None (no template tool-call affordance).
     """
     registered = set(available_parsers())
     for cfg in yml_conf.models:
@@ -123,7 +118,7 @@ def resolve_all_tool_parsers(yml_conf: ModelshipConfig) -> None:
         if cfg.usecase != ModelUsecase.generate:
             continue
         if _is_explicit_tool_opt_out(cfg):
-            logger.info("Tool-call auto-detection skipped for '%s' (explicit opt-out).", cfg.name)
+            logger.info("Tool-call resolution skipped for '%s' (explicit opt-out).", cfg.name)
             continue
 
         explicit = None
@@ -138,6 +133,7 @@ def resolve_all_tool_parsers(yml_conf: ModelshipConfig) -> None:
                     f"Model '{cfg.name}' configures tool_call_parser={explicit!r} "
                     f"which is not registered. Available: {sorted(registered) or '(none)'}."
                 )
+            cfg._resolved_tool_call_parser = explicit
             logger.info("Using explicit tool_call_parser=%r for '%s'", explicit, cfg.name)
             continue
 
@@ -166,3 +162,60 @@ def resolve_all_tool_parsers(yml_conf: ModelshipConfig) -> None:
             continue
         cfg._resolved_tool_call_parser = detected
         logger.info("Auto-detected tool_call_parser=%r for '%s'", detected, cfg.name)
+
+
+def _is_explicit_reasoning_opt_out(cfg) -> bool:
+    """Loader-specific explicit "no reasoning auto-detection" signal.
+
+    - vllm: ``enable_reasoning: false`` — user disabled reasoning.
+    """
+    if cfg.loader == ModelLoader.vllm:
+        return cfg.vllm_engine_kwargs is not None and cfg.vllm_engine_kwargs.enable_reasoning is False
+    return False
+
+
+def resolve_all_reasoning_parsers(yml_conf: ModelshipConfig) -> None:
+    """Pre-flight: resolve the final reasoning parser name per generative model.
+
+    Mirrors `resolve_all_tool_parsers`: captures the FINAL parser name onto
+    `_resolved_reasoning_parser` so loader code has a single source of truth.
+    Reuses `_resolved_chat_template` if populated by the tool-parser pass.
+
+    Behavior per model:
+    - Loader-specific opt-out: leaves `_resolved_reasoning_parser` as None.
+    - Explicit ``reasoning_parser`` on the loader config: stored as-is.
+    - Auto-detected from chat template: stored.
+    - Not detected: leaves None (reasoning disabled).
+    """
+    for cfg in yml_conf.models:
+        if cfg.loader not in (ModelLoader.vllm, ModelLoader.transformers, ModelLoader.llama_cpp):
+            continue
+        if cfg.usecase != ModelUsecase.generate:
+            continue
+        if _is_explicit_reasoning_opt_out(cfg):
+            logger.info("Reasoning resolution skipped for '%s' (explicit opt-out).", cfg.name)
+            continue
+
+        explicit = None
+        if cfg.loader == ModelLoader.vllm and cfg.vllm_engine_kwargs:
+            explicit = cfg.vllm_engine_kwargs.reasoning_parser
+
+        if explicit is not None:
+            cfg._resolved_reasoning_parser = explicit
+            logger.info("Using explicit reasoning_parser=%r for '%s'", explicit, cfg.name)
+            continue
+
+        template = cfg._resolved_chat_template
+        if template is None:
+            assert cfg._resolved_path is not None  # populated by resolve_all_model_sources
+            template = read_chat_template(cfg._resolved_path)
+            if template is None:
+                logger.info("No chat template found for '%s'; reasoning detection skipped.", cfg.name)
+                continue
+            cfg._resolved_chat_template = template
+
+        detected = classify_reasoning_template(template)
+        if detected is None:
+            continue
+        cfg._resolved_reasoning_parser = detected
+        logger.info("Auto-detected reasoning_parser=%r for '%s'", detected, cfg.name)

--- a/modelship/infer/infer_config.py
+++ b/modelship/infer/infer_config.py
@@ -56,6 +56,8 @@ class VllmEngineConfig(BaseModel):
     quantization: str | None = None
     enable_auto_tool_choice: bool | None = None
     tool_call_parser: str | None = None
+    enable_reasoning: bool | None = None
+    reasoning_parser: str | None = None
     chat_template_content_format: ChatTemplateContentFormatOption = "auto"
     enforce_eager: bool | None = None
     max_num_batched_tokens: int | None = None
@@ -105,6 +107,7 @@ class ModelshipModelConfig(BaseModel):
 
     _resolved_path: str | None = PrivateAttr(default=None)
     _resolved_tool_call_parser: str | None = PrivateAttr(default=None)
+    _resolved_reasoning_parser: str | None = PrivateAttr(default=None)
     _resolved_chat_template: str | None = PrivateAttr(default=None)
 
     @model_validator(mode="after")

--- a/modelship/infer/transformers/transformers_infer.py
+++ b/modelship/infer/transformers/transformers_infer.py
@@ -84,10 +84,10 @@ class TransformersInfer(BaseInfer):
             capabilities = TransformersCapabilities.detect(pipe)
             if capabilities.supports_image:
                 logger.info("Multimodal (vision) capability detected for model: %s", self.model_config.name)
-            if self.config.tool_calls_enabled is False:
-                tool_call_parser = None
-            else:
-                tool_call_parser = self.config.tool_call_parser or self.model_config._resolved_tool_call_parser
+            # `resolve_all_tool_parsers` already honored `tool_calls_enabled=False`
+            # (opt-out leaves the resolved field None) and captured an explicit
+            # `tool_call_parser` setting if any. Read the resolved value directly.
+            tool_call_parser = self.model_config._resolved_tool_call_parser
             self.serving_chat = OpenAIServingChat(
                 pipe, self.model_config.name, self.config, capabilities, tool_call_parser
             )

--- a/modelship/infer/vllm/vllm_infer.py
+++ b/modelship/infer/vllm/vllm_infer.py
@@ -214,19 +214,12 @@ class VllmInfer(BaseInfer):
             base_model_paths=[BaseModelPath(name=self.model_config.name, model_path=self.vllm_engine_kwargs.model)],
         )
 
-        enable_tools = False
-        tool_parser_name = None
-        if self.vllm_engine_kwargs.enable_auto_tool_choice is True:
-            enable_tools = True
-            tool_parser_name = self.vllm_engine_kwargs.tool_call_parser
-        elif self.vllm_engine_kwargs.enable_auto_tool_choice is not False:  # None implies auto
-            if self.model_config._resolved_tool_call_parser:
-                enable_tools = True
-                tool_parser_name = self.model_config._resolved_tool_call_parser
-            elif self.vllm_engine_kwargs.tool_call_parser:
-                # fallback if user sets parser but leaves enable_auto_tool_choice as None
-                enable_tools = True
-                tool_parser_name = self.vllm_engine_kwargs.tool_call_parser
+        # Driver-side `resolve_all_{tool,reasoning}_parsers` populated these
+        # with the final parser name (explicit user setting or auto-detected),
+        # or left them None to signal "disabled". Don't redo the precedence here.
+        tool_parser_name = self.model_config._resolved_tool_call_parser
+        enable_tools = tool_parser_name is not None
+        reasoning_parser_name = self.model_config._resolved_reasoning_parser or ""
 
         openai_serving_render = OpenAIServingRender(
             model_config=self.engine.model_config,
@@ -249,6 +242,7 @@ class VllmInfer(BaseInfer):
             chat_template_content_format=self.vllm_engine_kwargs.chat_template_content_format,
             enable_auto_tools=enable_tools,
             tool_parser=tool_parser_name,
+            reasoning_parser=reasoning_parser_name,
         )
 
     async def init_serving_embeding(self) -> ServingEmbedding | None:

--- a/modelship/openai/parsers/reasoning/utils.py
+++ b/modelship/openai/parsers/reasoning/utils.py
@@ -1,0 +1,22 @@
+"""Reasoning parser detection by chat-template inspection."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from modelship.openai.parsers.utils import read_chat_template
+
+
+def detect_reasoning_parser(model_path: str | Path) -> str | None:
+    """Return the name of the reasoning parser the model needs, or None."""
+    template = read_chat_template(model_path)
+    if template is None:
+        return None
+    return classify_template(template)
+
+
+def classify_template(template: str) -> str | None:
+    """Map a chat-template string to a reasoning parser name based on markers."""
+    if "<think>" in template or "</think>" in template:
+        return "deepseek_r1"
+    return None

--- a/mship_deploy.py
+++ b/mship_deploy.py
@@ -36,6 +36,7 @@ from modelship.deploy.config import (  # noqa: E402
     load_yaml_config,
     resolve_all_model_sources,
     resolve_all_plugin_wheels,
+    resolve_all_reasoning_parsers,
     resolve_all_tool_parsers,
 )
 from modelship.deploy.serve_utils import (  # noqa: E402
@@ -120,6 +121,7 @@ def main(argv: list[str] | None = None) -> None:
         # AFTER the gateway is up so /health and /readyz answer during downloads.
         resolve_all_model_sources(yml_conf)
         resolve_all_tool_parsers(yml_conf)
+        resolve_all_reasoning_parsers(yml_conf)
 
         gateway_handle = serve.get_app_handle(gateway_name)
         seed_expected_models(gateway_handle, yml_conf)

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -30,6 +30,22 @@ MODEL_CONFIGS: dict[str, dict] = {
             "tool_call_parser": "hermes",
         },
     },
+    "chat-reasoning": {
+        "name": "chat-reasoning",
+        # Qwen3-0.6B is the smallest reasoning-capable model in the Qwen3
+        # family; it natively emits `<think>...</think>`. Reasoning chains
+        # need headroom so `max_model_len` is bumped.
+        "model": "Qwen/Qwen3-0.6B",
+        "usecase": "generate",
+        "loader": "vllm",
+        "num_gpus": 0.5,
+        "vllm_engine_kwargs": {
+            "max_model_len": 4096,
+            "enforce_eager": True,
+            "enable_reasoning": True,
+            "reasoning_parser": "deepseek_r1",
+        },
+    },
     "chat-limited": {
         "name": "chat-limited",
         "model": "lmstudio-community/Qwen2.5-0.5B-Instruct-GGUF:*Q4_K_M.gguf",
@@ -323,6 +339,77 @@ class TestChatCapable:
         parsed_args = json.loads(call_0["arguments"])
         assert "Paris" in parsed_args.get("city", "")
         assert collected["finish_reason"] == "tool_calls"
+
+
+@pytest.mark.integration
+class TestChatReasoning:
+    @pytest.fixture(autouse=True, scope="class")
+    def _deploy(self, model_deployer):
+        model_deployer.deploy("chat-reasoning")
+
+    def test_reasoning_completion(self):
+        """Non-streaming: vLLM's deepseek_r1 reasoning parser routes the
+        `<think>...</think>` block to `message.reasoning` and leaves the
+        final answer in `message.content`. Verifies end-to-end wiring of
+        `reasoning_parser` through the modelship gateway.
+        """
+        # Use httpx so we read the raw `reasoning` field — the OpenAI Python
+        # SDK doesn't always surface it as a typed attribute.
+        response = httpx.post(
+            f"{OPENAI_API_BASE}/chat/completions",
+            json={
+                "model": "chat-reasoning",
+                "messages": [{"role": "user", "content": "Briefly: what is 7 times 8?"}],
+                "max_tokens": 512,
+            },
+            timeout=120,
+        )
+        assert response.status_code == 200, response.text
+        message = response.json()["choices"][0]["message"]
+        assert message.get("reasoning"), f"expected reasoning content, got {message!r}"
+        # `<think>` markers must be stripped from both fields.
+        assert "<think>" not in (message.get("content") or "")
+        assert "<think>" not in message["reasoning"]
+
+    def test_reasoning_streaming(self):
+        """Streaming: at least one delta carries `reasoning` and the
+        concatenated reasoning text is non-empty when the stream ends.
+        Markers must not leak into either field.
+        """
+        with httpx.stream(
+            "POST",
+            f"{OPENAI_API_BASE}/chat/completions",
+            json={
+                "model": "chat-reasoning",
+                "messages": [{"role": "user", "content": "Briefly: what is 7 times 8?"}],
+                "max_tokens": 512,
+                "stream": True,
+            },
+            timeout=120,
+        ) as response:
+            assert response.status_code == 200
+            reasoning_parts: list[str] = []
+            content_parts: list[str] = []
+            reasoning_deltas = 0
+            for line in response.iter_lines():
+                if not line.startswith("data: "):
+                    continue
+                payload = line[len("data: ") :]
+                if payload == "[DONE]":
+                    break
+                chunk = json.loads(payload)
+                delta = chunk["choices"][0].get("delta") or {}
+                if delta.get("reasoning"):
+                    reasoning_parts.append(delta["reasoning"])
+                    reasoning_deltas += 1
+                if delta.get("content"):
+                    content_parts.append(delta["content"])
+
+        assert reasoning_deltas >= 1, "expected at least one reasoning delta"
+        assert "".join(reasoning_parts).strip(), "expected non-empty reasoning content"
+        # Reasoning markers must not leak into either stream.
+        assert "<think>" not in "".join(reasoning_parts)
+        assert "<think>" not in "".join(content_parts)
 
 
 @pytest.mark.integration

--- a/tests/test_parser_resolution.py
+++ b/tests/test_parser_resolution.py
@@ -1,0 +1,145 @@
+"""Driver-side parser resolution: tool-calling and reasoning.
+
+Covers `resolve_all_tool_parsers` / `resolve_all_reasoning_parsers` populating
+`_resolved_tool_call_parser` / `_resolved_reasoning_parser` as the single
+source of truth for loader code.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from modelship.deploy.config import resolve_all_reasoning_parsers, resolve_all_tool_parsers
+from modelship.infer.infer_config import (
+    LlamaCppConfig,
+    ModelLoader,
+    ModelshipConfig,
+    ModelshipModelConfig,
+    ModelUsecase,
+    TransformersConfig,
+    VllmEngineConfig,
+)
+from modelship.openai.parsers.reasoning.utils import classify_template as classify_reasoning
+
+
+def _make_cfg(**overrides) -> ModelshipModelConfig:
+    base = {
+        "name": "m",
+        "model": "some/model",
+        "usecase": ModelUsecase.generate,
+        "loader": ModelLoader.vllm,
+    }
+    base.update(overrides)
+    return ModelshipModelConfig(**base)
+
+
+class TestClassifyReasoningTemplate:
+    def test_open_think_tag(self):
+        assert classify_reasoning("...<think>...") == "deepseek_r1"
+
+    def test_close_think_tag(self):
+        assert classify_reasoning("...</think>...") == "deepseek_r1"
+
+    def test_no_markers_returns_none(self):
+        assert classify_reasoning("plain template with no markers") is None
+
+    def test_empty_returns_none(self):
+        assert classify_reasoning("") is None
+
+
+class TestResolveReasoningParsers:
+    def test_explicit_parser_stored(self):
+        cfg = _make_cfg(vllm_engine_kwargs=VllmEngineConfig(reasoning_parser="qwen3"))
+        resolve_all_reasoning_parsers(ModelshipConfig(models=[cfg]))
+        assert cfg._resolved_reasoning_parser == "qwen3"
+
+    def test_explicit_opt_out_leaves_none(self, monkeypatch):
+        cfg = _make_cfg(vllm_engine_kwargs=VllmEngineConfig(enable_reasoning=False))
+        cfg._resolved_chat_template = "<think>x</think>"  # would auto-detect if not opted out
+        resolve_all_reasoning_parsers(ModelshipConfig(models=[cfg]))
+        assert cfg._resolved_reasoning_parser is None
+
+    def test_auto_detect_from_template(self, monkeypatch):
+        cfg = _make_cfg()
+        cfg._resolved_chat_template = "blah <think>...</think> blah"
+        resolve_all_reasoning_parsers(ModelshipConfig(models=[cfg]))
+        assert cfg._resolved_reasoning_parser == "deepseek_r1"
+
+    def test_no_markers_leaves_none(self):
+        cfg = _make_cfg()
+        cfg._resolved_chat_template = "no reasoning markers here"
+        resolve_all_reasoning_parsers(ModelshipConfig(models=[cfg]))
+        assert cfg._resolved_reasoning_parser is None
+
+    def test_explicit_wins_over_auto(self):
+        cfg = _make_cfg(vllm_engine_kwargs=VllmEngineConfig(reasoning_parser="custom_x"))
+        cfg._resolved_chat_template = "<think>x</think>"
+        resolve_all_reasoning_parsers(ModelshipConfig(models=[cfg]))
+        assert cfg._resolved_reasoning_parser == "custom_x"
+
+    def test_skips_non_generate_usecase(self):
+        cfg = _make_cfg(usecase=ModelUsecase.embed)
+        cfg._resolved_chat_template = "<think>x</think>"
+        resolve_all_reasoning_parsers(ModelshipConfig(models=[cfg]))
+        assert cfg._resolved_reasoning_parser is None
+
+    def test_skips_non_applicable_loader(self):
+        cfg = _make_cfg(loader=ModelLoader.diffusers)
+        cfg._resolved_chat_template = "<think>x</think>"
+        resolve_all_reasoning_parsers(ModelshipConfig(models=[cfg]))
+        assert cfg._resolved_reasoning_parser is None
+
+    def test_reads_template_from_disk_when_not_cached(self, monkeypatch):
+        cfg = _make_cfg()
+        cfg._resolved_path = "/fake/path"
+        monkeypatch.setattr(
+            "modelship.deploy.config.read_chat_template",
+            lambda p: "{% if tools %}<think>{% endif %}",
+        )
+        resolve_all_reasoning_parsers(ModelshipConfig(models=[cfg]))
+        assert cfg._resolved_reasoning_parser == "deepseek_r1"
+        # And the template gets cached on the cfg.
+        assert cfg._resolved_chat_template is not None
+
+    def test_no_template_leaves_none(self, monkeypatch):
+        cfg = _make_cfg()
+        cfg._resolved_path = "/fake/path"
+        monkeypatch.setattr("modelship.deploy.config.read_chat_template", lambda p: None)
+        resolve_all_reasoning_parsers(ModelshipConfig(models=[cfg]))
+        assert cfg._resolved_reasoning_parser is None
+
+
+class TestResolveToolParsersStoresExplicit:
+    """Regression: explicit `tool_call_parser` must populate `_resolved_tool_call_parser`."""
+
+    def test_vllm_explicit_stored(self):
+        cfg = _make_cfg(vllm_engine_kwargs=VllmEngineConfig(tool_call_parser="hermes"))
+        resolve_all_tool_parsers(ModelshipConfig(models=[cfg]))
+        assert cfg._resolved_tool_call_parser == "hermes"
+
+    def test_transformers_explicit_stored(self):
+        cfg = _make_cfg(
+            loader=ModelLoader.transformers,
+            transformers_config=TransformersConfig(tool_call_parser="hermes"),
+        )
+        resolve_all_tool_parsers(ModelshipConfig(models=[cfg]))
+        assert cfg._resolved_tool_call_parser == "hermes"
+
+    def test_unknown_explicit_raises(self):
+        cfg = _make_cfg(vllm_engine_kwargs=VllmEngineConfig(tool_call_parser="not-a-real-parser"))
+        with pytest.raises(ValueError, match="not-a-real-parser"):
+            resolve_all_tool_parsers(ModelshipConfig(models=[cfg]))
+
+    def test_vllm_opt_out_leaves_none(self):
+        cfg = _make_cfg(vllm_engine_kwargs=VllmEngineConfig(enable_auto_tool_choice=False, tool_call_parser="hermes"))
+        resolve_all_tool_parsers(ModelshipConfig(models=[cfg]))
+        assert cfg._resolved_tool_call_parser is None
+
+    def test_llama_cpp_chat_format_opts_out(self):
+        cfg = _make_cfg(
+            loader=ModelLoader.llama_cpp,
+            llama_cpp_config=LlamaCppConfig(chat_format="chatml-function-calling"),
+        )
+        cfg._resolved_chat_template = "{% if tools %}<tool_call>{% endif %}"
+        resolve_all_tool_parsers(ModelshipConfig(models=[cfg]))
+        assert cfg._resolved_tool_call_parser is None


### PR DESCRIPTION
Adds reasoning support for the vLLM loader: chat-template auto-detection of `<think>...</think>` markers, an explicit-or-auto `reasoning_parser` config knob on `VllmEngineConfig`, and end-to-end wiring through `OpenAIServingChat`.

Consolidates the parser-name precedence (explicit setting vs. auto-detection vs. opt-out) into the driver-side `resolve_all_*` helpers, so loader code reads `_resolved_tool_call_parser` / `_resolved_reasoning_parser` as a single source of truth instead of re-implementing the precedence dance per loader. Cleans up the redundant fallback in `vllm_infer.init_serving_chat` and the `or` chain in `transformers_infer`.

Tests:
- unit: full resolution matrix in `tests/test_parser_resolution.py` (explicit / opt-out / auto-detect / no-template / loader+usecase filtering, disk-read fallback, cache reuse)
- integration: new `chat-reasoning` deployment (Qwen3-0.6B + deepseek_r1 parser) covering non-streaming and streaming reasoning extraction

