### PR TITLE
feat: transformers reasoning content

### DIFF
--- a/modelship/infer/transformers/openai/serving_chat.py
+++ b/modelship/infer/transformers/openai/serving_chat.py
@@ -11,6 +11,7 @@ from modelship.infer.infer_config import RawRequestProxy, TransformersConfig
 from modelship.infer.transformers.capabilities import TransformersCapabilities
 from modelship.logging import TRACE, get_logger
 from modelship.openai.chat_utils import UnsupportedContentError, normalize_chat_messages
+from modelship.openai.parsers.reasoning import get_parser as get_reasoning_parser
 from modelship.openai.parsers.streaming import build_chat_completion_response, stream_chat_completion
 from modelship.openai.parsers.tool_calling import get_parser, resolve_tools_for_request
 from modelship.openai.protocol import (
@@ -33,22 +34,27 @@ class OpenAIServingChat(OpenAIServing):
         model_name: str,
         config: TransformersConfig,
         capabilities: TransformersCapabilities,
-        tool_call_parser: str | None,
+        tool_call_parser: str | None = None,
+        reasoning_parser: str | None = None,
     ):
         self.pipeline = pipeline
         self.model_name = model_name
         self.config = config
         self.capabilities = capabilities
         self.tool_call_parser = tool_call_parser
+        self.reasoning_parser = reasoning_parser
         assert pipeline.tokenizer is not None, "text-generation pipeline must have a tokenizer"
         self.tokenizer: PreTrainedTokenizerBase = pipeline.tokenizer
         self._lock = asyncio.Lock()
-        # Validate the configured parser at startup so misconfiguration surfaces
+        # Validate configured parsers at startup so misconfiguration surfaces
         # before the first request rather than mid-generation. None means
         # auto-detection found no usable parser; tool calls in requests will be
-        # dropped with a warning at request time.
+        # dropped with a warning at request time, and reasoning will simply
+        # not be extracted.
         if tool_call_parser is not None:
             get_parser(tool_call_parser)
+        if reasoning_parser is not None:
+            get_reasoning_parser(reasoning_parser)
 
     async def warmup(self) -> None:
         logger.info("Warming up chat model: %s", self.model_name)
@@ -94,11 +100,18 @@ class OpenAIServingChat(OpenAIServing):
             max_tokens = request.max_completion_tokens
 
         parser_name = self.tool_call_parser if tools else None
+        reasoning_parser_name = self.reasoning_parser
 
         if request.stream:
             include_usage = bool(request.stream_options and request.stream_options.include_usage)
             return self._locked_stream(
-                request_id, messages, tools, max_tokens, parser_name=parser_name, include_usage=include_usage
+                request_id,
+                messages,
+                tools,
+                max_tokens,
+                parser_name=parser_name,
+                reasoning_parser_name=reasoning_parser_name,
+                include_usage=include_usage,
             )
 
         async with self._lock:
@@ -117,6 +130,7 @@ class OpenAIServingChat(OpenAIServing):
             model_name=self.model_name,
             text=completion_text,
             parser_name=parser_name,
+            reasoning_parser_name=reasoning_parser_name,
             prompt_tokens=prompt_tokens,
             completion_tokens=completion_tokens,
             max_tokens=max_tokens,
@@ -178,11 +192,18 @@ class OpenAIServingChat(OpenAIServing):
         max_tokens: int | None,
         *,
         parser_name: str | None,
+        reasoning_parser_name: str | None,
         include_usage: bool,
     ) -> AsyncGenerator[str, None]:
         async with self._lock:
             async for chunk in self._stream(
-                request_id, messages, tools, max_tokens, parser_name=parser_name, include_usage=include_usage
+                request_id,
+                messages,
+                tools,
+                max_tokens,
+                parser_name=parser_name,
+                reasoning_parser_name=reasoning_parser_name,
+                include_usage=include_usage,
             ):
                 yield chunk
 
@@ -194,6 +215,7 @@ class OpenAIServingChat(OpenAIServing):
         max_tokens: int | None,
         *,
         parser_name: str | None,
