### PR TITLE
feat: llama_cpp reasoning content + parser unification

### DIFF
--- a/modelship/infer/llama_cpp/llama_cpp_infer.py
+++ b/modelship/infer/llama_cpp/llama_cpp_infer.py
@@ -96,17 +96,38 @@ class LlamaCppInfer(BaseInfer):
 
         if self.model_config.usecase == ModelUsecase.generate:
             parser_name = self.model_config._resolved_tool_call_parser
-            renderer = None
-            if parser_name is not None:
-                # Driver invariant: parser_name is only set when the template was
-                # successfully read, so _resolved_chat_template is non-None here.
-                assert self.model_config._resolved_chat_template is not None
-                renderer = build_tool_call_renderer(self.llamacpp, self.model_config._resolved_chat_template)
+            reasoning_name = self.model_config._resolved_reasoning_parser
+            template = self.model_config._resolved_chat_template
+            # Default to driving the model through raw `create_completion`
+            # so reasoning + tool-call markers in the model's output are
+            # visible to ChatOutputStreamer regardless of whether parsers
+            # are configured for this request. Fall back to llama-cpp's
+            # native chat handler only when:
+            #   - the user explicitly set `chat_format` (presumed opt-in
+            #     to llama-cpp's templating; our parsers are bypassed), or
+            #   - no chat template was resolvable (we'd have nothing to
+            #     render with).
+            if self.config.chat_format is None and template is not None:
+                renderer = build_tool_call_renderer(self.llamacpp, template)
+            else:
+                renderer = None
+                if parser_name is not None or reasoning_name is not None:
+                    logger.warning(
+                        "model '%s' has parsers resolved (tool=%s, reasoning=%s) but `chat_format` is set "
+                        "or no chat template is available; falling back to llama-cpp's native chat handler "
+                        "and our parsers will not run.",
+                        self.model_config.name,
+                        parser_name,
+                        reasoning_name,
+                    )
+                    parser_name = None
+                    reasoning_name = None
             self.serving_chat = OpenAIServingChat(
                 self.llamacpp,
                 self.model_config.name,
                 capabilities,
                 tool_call_parser=parser_name,
+                reasoning_parser=reasoning_name,
                 renderer=renderer,
             )
         elif self.model_config.usecase == ModelUsecase.embed:

--- a/modelship/infer/llama_cpp/openai/serving_chat.py
+++ b/modelship/infer/llama_cpp/openai/serving_chat.py
@@ -13,12 +13,9 @@ from modelship.infer.llama_cpp.capabilities import LlamaCppCapabilities
 from modelship.infer.llama_cpp.utils import LlamaCppToolCallRenderer
 from modelship.logging import get_logger
 from modelship.openai.chat_utils import UnsupportedContentError, normalize_chat_messages
-from modelship.openai.parsers.tool_calling import (
-    build_chat_completion_response,
-    get_parser,
-    resolve_tools_for_request,
-    stream_chat_completion,
-)
+from modelship.openai.parsers.reasoning import get_parser as get_reasoning_parser
+from modelship.openai.parsers.streaming import build_chat_completion_response, stream_chat_completion
+from modelship.openai.parsers.tool_calling import get_parser, resolve_tools_for_request
 from modelship.openai.protocol import (
     ChatCompletionRequest,
     ChatCompletionResponse,
@@ -39,6 +36,7 @@ class OpenAIServingChat(OpenAIServing):
         model_name: str,
         capabilities: LlamaCppCapabilities,
         tool_call_parser: str | None = None,
+        reasoning_parser: str | None = None,
         renderer: LlamaCppToolCallRenderer | None = None,
     ):
         self._llama = llama
@@ -48,11 +46,24 @@ class OpenAIServingChat(OpenAIServing):
         self._accepted_params = set(inspect.signature(llama.create_chat_completion).parameters)
         self._completion_accepted_params = set(inspect.signature(llama.create_completion).parameters)
         self.tool_call_parser = tool_call_parser
+        self.reasoning_parser = reasoning_parser
         self._renderer = renderer
+        # The renderer's presence is the sole switch between paths:
+        #  - renderer set → drive `create_completion` raw, route every
+        #    response through `ChatOutputStreamer`. Reasoning + tool-call
+        #    extraction happens here. Default for any model that exposes
+        #    a chat template via GGUF metadata.
+        #  - renderer None → fall back to llama-cpp's
+        #    `create_chat_completion`. Used when the user opted into
+        #    llama-cpp's own templating with `chat_format` on
+        #    LlamaCppConfig — they're presumed to know our parsers won't
+        #    fire for that config.
         if tool_call_parser is not None:
             assert renderer is not None, "renderer is required when tool_call_parser is set"
-            # Validate at startup so misconfiguration surfaces before the first request.
             get_parser(tool_call_parser)
+        if reasoning_parser is not None:
+            assert renderer is not None, "renderer is required when reasoning_parser is set"
+            get_reasoning_parser(reasoning_parser)
 
     async def warmup(self) -> None:
         logger.info("Warming up llama.cpp chat model: %s", self.model_name)
@@ -90,11 +101,19 @@ class OpenAIServingChat(OpenAIServing):
             )
             tools = None
 
-        if tools and self.tool_call_parser is not None:
-            return await self._handle_with_tools(request, request_id, messages, tools)
-        return await self._handle_without_tools(request, request_id, messages)
+        tool_parser_name = self.tool_call_parser if tools else None
+        # Renderer presence decides the path (see __init__ comment): when
+        # the user set `chat_format` on LlamaCppConfig we leave it to
+        # llama-cpp; otherwise we render the prompt ourselves so the
+        # ChatOutputStreamer sees the model's raw bytes regardless of
+        # whether reasoning or tools are active for this request.
+        if self._renderer is not None:
+            return await self._handle_with_parsers(
+                request, request_id, messages, tools, tool_parser_name=tool_parser_name
+            )
+        return await self._handle_native(request, request_id, messages)
 