+        reasoning_parser_name: str | None,
         include_usage: bool,
     ) -> AsyncGenerator[str, None]:
         streamer = TextIteratorStreamer(self.tokenizer, skip_prompt=True, skip_special_tokens=True)  # type: ignore[arg-type]
@@ -220,6 +242,7 @@ class OpenAIServingChat(OpenAIServing):
                 model_name=self.model_name,
                 text_chunks=_async_iter(streamer),
                 parser_name=parser_name,
+                reasoning_parser_name=reasoning_parser_name,
                 count_tokens=lambda text: len(self.tokenizer.encode(text, add_special_tokens=False)),
                 prompt_tokens=self._count_prompt_tokens(messages, tools),
                 max_tokens=max_tokens,

--- a/modelship/infer/transformers/transformers_infer.py
+++ b/modelship/infer/transformers/transformers_infer.py
@@ -84,12 +84,18 @@ class TransformersInfer(BaseInfer):
             capabilities = TransformersCapabilities.detect(pipe)
             if capabilities.supports_image:
                 logger.info("Multimodal (vision) capability detected for model: %s", self.model_config.name)
-            # `resolve_all_tool_parsers` already honored `tool_calls_enabled=False`
-            # (opt-out leaves the resolved field None) and captured an explicit
-            # `tool_call_parser` setting if any. Read the resolved value directly.
+            # `resolve_all_tool_parsers` / `resolve_all_reasoning_parsers`
+            # already honored loader-specific opt-outs (leaving the resolved
+            # field None) and captured explicit overrides. Read both directly.
             tool_call_parser = self.model_config._resolved_tool_call_parser
+            reasoning_parser = self.model_config._resolved_reasoning_parser
             self.serving_chat = OpenAIServingChat(
-                pipe, self.model_config.name, self.config, capabilities, tool_call_parser
+                pipe,
+                self.model_config.name,
+                self.config,
+                capabilities,
+                tool_call_parser=tool_call_parser,
+                reasoning_parser=reasoning_parser,
             )
             self._serving.append(self.serving_chat)
 

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -90,6 +90,23 @@ MODEL_CONFIGS: dict[str, dict] = {
             "torch_dtype": "float32",
         },
     },