-    async def _handle_without_tools(
+    async def _handle_native(
         self,
         request: ChatCompletionRequest,
         request_id: str,
@@ -102,9 +121,10 @@ class OpenAIServingChat(OpenAIServing):
     ) -> ErrorResponse | ChatCompletionResponse | AsyncGenerator[str, None]:
         """Pass-through to ``llama.create_chat_completion`` — no parser involved.
 
-        This path is used when no tools are requested, or when the user
-        configured ``chat_format`` (in which case our parser is intentionally
-        bypassed and llama-cpp-python handles tool calling itself if at all).
+        Used when neither tool calling nor reasoning is active for this
+        deployment, or when the user configured ``chat_format`` (in
+        which case our parsers are intentionally bypassed and
+        llama-cpp-python's own chat handler is responsible).
         """
         kwargs = self._build_kwargs(request, messages)
         loop = asyncio.get_event_loop()
@@ -140,28 +160,30 @@ class OpenAIServingChat(OpenAIServing):
                 logger.warning("llama_cpp chat inference failed: %s", e)
                 return create_error_response(e)
 
-    async def _handle_with_tools(
+    async def _handle_with_parsers(
         self,
         request: ChatCompletionRequest,
         request_id: str,
         messages: list[dict],
-        tools: list[dict[str, Any]],
+        tools: list[dict[str, Any]] | None,
+        *,
+        tool_parser_name: str | None,
     ) -> ErrorResponse | ChatCompletionResponse | AsyncGenerator[str, None]:
-        """Render prompt with tools, run raw completion, parse via shared streamer.
+        """Render prompt ourselves, run raw completion, parse via shared streamer.
 
-        Bypasses ``llama.create_chat_completion`` because that re-runs llama-cpp's
-        own chat templating (which produces tokens conditioned on a different
-        template than the one our parser expects).
+        Bypasses ``llama.create_chat_completion`` because that re-runs
+        llama-cpp's own chat templating (which also strips tokens our
+        parsers need to see). The unified streamer handles reasoning
+        and tool calls in a single pass over the model output.
         """
         assert self._renderer is not None  # guarded at __init__
-        assert self.tool_call_parser is not None
-        parser_name = self.tool_call_parser
         renderer = self._renderer
+        reasoning_parser_name = self.reasoning_parser
 
         try:
             prompt = renderer.render(messages, tools)
         except Exception as e:
-            logger.warning("llama_cpp tool-call prompt rendering failed for %s: %s", request_id, e)
+            logger.warning("llama_cpp prompt rendering failed for %s: %s", request_id, e)
             return create_error_response(e)
 
         max_tokens = request.max_tokens
@@ -175,10 +197,11 @@ class OpenAIServingChat(OpenAIServing):
 
         if request.stream:
             include_usage = bool(request.stream_options and request.stream_options.include_usage)
-            return self._locked_stream_with_tools(
+            return self._locked_stream_with_parsers(
                 request_id=request_id,
                 completion_kwargs=completion_kwargs,
-                parser_name=parser_name,
+                tool_parser_name=tool_parser_name,
+                reasoning_parser_name=reasoning_parser_name,
                 prompt_tokens=prompt_tokens,
                 max_tokens=max_tokens,
                 include_usage=include_usage,
@@ -192,7 +215,7 @@ class OpenAIServingChat(OpenAIServing):
                 )
                 result = cast(dict, raw)
             except Exception as e:
-                logger.warning("llama_cpp tool-call inference failed for %s: %s", request_id, e)
+                logger.warning("llama_cpp inference failed for %s: %s", request_id, e)
                 return create_error_response(e)
 
         completion_text = result["choices"][0]["text"] if result.get("choices") else ""
@@ -203,19 +226,21 @@ class OpenAIServingChat(OpenAIServing):
             request_id=request_id,
             model_name=self.model_name,
             text=completion_text,
-            parser_name=parser_name,
+            parser_name=tool_parser_name,
+            reasoning_parser_name=reasoning_parser_name,
             prompt_tokens=int(usage.get("prompt_tokens") or prompt_tokens),
             completion_tokens=completion_tokens,
             max_tokens=max_tokens,
             created=int(time.time()),
         )
 
-    async def _locked_stream_with_tools(
+    async def _locked_stream_with_parsers(
         self,
         *,
         request_id: str,
         completion_kwargs: dict,
-        parser_name: str,
+        tool_parser_name: str | None,
+        reasoning_parser_name: str | None,
         prompt_tokens: int,
         max_tokens: int | None,
         include_usage: bool,
@@ -227,7 +252,8 @@ class OpenAIServingChat(OpenAIServing):
                 request_id=request_id,
                 model_name=self.model_name,
                 text_chunks=self._raw_text_chunks(completion_kwargs),
-                parser_name=parser_name,
+                parser_name=tool_parser_name,
+                reasoning_parser_name=reasoning_parser_name,
                 count_tokens=renderer.count_tokens,
                 prompt_tokens=prompt_tokens,
                 max_tokens=max_tokens,

--- a/modelship/infer/transformers/openai/serving_chat.py
+++ b/modelship/infer/transformers/openai/serving_chat.py
@@ -11,12 +11,8 @@ from modelship.infer.infer_config import RawRequestProxy, TransformersConfig
 from modelship.infer.transformers.capabilities import TransformersCapabilities
 from modelship.logging import TRACE, get_logger
 from modelship.openai.chat_utils import UnsupportedContentError, normalize_chat_messages
-from modelship.openai.parsers.tool_calling import (
-    build_chat_completion_response,
-    get_parser,
-    resolve_tools_for_request,
-    stream_chat_completion,
-)
+from modelship.openai.parsers.streaming import build_chat_completion_response, stream_chat_completion
+from modelship.openai.parsers.tool_calling import get_parser, resolve_tools_for_request
 from modelship.openai.protocol import (
     ChatCompletionRequest,
     ChatCompletionResponse,

--- a/modelship/openai/parsers/__init__.py
+++ b/modelship/openai/parsers/__init__.py
@@ -1,0 +1,21 @@
+"""Cross-loader parser toolkit: reasoning + tool calls.
+
+Loaders import streaming helpers and the unified streamer/result
+classes from this package; the per-family parsers live under the
+``reasoning`` and ``tool_calling`` subpackages.
+"""
+
+from modelship.openai.parsers.output import ChatOutputStreamer, ParsedChatOutput
+from modelship.openai.parsers.streaming import (
+    build_chat_completion_response,
+    finish_reason_for,
+    stream_chat_completion,
+)
+
+__all__ = [
+    "ChatOutputStreamer",
+    "ParsedChatOutput",
+    "build_chat_completion_response",
+    "finish_reason_for",
+    "stream_chat_completion",
+]

--- a/modelship/openai/parsers/output.py
+++ b/modelship/openai/parsers/output.py
@@ -1,0 +1,314 @@
+"""Single-pass chat-output streamer that handles reasoning + tool calls.
+
+This is the loader-shared driver consumed by every chat serving path
+that emits raw text (transformers, llama.cpp, plugin-wrapped engines).
+It walks the cumulative model output once and routes each region to
+its appropriate stream:
+
+1. **Reasoning regions** — text inside the optional reasoning parser's
+   marker pair. Surfaced via ``DeltaMessage.reasoning``.
+2. **Tool-call regions** — text inside the tool-call parser's marker
+   pair, with name/arguments extraction. Surfaced via
+   ``DeltaMessage.tool_calls``.
+3. **Content regions** — everything else. Surfaced via
+   ``DeltaMessage.content``.
+
+The single-pass design matters: a ``<tool_call>`` marker emitted inside
+``<think>`` is part of the model's reasoning, not a real tool call.
+Two chained streamers would parse it as a real call; one streamer that
+knows about both marker kinds correctly routes it to the reasoning
+view. Both the streaming and non-streaming paths run the same streamer
+so behavior cannot drift between them.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from modelship.openai.parsers.reasoning.parsers import ReasoningParser
+from modelship.openai.parsers.tool_calling.parsers import ToolCallParser
+from modelship.openai.protocol import (
+    DeltaFunctionCall,
+    DeltaMessage,
+    DeltaToolCall,
+    FunctionCall,
+    ToolCall,
+    random_uuid,
+)
+
+
+@dataclass(frozen=True)
+class ParsedChatOutput:
+    """Aggregate result of parsing a model's full chat-completion text.
+
+    ``content`` carries the residual non-reasoning, non-tool-call text
+    once both kinds of markers are stripped. It is ``None`` when tool
+    calls were extracted *and* the residual is empty, matching OpenAI's
+    behavior of nulling ``content`` alongside ``tool_calls``.
+    ``reasoning`` is the concatenation of all ``<think>...`` regions
+    (or whichever marker pair the reasoning parser declared); ``None``
+    when reasoning was not enabled or no markers were emitted.
+    """
+
+    content: str | None
+    reasoning: str | None
+    tool_calls: list[ToolCall]
+
+    @property
+    def has_tool_calls(self) -> bool:
+        return bool(self.tool_calls)
+
+
+class ChatOutputStreamer:
+    """Per-request, stateful chat-output extractor.
+
+    State held per request:
+
+    - ``_sent_content_idx`` / ``_sent_reasoning_idx`` — chars already
+      shipped from each non-tool-call stream.
+    - ``_sent_name`` / ``_sent_id`` per tool index — whether the
+      function name and id deltas have been emitted.
+    - ``_sent_args`` per tool index — chars of arguments already
+      shipped (the suffix-diff cursor).
+    - ``_finalized_indices`` / ``_finalized_calls`` — closed tool-call
+      blocks accumulated for :attr:`result` and ``finish_reason``.
+    """
+
+    def __init__(
+        self,
+        tool_call_parser: ToolCallParser | None,
+        reasoning_parser: ReasoningParser | None = None,
+    ):
+        if tool_call_parser is None and reasoning_parser is None:
+            raise ValueError("ChatOutputStreamer requires at least one parser (tool-call or reasoning)")
+        self._tool_parser = tool_call_parser
+        self._tool_start = tool_call_parser.start_marker if tool_call_parser else ""
+        self._tool_end = tool_call_parser.end_marker if tool_call_parser else ""
+        self._reasoning = reasoning_parser
+        self._reasoning_start = reasoning_parser.start_marker if reasoning_parser else ""
+        self._reasoning_end = reasoning_parser.end_marker if reasoning_parser else ""
+        self._sent_content_idx = 0
+        self._sent_reasoning_idx = 0
+        self._sent_name: list[bool] = []
+        self._sent_id: list[str] = []
+        self._sent_args: list[str] = []
+        self._finalized_indices: set[int] = set()
+        self._finalized_calls: list[ToolCall] = []
+        self._last_text = ""
+
+    def extract_streaming(self, current_text: str) -> DeltaMessage | None:
+        """Run one diff pass against ``current_text`` and return any new deltas."""
+        self._last_text = current_text
+        regions = self._scan(current_text, hold_marker_tail=True)
+        content_delta = self._diff_content(regions)
+        reasoning_delta = self._diff_reasoning(regions)
+        tool_call_deltas = self._emit_new_tool_call_fragments(regions)
+        if not content_delta and not reasoning_delta and not tool_call_deltas:
+            return None
+        return DeltaMessage(content=content_delta, reasoning=reasoning_delta, tool_calls=tool_call_deltas)
+
+    def finalize(self) -> DeltaMessage | None:
+        """Flush any held-back tails once no more text is coming."""
+        regions = self._scan(self._last_text, hold_marker_tail=False)
+        content_delta = self._diff_content(regions)
+        reasoning_delta = self._diff_reasoning(regions)
+        if content_delta is None and reasoning_delta is None:
+            return None
+        return DeltaMessage(content=content_delta, reasoning=reasoning_delta)
+
+    @property
+    def result(self) -> ParsedChatOutput:
+        """Final view, suitable for the non-streaming response shape."""
+        regions = self._scan(self._last_text, hold_marker_tail=False)
+        content_view = "".join(payload for kind, payload, _ in regions if kind == "content")
+        reasoning_view = "".join(payload for kind, payload, _ in regions if kind == "reasoning")
+        content = (content_view.strip() or None) if self._finalized_calls else (content_view or None)
+        return ParsedChatOutput(
+            content=content,
+            reasoning=reasoning_view or None,
+            tool_calls=list(self._finalized_calls),
+        )
+
+    # ------------------------------------------------------------------
+    # Single-pass scanner
+    # ------------------------------------------------------------------
+
+    def _scan(self, text: str, *, hold_marker_tail: bool) -> list[tuple[str, str, bool]]:
+        """Walk ``text`` once, returning ordered ``(kind, payload, is_complete)`` regions.
+
+        ``kind`` is one of ``"content"``, ``"reasoning"``, ``"tool_call"``.
+        ``is_complete`` is meaningful only for ``"tool_call"``; for the
+        other kinds it is always ``True`` (their boundaries are handled
+        via the marker-tail holdback in the content/reasoning views).
+
+        ``hold_marker_tail`` controls mid-stream holdback: trailing
+        bytes that could be the prefix of any expected opening or
+        closing marker are withheld, so the client never sees a
+        fragment of a tag forwarded as content/reasoning bytes. At
+        finalize time we know no more text is coming, so all held
+        tails are flushed.
+        """
+        regions: list[tuple[str, str, bool]] = []
+        pos = 0
+        n = len(text)
+        while pos < n:
+            tool_start = text.find(self._tool_start, pos) if self._tool_start else -1
+            reason_start = text.find(self._reasoning_start, pos) if self._reasoning_start else -1
+            next_starts = [s for s in (tool_start, reason_start) if s >= 0]
+            if not next_starts:
+                # No more openings ahead; the rest is content.
+                remainder = text[pos:]
+                if hold_marker_tail:
+                    safe = self._safe_outside_flush_index(remainder)
+                    regions.append(("content", remainder[:safe], True))
+                else:
+                    regions.append(("content", remainder, True))
+                break
+
+            next_pos = min(next_starts)
+            if next_pos > pos:
+                regions.append(("content", text[pos:next_pos], True))
+
+            if next_pos == reason_start:
+                payload_start = next_pos + len(self._reasoning_start)
+                end = text.find(self._reasoning_end, payload_start) if self._reasoning_end else -1
+                if end < 0:
+                    inner = text[payload_start:]
+                    if hold_marker_tail:
+                        safe = _safe_overlap_index(inner, self._reasoning_end)
+                        regions.append(("reasoning", inner[:safe], False))
+                    else:
+                        regions.append(("reasoning", inner, False))
+                    break
+                regions.append(("reasoning", text[payload_start:end], True))
+                pos = end + len(self._reasoning_end)
+            else:
+                payload_start = next_pos + len(self._tool_start)
+                end = text.find(self._tool_end, payload_start) if self._tool_end else -1
+                if end < 0:
+                    partial = text[payload_start:]
+                    if hold_marker_tail:
+                        safe = _safe_overlap_index(partial, self._tool_end)
+                        regions.append(("tool_call", partial[:safe], False))
+                    else:
+                        regions.append(("tool_call", partial, False))
+                    break
+                regions.append(("tool_call", text[payload_start:end], True))
+                pos = end + len(self._tool_end)
+        return regions
+
+    def _safe_outside_flush_index(self, buf: str) -> int:
+        """Index up to which ``buf`` (a content tail) can be flushed.
+
+        ``buf`` does not contain a full opening marker; the unsafe tail
+        is the longest proper-prefix overlap with whichever opening
+        marker(s) the streamer is watching for.
+        """
+        cap = len(buf)
+        for marker in (self._tool_start, self._reasoning_start):
+            if not marker:
+                continue
+            cap = min(cap, _safe_overlap_index(buf, marker))
+        return cap
+
+    # ------------------------------------------------------------------
+    # Content + reasoning diff
+    # ------------------------------------------------------------------
+
+    def _diff_content(self, regions: list[tuple[str, str, bool]]) -> str | None:
+        view = "".join(payload for kind, payload, _ in regions if kind == "content")
+        if len(view) <= self._sent_content_idx:
+            return None
+        new = view[self._sent_content_idx :]
+        self._sent_content_idx = len(view)
+        return new or None
+
+    def _diff_reasoning(self, regions: list[tuple[str, str, bool]]) -> str | None:
+        view = "".join(payload for kind, payload, _ in regions if kind == "reasoning")
+        if len(view) <= self._sent_reasoning_idx:
+            return None
+        new = view[self._sent_reasoning_idx :]
+        self._sent_reasoning_idx = len(view)
+        return new or None
+
+    # ------------------------------------------------------------------
+    # Tool-call fragments
+    # ------------------------------------------------------------------
+
+    def _emit_new_tool_call_fragments(self, regions: list[tuple[str, str, bool]]) -> list[DeltaToolCall]:
+        if self._tool_parser is None:
+            return []
+        deltas: list[DeltaToolCall] = []
+        tool_blocks = [(payload, complete) for kind, payload, complete in regions if kind == "tool_call"]
+        for i, (payload, is_complete) in enumerate(tool_blocks):
+            self._ensure_slot(i)
+
+            if not self._sent_name[i]:
+                name = self._tool_parser.extract_partial_name(payload)
+                if name is None:
+                    if is_complete:
+                        # Closed but malformed (no extractable name) — skip,
+                        # but still process later blocks.
+                        continue
+                    # Mid-stream and no name yet; per OpenAI convention we don't
+                    # advance to later blocks until the current one has a name.
+                    break
+                tool_id = f"chatcmpl-tool-{random_uuid()}"
+                self._sent_name[i] = True
+                self._sent_id[i] = tool_id
+                deltas.append(
+                    DeltaToolCall(
+                        index=i,
+                        id=tool_id,
+                        type="function",
+                        function=DeltaFunctionCall(name=name),
+                    )
+                )
+
+            args = self._tool_parser.extract_partial_args(payload)
+            if args is not None and len(args) > len(self._sent_args[i]):
+                diff = args[len(self._sent_args[i]) :]
+                self._sent_args[i] = args
+                deltas.append(
+                    DeltaToolCall(
+                        index=i,
+                        function=DeltaFunctionCall(arguments=diff),
+                    )
+                )
+
+            if is_complete and i not in self._finalized_indices and self._sent_name[i]:
+                self._finalized_indices.add(i)
+                self._finalized_calls.append(
+                    ToolCall(
+                        id=self._sent_id[i],
+                        type="function",
+                        function=FunctionCall(
+                            name=self._tool_parser.extract_partial_name(payload) or "",
+                            arguments=self._sent_args[i],
+                        ),
+                    )
+                )
+        return deltas
+
+    def _ensure_slot(self, i: int) -> None:
+        while len(self._sent_name) <= i:
+            self._sent_name.append(False)
+            self._sent_id.append("")
+            self._sent_args.append("")
+
+
+def _safe_overlap_index(buf: str, marker: str) -> int:
+    """Index up to which ``buf`` can be flushed without risking a split marker.
+
+    ``buf`` is known not to contain the full marker. The unsafe tail is
+    the longest proper-prefix overlap between ``buf`` and ``marker``: if
+    the next chunk completes that prefix, we'd have to retract bytes we
+    already streamed. Holding them back avoids the retraction.
+    """
+    if not marker:
+        return len(buf)
+    max_overlap = min(len(buf), len(marker) - 1)
+    for k in range(max_overlap, 0, -1):
+        if buf.endswith(marker[:k]):
+            return len(buf) - k
+    return len(buf)

--- a/modelship/openai/parsers/output.py
+++ b/modelship/openai/parsers/output.py
@@ -122,7 +122,7 @@ class ChatOutputStreamer:
         regions = self._scan(self._last_text, hold_marker_tail=False)
         content_view = "".join(payload for kind, payload, _ in regions if kind == "content")
         reasoning_view = "".join(payload for kind, payload, _ in regions if kind == "reasoning")
-        content = (content_view.strip() or None) if self._finalized_calls else (content_view or None)
+        content = (content_view if content_view.strip() else None) if self._finalized_calls else (content_view or None)
         return ParsedChatOutput(
             content=content,
             reasoning=reasoning_view or None,

--- a/modelship/openai/parsers/reasoning/__init__.py
+++ b/modelship/openai/parsers/reasoning/__init__.py
@@ -1,0 +1,22 @@
+"""Cross-loader reasoning parser toolkit.
+
+Loaders without native reasoning support (transformers, llama.cpp) use
+the parsers here, dispatched via the unified
+:class:`ChatOutputStreamer`, to surface ``<think>...</think>`` blocks
+in the protocol-level ``reasoning`` field. vLLM has its own built-in
+reasoning parsers and uses only the auto-detected parser name.
+"""
+
+from modelship.openai.parsers.reasoning.parsers import DeepseekR1ReasoningParser, ReasoningParser
+from modelship.openai.parsers.reasoning.registry import available_parsers, get_parser, register_parser
+from modelship.openai.parsers.reasoning.utils import classify_template, detect_reasoning_parser
+
+__all__ = [
+    "DeepseekR1ReasoningParser",
+    "ReasoningParser",
+    "available_parsers",
+    "classify_template",
+    "detect_reasoning_parser",
+    "get_parser",
+    "register_parser",
+]

--- a/modelship/openai/parsers/reasoning/parsers/__init__.py
+++ b/modelship/openai/parsers/reasoning/parsers/__init__.py
@@ -1,0 +1,4 @@
+from modelship.openai.parsers.reasoning.parsers.base import ReasoningParser
+from modelship.openai.parsers.reasoning.parsers.deepseek import DeepseekR1ReasoningParser
+
+__all__ = ["DeepseekR1ReasoningParser", "ReasoningParser"]

--- a/modelship/openai/parsers/reasoning/parsers/base.py
+++ b/modelship/openai/parsers/reasoning/parsers/base.py
@@ -1,0 +1,29 @@
+"""Base class for model-family-specific reasoning output parsers.
+
+Reasoning parsers are *marker-based*: each family wraps its
+chain-of-thought in a fixed pair of literal strings (``<think>`` /
+``</think>`` for DeepSeek-R1, QwQ, Qwen3, Phi-4-reasoning, ...).
+Unlike tool-call parsers, the payload between markers is opaque text —
+no per-family extractors are needed, just the marker pair.
+
+The unified :class:`ChatOutputStreamer` (over in
+``modelship.openai.parsers.tool_calling.parsers``) consumes a parser
+instance and walks the cumulative model output once, splitting it into
+content / reasoning / tool-call regions in a single pass.
+"""
+
+from __future__ import annotations
+
+from abc import ABC
+
+
+class ReasoningParser(ABC):
+    """Family-specific marker pair for reasoning extraction.
+
+    Subclasses set ``name``, ``start_marker``, ``end_marker``. They hold
+    no per-request state — that all lives on :class:`ChatOutputStreamer`.
+    """
+
+    name: str
+    start_marker: str
+    end_marker: str

--- a/modelship/openai/parsers/reasoning/parsers/deepseek.py
+++ b/modelship/openai/parsers/reasoning/parsers/deepseek.py
@@ -1,0 +1,16 @@
+"""DeepSeek-R1-style ``<think>...</think>`` reasoning parser.
+
+Used by DeepSeek-R1 (and distilled variants), QwQ, Qwen3, and
+Phi-4-reasoning, all of which wrap their chain-of-thought in the
+literal tags ``<think>`` / ``</think>``.
+"""
+
+from __future__ import annotations
+
+from modelship.openai.parsers.reasoning.parsers.base import ReasoningParser
+
+
+class DeepseekR1ReasoningParser(ReasoningParser):
+    name = "deepseek_r1"
+    start_marker = "<think>"
+    end_marker = "</think>"

--- a/modelship/openai/parsers/reasoning/registry.py
+++ b/modelship/openai/parsers/reasoning/registry.py
@@ -1,0 +1,34 @@
+"""Registry of named reasoning parsers, dispatched by configuration string.
+
+Mirrors ``modelship.openai.parsers.tool_calling.registry``: loaders look
+up a reasoning parser by the name resolved on the driver
+(``_resolved_reasoning_parser``) and hand it to the unified
+``ChatOutputStreamer``. vLLM bypasses this registry — it has its own
+built-in reasoning parsers and consumes only the resolved name.
+"""
+
+from __future__ import annotations
+
+from modelship.openai.parsers.reasoning.parsers import DeepseekR1ReasoningParser, ReasoningParser
+
+_PARSERS: dict[str, ReasoningParser] = {
+    DeepseekR1ReasoningParser.name: DeepseekR1ReasoningParser(),
+}
+
+
+def get_parser(name: str) -> ReasoningParser:
+    """Return the parser registered under ``name`` or raise ``ValueError``."""
+    try:
+        return _PARSERS[name]
+    except KeyError:
+        available = ", ".join(sorted(_PARSERS)) or "(none)"
+        raise ValueError(f"unknown reasoning_parser {name!r}; available: {available}") from None
+
+
+def available_parsers() -> list[str]:
+    return sorted(_PARSERS)
+
+
+def register_parser(parser: ReasoningParser) -> None:
+    """Register an additional parser. Intended for tests and plugin code."""
+    _PARSERS[parser.name] = parser

--- a/modelship/openai/parsers/streaming.py
+++ b/modelship/openai/parsers/streaming.py
@@ -1,18 +1,23 @@
-"""Loader-agnostic chat-completion helpers for tool-call-aware responses.
+"""Loader-agnostic chat-completion helpers for parser-aware responses.
 
 Loaders produce text differently — HF ``Pipeline`` for transformers, raw
-``llama.create_completion`` for llama_cpp, async iterators from plugins — but
-the OpenAI response shapes (streaming and non-streaming) are the same. This
-module owns those shapes plus the `ToolCallStreamer` driving loop, so the
-loaders only deal in plain text.
+``llama.create_completion`` for llama_cpp, async iterators from plugins —
+but the OpenAI response shapes (streaming and non-streaming) are the
+same. This module owns those shapes plus the
+:class:`~modelship.openai.parsers.output.ChatOutputStreamer` driving
+loop, so the loaders only deal in plain text.
 
 Two helpers:
 
-- :func:`build_chat_completion_response` — non-streaming. Loader hands in the
-  full completion text and token counts; we parse tool calls and pack the
-  OpenAI ``ChatCompletionResponse``.
+- :func:`build_chat_completion_response` — non-streaming. Loader hands in
+  the full completion text and token counts; we parse reasoning and
+  tool calls and pack the OpenAI ``ChatCompletionResponse``.
 - :func:`stream_chat_completion` — streaming. Loader hands in an
-  ``AsyncIterator[str]`` of new text pieces; we emit the SSE byte stream.
+  ``AsyncIterator[str]`` of new text pieces; we emit the SSE byte
+  stream.
+
+Both accept ``parser_name`` (tool-call) and ``reasoning_parser_name``
+independently. Either or both may be ``None``.
 """
 
 from __future__ import annotations
@@ -21,8 +26,9 @@ import asyncio
 import json
 from collections.abc import AsyncIterator, Callable
 
-from modelship.openai.parsers.tool_calling.parsers import ParsedToolCalls, ToolCallStreamer
-from modelship.openai.parsers.tool_calling.registry import get_parser
+from modelship.openai.parsers.output import ChatOutputStreamer, ParsedChatOutput
+from modelship.openai.parsers.reasoning.registry import get_parser as get_reasoning_parser
+from modelship.openai.parsers.tool_calling.registry import get_parser as get_tool_call_parser
 from modelship.openai.protocol import (
     ChatCompletionResponse,
     ChatCompletionResponseChoice,
@@ -34,7 +40,7 @@ from modelship.openai.protocol import (
 )
 
 
-def finish_reason_for(parsed: ParsedToolCalls, completion_tokens: int, max_tokens: int | None) -> str:
+def finish_reason_for(parsed: ParsedChatOutput, completion_tokens: int, max_tokens: int | None) -> str:
     """Compute the OpenAI ``finish_reason`` for a chat completion."""
     if parsed.has_tool_calls:
         return "tool_calls"
@@ -49,6 +55,7 @@ def build_chat_completion_response(
     model_name: str,
     text: str,
     parser_name: str | None,
+    reasoning_parser_name: str | None = None,
     prompt_tokens: int,
     completion_tokens: int,
     max_tokens: int | None,
@@ -57,10 +64,10 @@ def build_chat_completion_response(
     """Parse ``text`` and pack it into an OpenAI ``ChatCompletionResponse``.
 
     Non-streaming counterpart of :func:`stream_chat_completion`. When
-    ``parser_name`` is ``None``, ``text`` becomes the message content as-is
-    with no tool-call extraction.
+    both parser names are ``None``, ``text`` becomes the message
+    content as-is with no extraction.
     """
-    parsed = get_parser(parser_name).parse(text) if parser_name else ParsedToolCalls(text, [])
+    parsed = _parse_full(text, parser_name=parser_name, reasoning_parser_name=reasoning_parser_name)
     finish_reason = finish_reason_for(parsed, completion_tokens, max_tokens)
     return ChatCompletionResponse(
         id=request_id,
@@ -71,6 +78,7 @@ def build_chat_completion_response(
                 message=ChatMessage(
                     role="assistant",
                     content=parsed.content,
+                    reasoning=parsed.reasoning,
                     tool_calls=parsed.tool_calls,
                 ),
                 finish_reason=finish_reason,
@@ -91,6 +99,7 @@ async def stream_chat_completion(
     model_name: str,
     text_chunks: AsyncIterator[str],
     parser_name: str | None,
+    reasoning_parser_name: str | None = None,
     count_tokens: Callable[[str], int],
     prompt_tokens: int,
     max_tokens: int | None,
@@ -99,17 +108,19 @@ async def stream_chat_completion(
 ) -> AsyncIterator[str]:
     """Drive the OpenAI streaming-response protocol from a stream of text pieces.
 
-    Yields SSE strings ready to be forwarded to the client. When
-    ``parser_name`` is set, the cumulative buffer is fed to a
-    :class:`ToolCallStreamer` so newly-emittable content/tool-call fragments
-    show up in deltas without a half-formed marker ever reaching the client.
-    When it's ``None``, each chunk is forwarded as a content delta unchanged.
+    Yields SSE strings ready to be forwarded to the client. When either
+    ``parser_name`` or ``reasoning_parser_name`` is set, the cumulative
+    buffer is fed to a :class:`ChatOutputStreamer` so newly-emittable
+    reasoning, content, and tool-call fragments show up in deltas
+    without a half-formed marker ever reaching the client. When both
+    are ``None``, each chunk is forwarded as a content delta unchanged.
 
     ``count_tokens`` is consulted only at end-of-stream to compute the
-    completion-token count for ``finish_reason`` and (optionally) usage; pass
-    ``lambda _: 0`` if the loader doesn't have a tokenizer handy.
+    completion-token count for ``finish_reason`` and (optionally)
+    usage; pass ``lambda _: 0`` if the loader doesn't have a tokenizer
+    handy.
     """
-    tool_call_streamer = ToolCallStreamer(get_parser(parser_name)) if parser_name else None
+    streamer = _make_streamer(parser_name=parser_name, reasoning_parser_name=reasoning_parser_name)
     accumulated = ""
 
     yield _delta_chunk(request_id, model_name, DeltaMessage(role="assistant"), created)
@@ -118,22 +129,22 @@ async def stream_chat_completion(
         if not piece:
             continue
         accumulated += piece
-        if tool_call_streamer is None:
+        if streamer is None:
             yield _delta_chunk(request_id, model_name, DeltaMessage(content=piece), created)
             await asyncio.sleep(0)
             continue
-        delta = tool_call_streamer.extract_streaming(accumulated)
+        delta = streamer.extract_streaming(accumulated)
         if delta is not None:
             yield _delta_chunk(request_id, model_name, delta, created)
         await asyncio.sleep(0)
 
-    if tool_call_streamer is not None:
-        final = tool_call_streamer.finalize()
+    if streamer is not None:
+        final = streamer.finalize()
         if final is not None:
             yield _delta_chunk(request_id, model_name, final, created)
-        parsed = tool_call_streamer.result
+        parsed = streamer.result
     else:
-        parsed = ParsedToolCalls(accumulated, [])
+        parsed = ParsedChatOutput(content=accumulated or None, reasoning=None, tool_calls=[])
 
     completion_tokens = count_tokens(accumulated)
     finish_reason = finish_reason_for(parsed, completion_tokens, max_tokens)
@@ -169,6 +180,23 @@ async def stream_chat_completion(
         )
 
     yield "data: [DONE]\n\n"
+
+
+def _parse_full(text: str, *, parser_name: str | None, reasoning_parser_name: str | None) -> ParsedChatOutput:
+    streamer = _make_streamer(parser_name=parser_name, reasoning_parser_name=reasoning_parser_name)
+    if streamer is None:
+        return ParsedChatOutput(content=text or None, reasoning=None, tool_calls=[])
+    streamer.extract_streaming(text)
+    streamer.finalize()
+    return streamer.result
+
+
+def _make_streamer(*, parser_name: str | None, reasoning_parser_name: str | None) -> ChatOutputStreamer | None:
+    if parser_name is None and reasoning_parser_name is None:
+        return None
+    tool_parser = get_tool_call_parser(parser_name) if parser_name else None
+    reasoning_parser = get_reasoning_parser(reasoning_parser_name) if reasoning_parser_name else None
+    return ChatOutputStreamer(tool_parser, reasoning_parser)
 
 
 def _delta_chunk(request_id: str, model_name: str, delta: DeltaMessage, created: int) -> str:

--- a/modelship/openai/parsers/tool_calling/__init__.py
+++ b/modelship/openai/parsers/tool_calling/__init__.py
@@ -1,30 +1,22 @@
-"""Cross-loader tool-calling toolkit.
+"""Cross-loader tool-calling parser package.
 
-Loaders without native tool-call support (Transformers today, plugin-wrapped
-raw-text engines tomorrow) use the parsers and helpers in this package to
-turn raw model output into OpenAI-shape ``tool_calls``. Loaders whose engines
-already emit structured tool calls (vLLM, llama.cpp via a function-calling
-chat handler) bypass it.
+Per-family tool-call parsers (Hermes today, more later) plus the
+registry that maps a configured name to a parser instance, plus tool
+input resolution. The unified streamer that drives parsing for
+streaming and non-streaming responses lives one level up at
+``modelship.openai.parsers.output``; loaders should import the
+streaming helpers from ``modelship.openai.parsers.streaming``.
 """
 
 from modelship.openai.parsers.tool_calling.input import resolve_tools_for_request
-from modelship.openai.parsers.tool_calling.parsers import ParsedToolCalls, ToolCallParser, ToolCallStreamer
+from modelship.openai.parsers.tool_calling.parsers import HermesToolCallParser, ToolCallParser
 from modelship.openai.parsers.tool_calling.registry import available_parsers, get_parser, register_parser
-from modelship.openai.parsers.tool_calling.streaming import (
-    build_chat_completion_response,
-    finish_reason_for,
-    stream_chat_completion,
-)
 
 __all__ = [
-    "ParsedToolCalls",
+    "HermesToolCallParser",
     "ToolCallParser",
-    "ToolCallStreamer",
     "available_parsers",
-    "build_chat_completion_response",
-    "finish_reason_for",
     "get_parser",
     "register_parser",
     "resolve_tools_for_request",
-    "stream_chat_completion",
 ]

--- a/modelship/openai/parsers/tool_calling/parsers/__init__.py
+++ b/modelship/openai/parsers/tool_calling/parsers/__init__.py
@@ -1,4 +1,4 @@
-from modelship.openai.parsers.tool_calling.parsers.base import ParsedToolCalls, ToolCallParser, ToolCallStreamer
+from modelship.openai.parsers.tool_calling.parsers.base import ToolCallParser
 from modelship.openai.parsers.tool_calling.parsers.hermes import HermesToolCallParser
 
-__all__ = ["HermesToolCallParser", "ParsedToolCalls", "ToolCallParser", "ToolCallStreamer"]
+__all__ = ["HermesToolCallParser", "ToolCallParser"]

--- a/modelship/openai/parsers/tool_calling/parsers/base.py
+++ b/modelship/openai/parsers/tool_calling/parsers/base.py
@@ -5,41 +5,21 @@ JSON in a fixed pair of literal strings (``<tool_call>`` / ``</tool_call>``
 for Hermes, ``[TOOL_CALLS]`` / closing token for Mistral, ...). A subclass
 declares the marker pair plus two small extractors that pick a function
 name and an arguments substring out of the (possibly partial) JSON between
-the markers. Both the streaming and non-streaming paths run the same
-:class:`ToolCallStreamer` so behavior cannot drift between them.
+the markers.
+
+The cumulative-text streaming and non-streaming paths both run through
+:class:`~modelship.openai.parsers.output.ChatOutputStreamer`, which
+consumes a parser instance plus an optional reasoning parser and walks
+the model output once.
 """
 
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from dataclasses import dataclass
+from typing import TYPE_CHECKING
 
-from modelship.openai.protocol import (
-    DeltaFunctionCall,
-    DeltaMessage,
-    DeltaToolCall,
-    FunctionCall,
-    ToolCall,
-    random_uuid,
-)
-
-
-@dataclass(frozen=True)
-class ParsedToolCalls:
-    """Aggregate result of parsing a model's full chat-completion text.
-
-    ``content`` carries the residual non-tool-call text once any tool-call
-    markers are stripped. It is ``None`` when tool calls were extracted *and*
-    the residual is empty, matching OpenAI's behavior of nulling ``content``
-    alongside ``tool_calls``.
-    """
-
-    content: str | None
-    tool_calls: list[ToolCall]
-
-    @property
-    def has_tool_calls(self) -> bool:
-        return bool(self.tool_calls)
+if TYPE_CHECKING:
+    from modelship.openai.parsers.output import ParsedChatOutput
 
 
 class ToolCallParser(ABC):
@@ -47,7 +27,8 @@ class ToolCallParser(ABC):
 
     Subclasses set ``start_marker`` / ``end_marker`` and implement the two
     extractors. They never touch streaming state — that lives on
-    :class:`ToolCallStreamer`, which can be instantiated once per request.
+    :class:`~modelship.openai.parsers.output.ChatOutputStreamer`, which is
+    instantiated once per request.
     """
 
     name: str
@@ -74,218 +55,12 @@ class ToolCallParser(ABC):
         stream and the client receives malformed JSON.
         """
 
-    def parse(self, text: str) -> ParsedToolCalls:
-        streamer = ToolCallStreamer(self)
+    def parse(self, text: str) -> ParsedChatOutput:
+        # Local import: ``output`` imports ``ToolCallParser`` for typing,
+        # so importing it at module top would create a cycle.
+        from modelship.openai.parsers.output import ChatOutputStreamer
+
+        streamer = ChatOutputStreamer(self)
         streamer.extract_streaming(text)
         streamer.finalize()
         return streamer.result
-
-
-class ToolCallStreamer:
-    """Per-request, stateful tool-call extractor.
-
-    Mirrors vLLM's approach: hold a small amount of "what we've already sent"
-    state, re-parse the cumulative ``current_text`` on every delta, and diff.
-    Returns either a :class:`DeltaMessage` carrying any newly-emittable
-    content / tool-call fragments or ``None`` if there is nothing to send yet.
-
-    State held per request:
-
-    - ``_sent_content_idx`` — number of content-stream chars already shipped.
-      The "content stream" view is the original text with every (complete or
-      open) tool-call region excised.
-    - ``_sent_name`` / ``_sent_id`` per tool index — whether the function name
-      and id deltas have been emitted.
-    - ``_sent_args`` per tool index — number of arguments chars already
-      shipped (the suffix-diff cursor).
-    - ``_finalized_indices`` — set of block indices that have been finalized.
-    - ``_finalized_calls`` — :class:`ToolCall` objects accumulated for blocks
-      that have closed, used to populate :attr:`result` for the non-streaming
-      path and for the final ``finish_reason``.
-    """
-
-    def __init__(self, parser: ToolCallParser):
-        self._parser = parser
-        self._start = parser.start_marker
-        self._end = parser.end_marker
-        self._sent_content_idx = 0
-        self._sent_name: list[bool] = []
-        self._sent_id: list[str] = []
-        self._sent_args: list[str] = []
-        self._finalized_indices: set[int] = set()
-        self._finalized_calls: list[ToolCall] = []
-        self._last_text = ""
-
-    def extract_streaming(self, current_text: str) -> DeltaMessage | None:
-        """Run one diff pass against ``current_text`` and return any new deltas."""
-        self._last_text = current_text
-        content_delta = self._emit_new_content(current_text, hold_marker_tail=True)
-        tool_call_deltas = self._emit_new_tool_call_fragments(current_text)
-        if not content_delta and not tool_call_deltas:
-            return None
-        return DeltaMessage(content=content_delta, tool_calls=tool_call_deltas)
-
-    def finalize(self) -> DeltaMessage | None:
-        """Flush any held-back content tail once no more text is coming."""
-        content_delta = self._emit_new_content(self._last_text, hold_marker_tail=False)
-        if content_delta is None:
-            return None
-        return DeltaMessage(content=content_delta)
-
-    @property
-    def result(self) -> ParsedToolCalls:
-        """Final view, suitable for the non-streaming response shape."""
-        # The content-view we accumulated as we streamed; reconstruct from the cursor.
-        view = self._build_content_view(self._last_text, hold_marker_tail=False)
-        content = (view.strip() or None) if self._finalized_calls else (view or None)
-        return ParsedToolCalls(content=content, tool_calls=list(self._finalized_calls))
-
-    # ------------------------------------------------------------------
-    # Content stream
-    # ------------------------------------------------------------------
-
-    def _emit_new_content(self, current_text: str, *, hold_marker_tail: bool) -> str | None:
-        view = self._build_content_view(current_text, hold_marker_tail=hold_marker_tail)
-        if len(view) <= self._sent_content_idx:
-            return None
-        new = view[self._sent_content_idx :]
-        self._sent_content_idx = len(view)
-        return new or None
-
-    def _build_content_view(self, text: str, *, hold_marker_tail: bool) -> str:
-        """Build the content-stream view: the original text with tool-call regions excised.
-
-        When ``hold_marker_tail`` is true (mid-stream), withhold a trailing
-        suffix that could be the start of a new ``start_marker``, so the
-        client never sees half of an opening tag. At finalize time we know
-        no more text is coming, so the held-back tail is safe to flush.
-        """
-        parts: list[str] = []
-        pos = 0
-        while pos < len(text):
-            start = text.find(self._start, pos)
-            if start < 0:
-                remainder = text[pos:]
-                if hold_marker_tail:
-                    safe = _safe_outside_flush_index(remainder, self._start)
-                    parts.append(remainder[:safe])
-                else:
-                    parts.append(remainder)
-                break
-            parts.append(text[pos:start])
-            payload_start = start + len(self._start)
-            end = text.find(self._end, payload_start)
-            if end < 0:
-                # Open block, not yet closed — nothing more to append to content.
-                break
-            pos = end + len(self._end)
-        return "".join(parts)
-
-    # ------------------------------------------------------------------
-    # Tool-call fragments
-    # ------------------------------------------------------------------
-
-    def _emit_new_tool_call_fragments(self, current_text: str) -> list[DeltaToolCall]:
-        deltas: list[DeltaToolCall] = []
-        for i, (payload, is_complete) in enumerate(self._iter_tool_call_blocks(current_text)):
-            self._ensure_slot(i)
-
-            if not self._sent_name[i]:
-                name = self._parser.extract_partial_name(payload)
-                if name is None:
-                    if is_complete:
-                        # This block is finished but has no extractable name (malformed).
-                        # Skip it so we can potentially process later blocks.
-                        continue
-                    # Mid-stream and no name yet; per OpenAI convention we don't
-                    # advance to later blocks until the current one has a name.
-                    break
-                tool_id = f"chatcmpl-tool-{random_uuid()}"
-                self._sent_name[i] = True
-                self._sent_id[i] = tool_id
-                deltas.append(
-                    DeltaToolCall(
-                        index=i,
-                        id=tool_id,
-                        type="function",
-                        function=DeltaFunctionCall(name=name),
-                    )
-                )
-
-            args = self._parser.extract_partial_args(payload)
-            if args is not None and len(args) > len(self._sent_args[i]):
-                diff = args[len(self._sent_args[i]) :]
-                self._sent_args[i] = args
-                deltas.append(
-                    DeltaToolCall(
-                        index=i,
-                        function=DeltaFunctionCall(arguments=diff),
-                    )
-                )
-
-            if is_complete and i not in self._finalized_indices and self._sent_name[i]:
-                self._finalized_indices.add(i)
-                self._finalized_calls.append(
-                    ToolCall(
-                        id=self._sent_id[i],
-                        type="function",
-                        function=FunctionCall(
-                            name=self._extract_committed_name(i),
-                            arguments=self._sent_args[i],
-                        ),
-                    )
-                )
-        return deltas
-
-    def _ensure_slot(self, i: int) -> None:
-        while len(self._sent_name) <= i:
-            self._sent_name.append(False)
-            self._sent_id.append("")
-            self._sent_args.append("")
-
-    def _extract_committed_name(self, i: int) -> str:
-        # We only stash the bool that the name was sent, not the value, so
-        # re-derive from the current payload (cheap, the regex is small).
-        for j, (payload, _) in enumerate(self._iter_tool_call_blocks(self._last_text)):
-            if j == i:
-                name = self._parser.extract_partial_name(payload)
-                return name or ""
-        return ""
-
-    def _iter_tool_call_blocks(self, text: str):
-        """Yield ``(partial_payload, is_complete)`` for each tool-call region in order.
-
-        For the still-open final block, the partial payload has any tail
-        suffix that could be the start of ``end_marker`` withheld, so the
-        client never sees a fragment of the closing tag forwarded as
-        argument bytes.
-        """
-        pos = 0
-        while True:
-            start = text.find(self._start, pos)
-            if start < 0:
-                return
-            payload_start = start + len(self._start)
-            end = text.find(self._end, payload_start)
-            if end < 0:
-                partial = text[payload_start:]
-                safe = _safe_outside_flush_index(partial, self._end)
-                yield partial[:safe], False
-                return
-            yield text[payload_start:end], True
-            pos = end + len(self._end)
-
-
-def _safe_outside_flush_index(buf: str, start_marker: str) -> int:
-    """Index up to which ``buf`` can be flushed without risking a split marker.
-
-    ``buf`` is known not to contain the full marker. The unsafe tail is the
-    longest proper-prefix overlap between ``buf`` and ``start_marker``: if
-    the next chunk completes that prefix, we'd have to retract bytes we
-    already streamed. Holding them back avoids the retraction.
-    """
-    max_overlap = min(len(buf), len(start_marker) - 1)
-    for k in range(max_overlap, 0, -1):
-        if buf.endswith(start_marker[:k]):
-            return len(buf) - k
-    return len(buf)

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -63,6 +63,22 @@ MODEL_CONFIGS: dict[str, dict] = {
         "loader": "llama_cpp",
         "num_cpus": 1,
     },
+    "chat-llama-reasoning": {
+        "name": "chat-llama-reasoning",
+        # Qwen3-0.6B in GGUF form: same family as the vLLM `chat-reasoning`
+        # deployment (which uses the safetensors checkpoint), so the
+        # model emits `<think>...</think>` and supports Hermes-style tool
+        # calls in the same chat template. Lets us exercise reasoning,
+        # tools, and reasoning+tools through the llama_cpp loader in one
+        # deployment. Reasoning chains need headroom, so n_ctx is bumped.
+        "model": "lmstudio-community/Qwen3-0.6B-GGUF:*Q4_K_M.gguf",
+        "usecase": "generate",
+        "loader": "llama_cpp",
+        "num_cpus": 1,
+        "llama_cpp_config": {
+            "n_ctx": 4096,
+        },
+    },
     "chat-transformers": {
         "name": "chat-transformers",
         "model": "Qwen/Qwen2.5-0.5B-Instruct",
@@ -540,6 +556,176 @@ class TestChatLlamaCpp:
         assert parsed_args.get("city")
         assert "Paris" in parsed_args["city"]
         assert collected["finish_reason"] == "tool_calls"
+
+
+@pytest.mark.integration
+class TestChatLlamaCppReasoning:
+    """End-to-end reasoning + tool calling through the llama_cpp loader.
+
+    Same Qwen3-0.6B family as the vLLM `chat-reasoning` deployment but
+    in GGUF form, so the modelship-side ``ChatOutputStreamer`` is
+    actually exercised on real model output (vLLM has its own native
+    reasoning parser, llama_cpp does not). One deployment covers
+    three scenarios because Qwen3 emits ``<think>...</think>`` AND
+    supports Hermes-style tool calls in the same chat template.
+    """
+
+    @pytest.fixture(autouse=True, scope="class")
+    def _deploy(self, model_deployer):
+        model_deployer.deploy("chat-llama-reasoning")
+
+    def test_reasoning_completion_llama_cpp(self):
+        """Non-streaming: ``<think>...`` block routes to ``message.reasoning``,
+        the final answer lands in ``message.content``, no marker leakage."""
+        response = httpx.post(
+            f"{OPENAI_API_BASE}/chat/completions",
+            json={
+                "model": "chat-llama-reasoning",
+                "messages": [{"role": "user", "content": "Briefly: what is 7 times 8?"}],
+                "max_tokens": 1024,
+            },
+            timeout=300,
+        )
+        assert response.status_code == 200, response.text
+        message = response.json()["choices"][0]["message"]
+        assert message.get("reasoning"), f"expected reasoning content, got {message!r}"
+        assert "<think>" not in (message.get("content") or "")
+        assert "</think>" not in (message.get("content") or "")
+        assert "<think>" not in message["reasoning"]
+        assert "</think>" not in message["reasoning"]
+
+    def test_reasoning_streaming_llama_cpp(self):
+        """Streaming: at least one delta carries ``reasoning``; concatenated
+        reasoning is non-empty; markers never leak into either field."""
+        with httpx.stream(
+            "POST",
+            f"{OPENAI_API_BASE}/chat/completions",
+            json={
+                "model": "chat-llama-reasoning",
+                "messages": [{"role": "user", "content": "Briefly: what is 7 times 8?"}],
+                "max_tokens": 1024,
+                "stream": True,
+            },
+            timeout=300,
+        ) as response:
+            assert response.status_code == 200
+            reasoning_parts: list[str] = []
+            content_parts: list[str] = []
+            reasoning_deltas = 0
+            for line in response.iter_lines():
+                if not line.startswith("data: "):
+                    continue
+                payload = line[len("data: ") :]
+                if payload == "[DONE]":
+                    break
+                chunk = json.loads(payload)
+                delta = chunk["choices"][0].get("delta") or {}
+                if delta.get("reasoning"):
+                    reasoning_parts.append(delta["reasoning"])
+                    reasoning_deltas += 1
+                if delta.get("content"):
+                    content_parts.append(delta["content"])
+
+        assert reasoning_deltas >= 1, "expected at least one reasoning delta"
+        assert "".join(reasoning_parts).strip(), "expected non-empty reasoning content"
+        assert "<think>" not in "".join(reasoning_parts)
+        assert "</think>" not in "".join(reasoning_parts)
+        assert "<think>" not in "".join(content_parts)
+        assert "</think>" not in "".join(content_parts)
+
+    def test_reasoning_with_tools_llama_cpp(self, client):
+        """Reasoning + tool calling in one round-trip.
+
+        Asserts that when a reasoning model also emits a tool call, the
+        single-pass ``ChatOutputStreamer`` populates BOTH
+        ``message.reasoning`` and ``message.tool_calls``, and that
+        ``finish_reason="tool_calls"``.
+        """
+        completion = client.chat.completions.create(
+            model="chat-llama-reasoning",
+            messages=[{"role": "user", "content": "What is the weather in Paris?"}],
+            tools=[_WEATHER_TOOL],
+            tool_choice="auto",
+            max_tokens=1024,
+        )
+        message = completion.choices[0].message
+        # The OpenAI Python SDK exposes unknown fields via ``model_extra``.
+        reasoning = getattr(message, "reasoning", None) or message.model_extra.get("reasoning")
+        assert reasoning, f"expected reasoning, got message={message!r}"
+        assert "<think>" not in reasoning
+        tool_calls = message.tool_calls
+        assert tool_calls, f"expected a tool call, got content={message.content!r}, reasoning={reasoning!r}"
+        assert tool_calls[0].function.name == "get_weather"
+        assert "Paris" in tool_calls[0].function.arguments
+        assert completion.choices[0].finish_reason == "tool_calls"
+
+    def test_tool_markers_inside_reasoning_not_double_counted(self, client):
+        """Tool-call markers emitted *inside* ``<think>`` must route to
+        reasoning, never become real tool calls.
+
+        Coaxes the model into illustrating tool-call syntax inside its
+        reasoning and then making one actual call. The single-pass
+        ``ChatOutputStreamer`` must:
+
+        - Surface the illustrative ``<tool_call>...</tool_call>`` text
+          inside ``message.reasoning`` (proving it was treated as
+          reasoning bytes, not a real call).
+        - Emit exactly ONE ``tool_calls`` entry (the actual post-
+          reasoning call), not multiples.
+
+        Real models are non-deterministic; if the prompt fails to
+        produce literal markers in reasoning, we skip the
+        marker-routing assertion rather than flake — the
+        single-tool-call assertion still has value either way. The
+        deterministic equivalent is exercised in unit tests
+        (``tests/test_reasoning.py::TestComposition``).
+        """
+        completion = client.chat.completions.create(
+            model="chat-llama-reasoning",
+            messages=[
+                {
+                    "role": "system",
+                    "content": (
+                        "You are an assistant with access to tools. When you think inside "
+                        "<think>...</think>, FIRST quote one example of tool-call syntax "
+                        "verbatim inside angle brackets — e.g. write the literal text "
+                        '<tool_call>{"name":"example","arguments":{}}</tool_call> as part '
+                        "of your reasoning to remind yourself of the format. THEN decide "
+                        "which real tool to call."
+                    ),
+                },
+                {"role": "user", "content": "What is the weather in Paris?"},
+            ],
+            tools=[_WEATHER_TOOL],
+            tool_choice="auto",
+            max_tokens=1024,
+        )
+        message = completion.choices[0].message
+        reasoning = getattr(message, "reasoning", None) or message.model_extra.get("reasoning") or ""
+        tool_calls = message.tool_calls or []
+
+        # Hard assertions: regardless of prompt compliance, the streamer
+        # must produce exactly one real tool call for the weather query.
+        assert tool_calls, (
+            f"expected exactly one real tool call, got content={message.content!r}, reasoning={reasoning!r}"
+        )
+        assert len(tool_calls) == 1, (
+            f"expected exactly one tool call (markers inside <think> must not be double-counted); "
+            f"got {len(tool_calls)} calls={[tc.function.name for tc in tool_calls]}"
+        )
+        assert tool_calls[0].function.name == "get_weather"
+        assert completion.choices[0].finish_reason == "tool_calls"
+
+        # Soft assertion: only meaningful if the model actually quoted
+        # the marker syntax inside its reasoning.
+        if "<tool_call>" in reasoning:
+            # Reasoning carries the literal marker text — confirms the
+            # streamer routed it to the reasoning view rather than
+            # parsing it as a real call (which would have shown up as a
+            # second tool_calls entry).
+            assert "</tool_call>" in reasoning, (
+                f"reasoning has an unmatched <tool_call> marker (open without close): {reasoning!r}"
+            )
 
 
 @pytest.mark.integration

--- a/tests/test_reasoning.py
+++ b/tests/test_reasoning.py
@@ -1,0 +1,280 @@
+"""Tests for the cross-loader reasoning parser toolkit.
+
+Covers:
+- The reasoning parser registry and the DeepSeek-R1 marker pair.
+- ``ChatOutputStreamer`` running with only a reasoning parser.
+- Composition: reasoning + tool-call parsers together, including the
+  case where a tool-call marker appears *inside* a reasoning region
+  (must not be parsed as a real tool call).
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from modelship.openai.parsers.output import ChatOutputStreamer
+from modelship.openai.parsers.reasoning import (
+    DeepseekR1ReasoningParser,
+    available_parsers,
+    get_parser,
+    register_parser,
+)
+from modelship.openai.parsers.reasoning.parsers import ReasoningParser
+from modelship.openai.parsers.tool_calling.parsers import HermesToolCallParser
+
+
+class TestReasoningRegistry:
+    def test_default_registry_includes_deepseek_r1(self):
+        assert "deepseek_r1" in available_parsers()
+
+    def test_get_parser_returns_singleton(self):
+        a = get_parser("deepseek_r1")
+        b = get_parser("deepseek_r1")
+        assert a is b
+
+    def test_unknown_parser_raises_with_available_list(self):
+        with pytest.raises(ValueError, match="deepseek_r1"):
+            get_parser("does-not-exist")
+
+    def test_register_parser_makes_it_findable(self):
+        class Stub(ReasoningParser):
+            name = "stub-reasoning"
+            start_marker = "<<r>>"
+            end_marker = "<</r>>"
+
+        register_parser(Stub())
+        try:
+            assert get_parser("stub-reasoning").name == "stub-reasoning"
+        finally:
+            from modelship.openai.parsers.reasoning import registry
+
+            registry._PARSERS.pop("stub-reasoning", None)
+
+
+class TestDeepseekR1Markers:
+    def test_marker_pair(self):
+        p = DeepseekR1ReasoningParser()
+        assert p.start_marker == "<think>"
+        assert p.end_marker == "</think>"
+
+
+class TestReasoningOnlyStreamer:
+    """``ChatOutputStreamer`` driven by a reasoning parser alone (no tools)."""
+
+    def _feed(self, chunks: list[str]) -> tuple[ChatOutputStreamer, list]:
+        streamer = ChatOutputStreamer(None, DeepseekR1ReasoningParser())
+        deltas = []
+        cumulative = ""
+        for chunk in chunks:
+            cumulative += chunk
+            d = streamer.extract_streaming(cumulative)
+            if d is not None:
+                deltas.append(d)
+        final = streamer.finalize()
+        if final is not None:
+            deltas.append(final)
+        return streamer, deltas
+
+    def test_at_least_one_parser_required(self):
+        with pytest.raises(ValueError, match="at least one parser"):
+            ChatOutputStreamer(None, None)
+
+    def test_pure_content_streams_immediately(self):
+        _, deltas = self._feed(["Hello", " ", "world"])
+        assert "".join(d.content or "" for d in deltas) == "Hello world"
+        assert all((d.reasoning or "") == "" for d in deltas)
+
+    def test_reasoning_block_routed_to_reasoning_field(self):
+        text = "<think>thinking step</think>final answer"
+        _, deltas = self._feed([text])
+        reasoning = "".join(d.reasoning or "" for d in deltas)
+        content = "".join(d.content or "" for d in deltas)
+        assert reasoning == "thinking step"
+        assert content == "final answer"
+
+    def test_reasoning_streams_incrementally(self):
+        # Drip-feed a `<think>` block one char at a time. We want at least
+        # several reasoning deltas, not one big shot at finalize.
+        text = "<think>abc</think>"
+        _, deltas = self._feed(list(text))
+        reasoning_deltas = [d for d in deltas if d.reasoning]
+        assert len(reasoning_deltas) >= 2
+        assert "".join(d.reasoning or "" for d in deltas) == "abc"
+
+    def test_holds_back_marker_prefix_until_disambiguated(self):
+        # `<th` could be the first chars of `<think>`; the streamer must
+        # not ship those as content mid-stream.
+        streamer = ChatOutputStreamer(None, DeepseekR1ReasoningParser())
+        d = streamer.extract_streaming("hello <th")
+        assert d is not None and d.content == "hello "
+        # Disambiguate by completing the marker → still no content (we
+        # entered a reasoning region instead).
+        d = streamer.extract_streaming("hello <think>x")
+        assert d is None or (d.reasoning or "") == "x"
+
+    def test_held_tail_flushes_when_disambiguated_as_content(self):
+        # `<thr` proves it wasn't `<think>`; the held tail should flush.
+        streamer = ChatOutputStreamer(None, DeepseekR1ReasoningParser())
+        streamer.extract_streaming("hi <th")
+        d = streamer.extract_streaming("hi <thr")
+        # Content should now contain the previously-held `<th` plus `r`.
+        assert d is not None and "thr" in (d.content or "")
+
+    def test_holds_back_close_marker_prefix_inside_reasoning(self):
+        # Inside an open reasoning block, `</thi` could be the start of
+        # `</think>`; mid-stream we must not ship it as reasoning bytes
+        # because the next chunk might prove it was the closer.
+        streamer = ChatOutputStreamer(None, DeepseekR1ReasoningParser())
+        d = streamer.extract_streaming("<think>thinking</thi")
+        # Reasoning so far: "thinking" (the tail "</thi" is held back).
+        assert d is not None and (d.reasoning or "") == "thinking"
+
+    def test_multiple_reasoning_blocks_are_concatenated(self):
+        text = "<think>a</think>between<think>b</think>after"
+        streamer, _ = self._feed([text])
+        result = streamer.result
+        assert result.reasoning == "ab"
+        assert result.content == "betweenafter"
+
+    def test_unterminated_reasoning_block_flushes_at_finalize(self):
+        # Model emits `<think>...` but never closes. Finalize should not
+        # raise; the open block becomes reasoning content (best-effort
+        # rendering of what the model produced).
+        text = "<think>incomplete"
+        streamer, _ = self._feed([text])
+        assert streamer.result.reasoning == "incomplete"
+        assert streamer.result.content is None
+
+    def test_no_reasoning_no_content_returns_no_delta(self):
+        streamer = ChatOutputStreamer(None, DeepseekR1ReasoningParser())
+        # An empty cumulative text produces nothing.
+        assert streamer.extract_streaming("") is None
+
+    def test_chunk_boundary_in_open_marker(self):
+        # The opening `<think>` is split exactly at `<think` / `>`.
+        streamer = ChatOutputStreamer(None, DeepseekR1ReasoningParser())
+        d1 = streamer.extract_streaming("hi <think")
+        d2 = streamer.extract_streaming("hi <think>r")
+        d3 = streamer.extract_streaming("hi <think>r</think>ok")
+        # Combine all yielded deltas + finalize.
+        deltas = [d for d in (d1, d2, d3) if d is not None]
+        final = streamer.finalize()
+        if final is not None:
+            deltas.append(final)
+        assert "".join(d.reasoning or "" for d in deltas) == "r"
+        assert "".join(d.content or "" for d in deltas) == "hi ok"
+
+
+class TestComposition:
+    """ChatOutputStreamer with both reasoning + tool-call parsers active.
+
+    The single-pass design must route tool-call markers that appear
+    inside a reasoning region to the reasoning view, NOT parse them as
+    real tool calls.
+    """
+
+    def _feed(self, chunks: list[str]) -> tuple[ChatOutputStreamer, list]:
+        streamer = ChatOutputStreamer(HermesToolCallParser(), DeepseekR1ReasoningParser())
+        deltas = []
+        cumulative = ""
+        for chunk in chunks:
+            cumulative += chunk
+            d = streamer.extract_streaming(cumulative)
+            if d is not None:
+                deltas.append(d)
+        final = streamer.finalize()
+        if final is not None:
+            deltas.append(final)
+        return streamer, deltas
+
+    def test_reasoning_then_tool_call_then_residual(self):
+        text = (
+            "<think>I should call get_weather</think>"
+            '<tool_call>{"name": "get_weather", "arguments": {"city": "Paris"}}</tool_call>'
+            "ok"
+        )
+        streamer, deltas = self._feed([text])
+        # Reasoning surfaced.
+        assert "".join(d.reasoning or "" for d in deltas) == "I should call get_weather"
+        # Real tool call extracted.
+        assert len(streamer.result.tool_calls) == 1
+        assert streamer.result.tool_calls[0].function.name == "get_weather"
+        # `ok` ends up in content view.
+        assert (streamer.result.content or "") == "ok"
+
+    def test_tool_marker_inside_reasoning_is_not_a_real_tool_call(self):
+        # The model is "thinking out loud" about tool calls inside its
+        # `<think>` block. Those markers must NOT be parsed as real
+        # tool calls — they're part of the reasoning text.
+        text = '<think>I might need <tool_call>{"name":"x","arguments":{}}</tool_call> later</think>actual answer'
+        streamer, _ = self._feed([text])
+        assert streamer.result.tool_calls == []
+        # Reasoning includes the literal markers because the streamer
+        # surfaces the reasoning region's bytes verbatim.
+        assert (streamer.result.reasoning or "").startswith("I might need <tool_call>")
+        assert streamer.result.content == "actual answer"
+
+    def test_real_tool_call_after_reasoning_streams_correctly(self):
+        # Char-by-char to confirm both streams progress incrementally.
+        text = '<think>plan</think><tool_call>{"name": "ping", "arguments": {"x": 1}}</tool_call>'
+        _, deltas = self._feed(list(text))
+
+        reasoning = "".join(d.reasoning or "" for d in deltas)
+        assert reasoning == "plan"
+
+        tool_deltas = [tc for d in deltas for tc in d.tool_calls]
+        names = [tc.function.name for tc in tool_deltas if tc.function and tc.function.name]
+        assert names == ["ping"]
+        joined_args = "".join(
+            tc.function.arguments or "" for tc in tool_deltas if tc.function and tc.function.arguments
+        )
+        assert json.loads(joined_args) == {"x": 1}
+
+    def test_chunk_boundary_at_marker_seam(self):
+        # The chunk lands exactly at `<thi` / `nk>...</think><tool_call>...`
+        # — the streamer must hold `<thi` until the next chunk proves
+        # which marker (or none) it belonged to.
+        chunks = [
+            "hello ",
+            "<thi",
+            'nk>r</think><tool_call>{"name": "p", "arguments": {}}</tool_call>',
+        ]
+        streamer, deltas = self._feed(chunks)
+        # `hello ` lands as content, never `hello <thi`.
+        contents = "".join(d.content or "" for d in deltas)
+        # Note: residual content may be empty after the tool call (the
+        # model emitted nothing post-call), but `hello ` is in there.
+        assert contents.startswith("hello ")
+        # Real tool call extracted.
+        assert [tc.function.name for tc in streamer.result.tool_calls] == ["p"]
+        # Reasoning extracted.
+        assert streamer.result.reasoning == "r"
+
+    def test_finish_reason_with_reasoning_only_is_stop(self):
+        from modelship.openai.parsers.streaming import finish_reason_for
+
+        text = "<think>r</think>ok"
+        streamer, _ = self._feed([text])
+        assert finish_reason_for(streamer.result, completion_tokens=10, max_tokens=100) == "stop"
+
+    def test_finish_reason_with_tool_calls_overrides(self):
+        from modelship.openai.parsers.streaming import finish_reason_for
+
+        text = '<think>r</think><tool_call>{"name": "f", "arguments": {}}</tool_call>'
+        streamer, _ = self._feed([text])
+        assert finish_reason_for(streamer.result, completion_tokens=10, max_tokens=100) == "tool_calls"
+
+
+class TestParseFullViaToolCallParser:
+    """`ToolCallParser.parse()` returns the unified ParsedChatOutput."""
+
+    def test_parse_returns_parsed_chat_output(self):
+        from modelship.openai.parsers.output import ParsedChatOutput
+
+        text = '<tool_call>{"name": "x", "arguments": {}}</tool_call>'
+        result = HermesToolCallParser().parse(text)
+        assert isinstance(result, ParsedChatOutput)
+        assert result.has_tool_calls
+        assert result.reasoning is None

--- a/tests/test_tool_calling.py
+++ b/tests/test_tool_calling.py
@@ -7,8 +7,8 @@ from typing import ClassVar
 
 import pytest
 
+from modelship.openai.parsers.output import ChatOutputStreamer
 from modelship.openai.parsers.tool_calling import (
-    ToolCallStreamer,
     available_parsers,
     get_parser,
     register_parser,
@@ -123,7 +123,7 @@ class TestHermesParser:
         assert result.tool_calls[0].id != result.tool_calls[1].id
 
 
-class TestToolCallStreamer:
+class TestChatOutputStreamer:
     """Drive the streamer one chunk at a time and verify the deltas.
 
     The cumulative-text protocol matches what serving_chat does in production:
@@ -131,8 +131,8 @@ class TestToolCallStreamer:
     delta.
     """
 
-    def _feed(self, chunks: list[str]) -> tuple[ToolCallStreamer, list]:
-        streamer = ToolCallStreamer(HermesToolCallParser())
+    def _feed(self, chunks: list[str]) -> tuple[ChatOutputStreamer, list]:
+        streamer = ChatOutputStreamer(HermesToolCallParser())
         deltas = []
         cumulative = ""
         for chunk in chunks:
@@ -154,7 +154,7 @@ class TestToolCallStreamer:
         # `<` could be the first char of `<tool_call>`; the streamer must not
         # ship it mid-stream. Once finalize() runs (no more text coming) the
         # held tail is safe to flush as content.
-        streamer = ToolCallStreamer(HermesToolCallParser())
+        streamer = ChatOutputStreamer(HermesToolCallParser())
         mid = streamer.extract_streaming("before <")
         assert mid is not None and mid.content == "before "
         final = streamer.finalize()
@@ -221,7 +221,7 @@ class TestToolCallStreamer:
     def test_partial_name_held_until_closing_quote(self):
         # While the model is mid-name (``"name": "get_wea`` so far), the
         # streamer must NOT send a partial name — wait for the closing quote.
-        streamer = ToolCallStreamer(HermesToolCallParser())
+        streamer = ChatOutputStreamer(HermesToolCallParser())
         partial = '<tool_call>{"name": "get_wea'
         d = streamer.extract_streaming(partial)
         # No name yet → no tool delta.

--- a/tests/test_tool_calling.py
+++ b/tests/test_tool_calling.py
@@ -78,10 +78,18 @@ class TestHermesParser:
         assert [tc.function.name for tc in result.tool_calls] == ["a", "b"]
 
     def test_tool_call_with_residual_text(self):
+        # Trailing whitespace in the preamble is preserved — only an
+        # all-whitespace residual gets nulled out alongside tool_calls.
         text = 'Sure, calling that.\n<tool_call>{"name": "ping", "arguments": {}}</tool_call>'
         result = self.parser.parse(text)
         assert len(result.tool_calls) == 1
-        assert result.content == "Sure, calling that."
+        assert result.content == "Sure, calling that.\n"
+
+    def test_whitespace_only_preamble_nulls_content(self):
+        text = '   \n<tool_call>{"name": "ping", "arguments": {}}</tool_call>'
+        result = self.parser.parse(text)
+        assert len(result.tool_calls) == 1
+        assert result.content is None
 
     def test_string_arguments_forwarded_verbatim(self):
         # vLLM-style: the streamer forwards the raw bytes of the arguments

--- a/tests/test_transformers_chat_tools.py
+++ b/tests/test_transformers_chat_tools.py
@@ -148,7 +148,7 @@ async def test_tool_call_with_trailing_text_preserves_content():
 
     assert isinstance(resp, ChatCompletionResponse)
     msg = resp.choices[0].message
-    assert msg.content == "Calling now."
+    assert msg.content == "Calling now.\n"
     assert len(msg.tool_calls) == 1
 
 


### PR DESCRIPTION
Extends reasoning support across the llama_cpp loader. The model's raw output is now walked once by a unified ChatOutputStreamer that handles both reasoning markers (`<think>...</think>`) and tool-call markers in a single pass, so a tool-call marker emitted inside a reasoning region is correctly routed to `message.reasoning` and never double-counted as a real tool call.

Restructures the parsers package so the unified streamer + streaming helpers live one level up:

  modelship/openai/parsers/
    output.py        - ChatOutputStreamer, ParsedChatOutput
    streaming.py     - stream_chat_completion, build_chat_completion_response
    reasoning/       - ReasoningParser ABC + DeepseekR1 + registry
    tool_calling/    - ToolCallParser ABC + Hermes + registry (unchanged)

Renames ToolCallStreamer -> ChatOutputStreamer and ParsedToolCalls -> ParsedChatOutput in place; both now carry reasoning alongside content and tool_calls. The streaming helpers accept an optional reasoning_parser_name argument independently from parser_name.

Llama_cpp now drives `create_completion` raw whenever a chat template is resolvable and `chat_format` is unset. The native `create_chat_completion` path is kept only as a fallback for users who explicitly opted into llama-cpp's templating via `chat_format`.

Tests:
- tests/test_reasoning.py: registry, marker pair, reasoning-only streaming (incl. chunk-boundary cases), composition with tool-calling (incl. tool markers inside `<think>` not double-counted).
- tests/test_tool_calling.py: import paths + class names updated.
- tests/test_integration.py: new chat-llama-reasoning deployment (Qwen3-0.6B-GGUF) covering reasoning, streaming reasoning, reasoning+tools, and end-to-end marker-routing.