+    "chat-transformers-reasoning": {
+        "name": "chat-transformers-reasoning",
+        # Qwen3-0.6B safetensors — same family as the vLLM `chat-reasoning`
+        # and llama_cpp `chat-llama-reasoning` deployments. Lets us
+        # exercise reasoning, tools, and reasoning+tools through the
+        # transformers loader's `ChatOutputStreamer` wiring on real model
+        # output. CPU-only and float32 to match the rest of the
+        # transformers integration suite.
+        "model": "Qwen/Qwen3-0.6B",
+        "usecase": "generate",
+        "loader": "transformers",
+        "num_cpus": 2,
+        "transformers_config": {
+            "device": "cpu",
+            "torch_dtype": "float32",
+        },
+    },
     "embed-model": {
         "name": "embed-model",
         "model": "nomic-ai/nomic-embed-text-v1.5",
@@ -726,6 +743,105 @@ class TestChatLlamaCppReasoning:
             assert "</tool_call>" in reasoning, (
                 f"reasoning has an unmatched <tool_call> marker (open without close): {reasoning!r}"
             )
+
+
+@pytest.mark.integration
+class TestChatTransformersReasoning:
+    """End-to-end reasoning + tool calling through the transformers loader.
+
+    Qwen3-0.6B safetensors driven through the HF text-generation pipeline.
+    Verifies that ``transformers/openai/serving_chat.py`` plumbs
+    ``_resolved_reasoning_parser`` into the unified ``ChatOutputStreamer``
+    and that reasoning, tools, and reasoning+tools all surface correctly
+    on real model output.
+    """
+
+    @pytest.fixture(autouse=True, scope="class")
+    def _deploy(self, model_deployer):
+        model_deployer.deploy("chat-transformers-reasoning")
+
+    def test_reasoning_completion_transformers(self):
+        """Non-streaming: ``<think>...`` block routes to ``message.reasoning``,
+        the final answer lands in ``message.content``, no marker leakage."""
+        response = httpx.post(
+            f"{OPENAI_API_BASE}/chat/completions",
+            json={
+                "model": "chat-transformers-reasoning",
+                "messages": [{"role": "user", "content": "Briefly: what is 7 times 8?"}],
+                "max_tokens": 1024,
+            },
+            timeout=300,
+        )
+        assert response.status_code == 200, response.text
+        message = response.json()["choices"][0]["message"]
+        assert message.get("reasoning"), f"expected reasoning content, got {message!r}"
+        assert "<think>" not in (message.get("content") or "")
+        assert "</think>" not in (message.get("content") or "")
+        assert "<think>" not in message["reasoning"]
+        assert "</think>" not in message["reasoning"]
+
+    def test_reasoning_streaming_transformers(self):
+        """Streaming: at least one delta carries ``reasoning``; concatenated
+        reasoning is non-empty; markers never leak into either field."""
+        with httpx.stream(
+            "POST",
+            f"{OPENAI_API_BASE}/chat/completions",
+            json={
+                "model": "chat-transformers-reasoning",
+                "messages": [{"role": "user", "content": "Briefly: what is 7 times 8?"}],
+                "max_tokens": 1024,
+                "stream": True,
+            },
+            timeout=300,
+        ) as response:
+            assert response.status_code == 200
+            reasoning_parts: list[str] = []
+            content_parts: list[str] = []
+            reasoning_deltas = 0
+            for line in response.iter_lines():
+                if not line.startswith("data: "):
+                    continue
+                payload = line[len("data: ") :]
+                if payload == "[DONE]":
+                    break
+                chunk = json.loads(payload)
+                delta = chunk["choices"][0].get("delta") or {}
+                if delta.get("reasoning"):
+                    reasoning_parts.append(delta["reasoning"])
+                    reasoning_deltas += 1
+                if delta.get("content"):
+                    content_parts.append(delta["content"])
+
+        assert reasoning_deltas >= 1, "expected at least one reasoning delta"
+        assert "".join(reasoning_parts).strip(), "expected non-empty reasoning content"
+        assert "<think>" not in "".join(reasoning_parts)
+        assert "</think>" not in "".join(reasoning_parts)
+        assert "<think>" not in "".join(content_parts)
+        assert "</think>" not in "".join(content_parts)
+
+    def test_reasoning_with_tools_transformers(self, client):
+        """Reasoning + tool calling in one round-trip through transformers.
+
+        Mirrors ``TestChatLlamaCppReasoning.test_reasoning_with_tools_llama_cpp``:
+        the single-pass ``ChatOutputStreamer`` must populate BOTH
+        ``message.reasoning`` and ``message.tool_calls``.
+        """
+        completion = client.chat.completions.create(
+            model="chat-transformers-reasoning",
+            messages=[{"role": "user", "content": "What is the weather in Paris?"}],
+            tools=[_WEATHER_TOOL],
+            tool_choice="auto",
+            max_tokens=1024,
+        )
+        message = completion.choices[0].message
+        reasoning = getattr(message, "reasoning", None) or message.model_extra.get("reasoning")
+        assert reasoning, f"expected reasoning, got message={message!r}"
+        assert "<think>" not in reasoning
+        tool_calls = message.tool_calls
+        assert tool_calls, f"expected a tool call, got content={message.content!r}, reasoning={reasoning!r}"
+        assert tool_calls[0].function.name == "get_weather"
+        assert "Paris" in tool_calls[0].function.arguments
+        assert completion.choices[0].finish_reason == "tool_calls"
 
 
 @pytest.mark.integration

--- a/tests/test_transformers_chat_reasoning.py
+++ b/tests/test_transformers_chat_reasoning.py
@@ -1,0 +1,178 @@
+"""Tests for the Transformers chat path's reasoning + tool-call composition.
+
+These tests bypass the real HF pipeline by injecting a callable that returns
+a canned generation, so they run offline and do not touch any model weights.
+The shared parser/streamer logic is exercised in ``test_reasoning.py`` and
+``test_tool_calling.py``; this file focuses on the wiring between
+``transformers/openai/serving_chat.py`` and the unified streamer.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import pytest
+
+from modelship.infer.infer_config import RawRequestProxy, TransformersConfig
+from modelship.infer.transformers.capabilities import TransformersCapabilities
+from modelship.infer.transformers.openai.serving_chat import OpenAIServingChat
+from modelship.openai.protocol import ChatCompletionRequest, ChatCompletionResponse
+
+
+class _FakeTokenizer:
+    def encode(self, text: str, add_special_tokens: bool = False) -> list[int]:
+        return [0] * len(text.split())
+
+    def apply_chat_template(self, messages: list[dict], **kwargs: Any) -> Any:
+        prompt = "\n".join(f"{m['role']}: {m.get('content', '')}" for m in messages)
+        if "tools" in kwargs:
+            prompt = f"[TOOLS:{len(kwargs['tools'])}]\n" + prompt
+        if kwargs.get("tokenize"):
+            return [0] * len(prompt.split())
+        return prompt
+
+
+class _FakePipeline:
+    def __init__(self, generated_text: str):
+        self.tokenizer = _FakeTokenizer()
+        self.task = "text-generation"
+        self.generated_text = generated_text
+
+    def __call__(self, inputs: Any, **kwargs: Any) -> list[dict]:
+        return [{"generated_text": self.generated_text}]
+
+
+def _make_serving(
+    generated: str,
+    *,
+    tool_call_parser: str | None = None,
+    reasoning_parser: str | None = "deepseek_r1",
+) -> OpenAIServingChat:
+    pipe = _FakePipeline(generated)
+    return OpenAIServingChat(
+        pipeline=pipe,  # type: ignore[arg-type]
+        model_name="test-model",
+        config=TransformersConfig(),
+        capabilities=TransformersCapabilities(supports_image=False, supports_audio=False),
+        tool_call_parser=tool_call_parser,
+        reasoning_parser=reasoning_parser,
+    )
+
+
+def _raw_request() -> RawRequestProxy:
+    return RawRequestProxy(None, {})
+
+
+@pytest.mark.asyncio
+async def test_reasoning_only_response_splits_thinking_and_content():
+    raw = "<think>let me think</think>The answer is 42."
+    serving = _make_serving(raw)
+    req = ChatCompletionRequest(messages=[{"role": "user", "content": "hi"}], stream=False)
+    resp = await serving.create_chat_completion(req, _raw_request())
+
+    assert isinstance(resp, ChatCompletionResponse)
+    msg = resp.choices[0].message
+    assert msg.reasoning == "let me think"
+    assert msg.content == "The answer is 42."
+    assert msg.tool_calls == []
+    assert resp.choices[0].finish_reason == "stop"
+
+
+@pytest.mark.asyncio
+async def test_reasoning_with_no_markers_falls_back_to_content():
+    # Reasoning parser is configured, but the model emitted no <think>
+    # block — content should pass through intact and reasoning is None.
+    serving = _make_serving("just a regular reply")
+    req = ChatCompletionRequest(messages=[{"role": "user", "content": "hi"}], stream=False)
+    resp = await serving.create_chat_completion(req, _raw_request())
+
+    assert isinstance(resp, ChatCompletionResponse)
+    msg = resp.choices[0].message
+    assert msg.reasoning is None
+    assert msg.content == "just a regular reply"
+
+
+@pytest.mark.asyncio
+async def test_tool_call_marker_inside_thinking_is_not_parsed_as_tool_call():
+    # The single-pass streamer routes the tool marker inside <think> to the
+    # reasoning view; it must NOT show up as a finalized tool call.
+    raw = (
+        '<think>I would call <tool_call>{"name": "x", "arguments": {}}</tool_call> here</think>'
+        "Sure, I'll call it for real now."
+    )
+    serving = _make_serving(raw, tool_call_parser="hermes", reasoning_parser="deepseek_r1")
+    req = ChatCompletionRequest(
+        messages=[{"role": "user", "content": "ping"}],
+        tools=[{"type": "function", "function": {"name": "x"}}],
+        stream=False,
+    )
+    resp = await serving.create_chat_completion(req, _raw_request())
+
+    assert isinstance(resp, ChatCompletionResponse)
+    msg = resp.choices[0].message
+    assert msg.tool_calls == []
+    assert msg.reasoning is not None
+    assert "<tool_call>" in msg.reasoning  # the marker text lives inside reasoning
+    assert msg.content == "Sure, I'll call it for real now."
+    assert resp.choices[0].finish_reason == "stop"
+
+
+@pytest.mark.asyncio
+async def test_thinking_then_real_tool_call_after_close_marker():
+    # Reasoning closes before a real tool call is emitted; both should land.
+    raw = (
+        "<think>I should call get_weather for Paris.</think>"
+        '<tool_call>{"name": "get_weather", "arguments": {"city": "Paris"}}</tool_call>'
+    )
+    serving = _make_serving(raw, tool_call_parser="hermes", reasoning_parser="deepseek_r1")
+    req = ChatCompletionRequest(
+        messages=[{"role": "user", "content": "weather paris?"}],
+        tools=[{"type": "function", "function": {"name": "get_weather"}}],
+        stream=False,
+    )
+    resp = await serving.create_chat_completion(req, _raw_request())
+
+    assert isinstance(resp, ChatCompletionResponse)
+    msg = resp.choices[0].message
+    assert msg.reasoning == "I should call get_weather for Paris."
+    assert len(msg.tool_calls) == 1
+    assert msg.tool_calls[0].function.name == "get_weather"
+    assert json.loads(msg.tool_calls[0].function.arguments) == {"city": "Paris"}
+    assert msg.content is None
+    assert resp.choices[0].finish_reason == "tool_calls"
+
+
+@pytest.mark.asyncio
+async def test_unknown_reasoning_parser_at_init_raises():
+    pipe = _FakePipeline("anything")
+    with pytest.raises(ValueError, match="reasoning"):
+        OpenAIServingChat(
+            pipeline=pipe,  # type: ignore[arg-type]
+            model_name="test-model",
+            config=TransformersConfig(),
+            capabilities=TransformersCapabilities(supports_image=False, supports_audio=False),
+            reasoning_parser="not-a-real-parser",
+        )
+
+
+@pytest.mark.asyncio
+async def test_no_parsers_configured_passes_text_through_unchanged():
+    # Both parsers None: the chat path must not extract anything, even if the
+    # model happens to emit marker-shaped tokens.
+    raw = "<think>shouldn't be split</think>plain"
+    pipe = _FakePipeline(raw)
+    serving = OpenAIServingChat(
+        pipeline=pipe,  # type: ignore[arg-type]
+        model_name="test-model",
+        config=TransformersConfig(),
+        capabilities=TransformersCapabilities(supports_image=False, supports_audio=False),
+    )
+    req = ChatCompletionRequest(messages=[{"role": "user", "content": "hi"}], stream=False)
+    resp = await serving.create_chat_completion(req, _raw_request())
+
+    assert isinstance(resp, ChatCompletionResponse)
+    msg = resp.choices[0].message
+    assert msg.reasoning is None
+    assert msg.content == raw
+    assert msg.tool_calls == []


### PR DESCRIPTION
Wires `_resolved_reasoning_parser` through the transformers chat serving path, completing PR4 of the reasoning content sequence (after vLLM and llama_cpp). The unified ChatOutputStreamer now runs across all three generative loaders, so a `<think>...</think>` block emitted by a transformers-driven model surfaces on `message.reasoning` and tool-call markers inside reasoning are correctly routed to the reasoning view rather than parsed as real calls.

- `OpenAIServingChat.__init__` accepts `reasoning_parser`; both parser kwargs default to None for symmetry with llama_cpp.
- Streaming and non-streaming paths plumb `reasoning_parser_name` into the shared streaming helpers.
- Driver wiring reads `_resolved_reasoning_parser` next to the tool-call parser and passes both to the serving constructor.

Tests:
- New unit suite (offline, fake pipeline) covering reasoning-only responses, reasoning + tool composition, marker-inside-reasoning routing, init validation, and the no-parsers passthrough case.
- New integration class `TestChatTransformersReasoning` mirroring the llama_cpp Qwen3 setup: reasoning completion, reasoning streaming, and reasoning + tools through the transformers loader.

