### PR TITLE
feat: mistral tool-call parser

### DIFF
--- a/modelship/openai/parsers/output.py
+++ b/modelship/openai/parsers/output.py
@@ -188,10 +188,13 @@ class ChatOutputStreamer:
                 if end < 0:
                     partial = text[payload_start:]
                     if hold_marker_tail:
-                        safe = _safe_overlap_index(partial, self._tool_end)
+                        # No end marker → region extends to EOS; nothing to hold back.
+                        safe = _safe_overlap_index(partial, self._tool_end) if self._tool_end else len(partial)
                         regions.append(("tool_call", partial[:safe], False))
                     else:
-                        regions.append(("tool_call", partial, False))
+                        # Finalize: with an end marker we never saw it (unterminated, leave incomplete);
+                        # without an end marker the region is complete by design.
+                        regions.append(("tool_call", partial, not self._tool_end))
                     break
                 regions.append(("tool_call", text[payload_start:end], True))
                 pos = end + len(self._tool_end)
@@ -240,54 +243,67 @@ class ChatOutputStreamer:
             return []
         deltas: list[DeltaToolCall] = []
         tool_blocks = [(payload, complete) for kind, payload, complete in regions if kind == "tool_call"]
-        for i, (payload, is_complete) in enumerate(tool_blocks):
-            self._ensure_slot(i)
+        # Flatten across regions and sub-blocks. Most parsers map one region to
+        # one call (default `split_payload`); families like Mistral wrap N calls
+        # in a single envelope and split them out here. The flat index is what
+        # the OpenAI ``tool_calls[i]`` slot uses.
+        flat_index = 0
+        stop = False
+        for region_payload, region_complete in tool_blocks:
+            if stop:
+                break
+            for sub_payload, sub_complete in self._tool_parser.split_payload(region_payload, region_complete):
+                i = flat_index
+                self._ensure_slot(i)
 
-            if not self._sent_name[i]:
-                name = self._tool_parser.extract_partial_name(payload)
-                if name is None:
-                    if is_complete:
-                        # Closed but malformed (no extractable name) — skip,
-                        # but still process later blocks.
-                        continue
-                    # Mid-stream and no name yet; per OpenAI convention we don't
-                    # advance to later blocks until the current one has a name.
-                    break
-                tool_id = f"chatcmpl-tool-{random_uuid()}"
-                self._sent_name[i] = True
-                self._sent_id[i] = tool_id
-                deltas.append(
-                    DeltaToolCall(
-                        index=i,
-                        id=tool_id,
-                        type="function",
-                        function=DeltaFunctionCall(name=name),
+                if not self._sent_name[i]:
+                    name = self._tool_parser.extract_partial_name(sub_payload)
+                    if name is None:
+                        if sub_complete:
+                            # Closed but malformed (no extractable name) — skip,
+                            # but still process later sub-blocks.
+                            flat_index += 1
+                            continue
+                        # Mid-stream and no name yet; per OpenAI convention we don't
+                        # advance to later blocks until the current one has a name.
+                        stop = True
+                        break
+                    tool_id = f"chatcmpl-tool-{random_uuid()}"
+                    self._sent_name[i] = True
+                    self._sent_id[i] = tool_id
+                    deltas.append(
+                        DeltaToolCall(
+                            index=i,
+                            id=tool_id,
+                            type="function",
+                            function=DeltaFunctionCall(name=name),
+                        )
                     )
-                )
 
-            args = self._tool_parser.extract_partial_args(payload)
-            if args is not None and len(args) > len(self._sent_args[i]):
-                diff = args[len(self._sent_args[i]) :]
-                self._sent_args[i] = args
-                deltas.append(
-                    DeltaToolCall(
-                        index=i,
-                        function=DeltaFunctionCall(arguments=diff),
+                args = self._tool_parser.extract_partial_args(sub_payload)
+                if args is not None and len(args) > len(self._sent_args[i]):
+                    diff = args[len(self._sent_args[i]) :]
+                    self._sent_args[i] = args
+                    deltas.append(
+                        DeltaToolCall(
+                            index=i,
+                            function=DeltaFunctionCall(arguments=diff),
+                        )
                     )
-                )
 
-            if is_complete and i not in self._finalized_indices and self._sent_name[i]:
-                self._finalized_indices.add(i)
-                self._finalized_calls.append(
-                    ToolCall(
-                        id=self._sent_id[i],
-                        type="function",
-                        function=FunctionCall(
-                            name=self._tool_parser.extract_partial_name(payload) or "",
-                            arguments=self._sent_args[i],
-                        ),
+                if sub_complete and i not in self._finalized_indices and self._sent_name[i]:
+                    self._finalized_indices.add(i)
+                    self._finalized_calls.append(
+                        ToolCall(
+                            id=self._sent_id[i],
+                            type="function",
+                            function=FunctionCall(
+                                name=self._tool_parser.extract_partial_name(sub_payload) or "",
+                                arguments=self._sent_args[i],
+                            ),
+                        )
                     )
-                )
+                flat_index += 1
         return deltas
 
     def _ensure_slot(self, i: int) -> None:

--- a/modelship/openai/parsers/tool_calling/__init__.py
+++ b/modelship/openai/parsers/tool_calling/__init__.py
@@ -9,11 +9,12 @@ streaming helpers from ``modelship.openai.parsers.streaming``.
 """
 
 from modelship.openai.parsers.tool_calling.input import resolve_tools_for_request
-from modelship.openai.parsers.tool_calling.parsers import HermesToolCallParser, ToolCallParser
+from modelship.openai.parsers.tool_calling.parsers import HermesToolCallParser, MistralToolCallParser, ToolCallParser
 from modelship.openai.parsers.tool_calling.registry import available_parsers, get_parser, register_parser
 
 __all__ = [
     "HermesToolCallParser",
+    "MistralToolCallParser",
     "ToolCallParser",
     "available_parsers",
     "get_parser",

--- a/modelship/openai/parsers/tool_calling/parsers/__init__.py
+++ b/modelship/openai/parsers/tool_calling/parsers/__init__.py
@@ -1,4 +1,5 @@
 from modelship.openai.parsers.tool_calling.parsers.base import ToolCallParser
 from modelship.openai.parsers.tool_calling.parsers.hermes import HermesToolCallParser
+from modelship.openai.parsers.tool_calling.parsers.mistral import MistralToolCallParser
 
-__all__ = ["HermesToolCallParser", "ToolCallParser"]
+__all__ = ["HermesToolCallParser", "MistralToolCallParser", "ToolCallParser"]

--- a/modelship/openai/parsers/tool_calling/parsers/base.py
+++ b/modelship/openai/parsers/tool_calling/parsers/base.py
@@ -55,6 +55,17 @@ class ToolCallParser(ABC):
         stream and the client receives malformed JSON.
         """
 
+    def split_payload(self, payload: str, is_complete: bool) -> list[tuple[str, bool]]:
+        """Split a region payload into ``(sub_payload, is_complete)`` per-call entries.
+
+        Default: one call per region (Hermes-style). Families like Mistral
+        whose envelope wraps a JSON array of calls override this to yield
+        one entry per array element. Each entry is then fed independently to
+        :meth:`extract_partial_name` / :meth:`extract_partial_args`, and each
+        becomes its own OpenAI ``tool_calls[i]`` slot.
+        """
+        return [(payload, is_complete)]
+
     def parse(self, text: str) -> ParsedChatOutput:
         # Local import: ``output`` imports ``ToolCallParser`` for typing,
         # so importing it at module top would create a cycle.

--- a/modelship/openai/parsers/tool_calling/parsers/mistral.py
+++ b/modelship/openai/parsers/tool_calling/parsers/mistral.py
@@ -1,0 +1,100 @@
+"""Mistral-style ``[TOOL_CALLS][{...}, {...}]`` parser.
+
+Used by Mistral 7B Instruct v0.3+, Mistral Small/Large, and downstream
+fine-tunes whose chat templates emit a single ``[TOOL_CALLS]`` envelope
+followed by a JSON array of one or more ``{"name": "...", "arguments":
+{...}}`` objects, with no trailing closing marker — the array runs to
+end-of-stream.
+
+The per-call JSON shape is identical to Hermes; the differences are
+that all calls share one envelope (we split the array into per-call
+sub-blocks via :meth:`split_payload`) and that the region is
+EOS-bounded (the streamer marks it complete at finalize time when
+``end_marker`` is empty).
+"""
+
+from __future__ import annotations
+
+import re
+
+from modelship.openai.parsers.tool_calling.parsers.base import ToolCallParser
+
+
+class MistralToolCallParser(ToolCallParser):
+    name = "mistral"
+    start_marker = "[TOOL_CALLS]"
+    end_marker = ""
+
+    _NAME_RE = re.compile(r'"name"\s*:\s*"([^"]+)"')
+    _ARGS_RE = re.compile(r'"arguments"\s*:\s*')
+
+    def split_payload(self, payload: str, is_complete: bool) -> list[tuple[str, bool]]:
+        """Split ``[{...}, {...}]`` into per-call ``({...}, complete)`` entries.
+
+        Walks the payload once tracking string state and brace depth. Each
+        balanced top-level ``{...}`` becomes one complete sub-block; a
+        trailing partially-open object becomes one incomplete sub-block (so
+        the streamer can start emitting its name/args as bytes arrive).
+
+        ``is_complete`` is the region's completion flag (True at finalize).
+        It only affects whether a trailing partial object is reported as
+        complete — closed objects are always complete on their own merits.
+        """
+        s = payload.lstrip()
+        # Skip the leading `[` of the JSON array if present. Some templates
+        # render `[TOOL_CALLS] [{...}]` with whitespace; lstrip handled that.
+        if s.startswith("["):
+            s = s[1:]
+
+        results: list[tuple[str, bool]] = []
+        depth = 0
+        in_str = False
+        escape = False
+        start: int | None = None
+        for i, c in enumerate(s):
+            if escape:
+                escape = False
+                continue
+            if in_str:
+                if c == "\\":
+                    escape = True
+                elif c == '"':
+                    in_str = False
+                continue
+            if c == '"':
+                in_str = True
+            elif c == "{":
+                if depth == 0:
+                    start = i
+                depth += 1
+            elif c == "}":
+                depth -= 1
+                if depth == 0 and start is not None:
+                    results.append((s[start : i + 1], True))
+                    start = None
+
+        if start is not None and depth > 0:
+            # Partial trailing object. Mark it complete only if the whole
+            # region is complete AND somehow we landed inside an object — in
+            # practice the model never closes the array without closing the
+            # object, so a complete region means a clean split above.
+            results.append((s[start:], is_complete and depth == 0))
+        return results
+
+    def extract_partial_name(self, partial_payload: str) -> str | None:
+        m = self._NAME_RE.search(partial_payload)
+        return m.group(1) if m else None
+
+    def extract_partial_args(self, partial_payload: str) -> str | None:
+        m = self._ARGS_RE.search(partial_payload)
+        if m is None:
+            return None
+        args = partial_payload[m.end() :].rstrip()
+        if args.endswith("}"):
+            # Mirror Hermes: the per-call envelope is
+            # `{"name":"x","arguments":<args>}` and the closing brace of
+            # the envelope arrives in the byte stream alongside (or before)
+            # the args object's closer. Withhold one trailing `}` so the
+            # streamed args view never contains the envelope's closer.
+            args = args[:-1].rstrip()
+        return args or None

--- a/modelship/openai/parsers/tool_calling/registry.py
+++ b/modelship/openai/parsers/tool_calling/registry.py
@@ -9,10 +9,11 @@ function-calling chat handler) bypass the registry entirely.
 
 from __future__ import annotations
 
-from modelship.openai.parsers.tool_calling.parsers import HermesToolCallParser, ToolCallParser
+from modelship.openai.parsers.tool_calling.parsers import HermesToolCallParser, MistralToolCallParser, ToolCallParser
 
 _PARSERS: dict[str, ToolCallParser] = {
     HermesToolCallParser.name: HermesToolCallParser(),
+    MistralToolCallParser.name: MistralToolCallParser(),
 }
 
 

--- a/tests/test_tool_calling.py
+++ b/tests/test_tool_calling.py
@@ -14,12 +14,15 @@ from modelship.openai.parsers.tool_calling import (
     register_parser,
     resolve_tools_for_request,
 )
-from modelship.openai.parsers.tool_calling.parsers import HermesToolCallParser, ToolCallParser
+from modelship.openai.parsers.tool_calling.parsers import HermesToolCallParser, MistralToolCallParser, ToolCallParser
 
 
 class TestRegistry:
     def test_default_registry_includes_hermes(self):
         assert "hermes" in available_parsers()
+
+    def test_default_registry_includes_mistral(self):
+        assert "mistral" in available_parsers()
 
     def test_get_parser_returns_singleton(self):
         a = get_parser("hermes")
@@ -292,3 +295,153 @@ class TestResolveToolsForRequest:
     def test_unrecognized_choice_falls_back_to_all(self):
         result = resolve_tools_for_request(self.tools, "weird-mode")
         assert result == self.tools
+
+
+class TestMistralParser:
+    parser = MistralToolCallParser()
+
+    def test_no_tool_calls_returns_text_unchanged(self):
+        result = self.parser.parse("just a regular response")
+        assert result.tool_calls == []
+        assert result.content == "just a regular response"
+        assert result.has_tool_calls is False
+
+    def test_single_tool_call(self):
+        text = '[TOOL_CALLS][{"name": "get_weather", "arguments": {"city": "Paris"}}]'
+        result = self.parser.parse(text)
+        assert len(result.tool_calls) == 1
+        assert result.tool_calls[0].function.name == "get_weather"
+        assert json.loads(result.tool_calls[0].function.arguments) == {"city": "Paris"}
+        assert result.content is None
+
+    def test_multiple_tool_calls_in_one_envelope(self):
+        # The defining feature of Mistral: multiple calls share one
+        # `[TOOL_CALLS]` envelope, separated by commas inside a JSON array.
+        text = '[TOOL_CALLS][{"name": "a", "arguments": {"x": 1}}, {"name": "b", "arguments": {"y": 2}}]'
+        result = self.parser.parse(text)
+        assert [tc.function.name for tc in result.tool_calls] == ["a", "b"]
+        assert json.loads(result.tool_calls[0].function.arguments) == {"x": 1}
+        assert json.loads(result.tool_calls[1].function.arguments) == {"y": 2}
+
+    def test_tool_call_with_residual_text(self):
+        text = 'Sure, calling that.\n[TOOL_CALLS][{"name": "ping", "arguments": {}}]'
+        result = self.parser.parse(text)
+        assert len(result.tool_calls) == 1
+        assert result.content == "Sure, calling that.\n"
+
+    def test_whitespace_only_preamble_nulls_content(self):
+        text = '   \n[TOOL_CALLS][{"name": "ping", "arguments": {}}]'
+        result = self.parser.parse(text)
+        assert len(result.tool_calls) == 1
+        assert result.content is None
+
+    def test_object_arguments_passed_through(self):
+        text = '[TOOL_CALLS][{"name": "x", "arguments": {"a": 1, "b": [2, 3]}}]'
+        result = self.parser.parse(text)
+        assert json.loads(result.tool_calls[0].function.arguments) == {"a": 1, "b": [2, 3]}
+
+    def test_string_arguments_forwarded_verbatim(self):
+        text = '[TOOL_CALLS][{"name": "x", "arguments": "{\\"a\\": 1}"}]'
+        result = self.parser.parse(text)
+        assert result.tool_calls[0].function.arguments == '"{\\"a\\": 1}"'
+
+    def test_braces_inside_string_args_do_not_break_split(self):
+        # The split walker tracks string state; literal `{` / `}` inside
+        # string values must not move the brace-depth counter.
+        text = '[TOOL_CALLS][{"name": "x", "arguments": {"q": "}{ literal"}}]'
+        result = self.parser.parse(text)
+        assert len(result.tool_calls) == 1
+        assert json.loads(result.tool_calls[0].function.arguments) == {"q": "}{ literal"}
+
+    def test_block_without_extractable_name_is_dropped(self):
+        text = "[TOOL_CALLS][{not valid json}]"
+        result = self.parser.parse(text)
+        assert result.tool_calls == []
+
+    def test_missing_name_drops_call(self):
+        text = '[TOOL_CALLS][{"arguments": {}}]'
+        result = self.parser.parse(text)
+        assert result.tool_calls == []
+
+    def test_each_tool_call_gets_unique_id(self):
+        text = '[TOOL_CALLS][{"name": "a", "arguments": {}}, {"name": "b", "arguments": {}}]'
+        result = self.parser.parse(text)
+        assert result.tool_calls[0].id != result.tool_calls[1].id
+
+
+class TestMistralStreamer:
+    """Stream a Mistral envelope incrementally and verify deltas.
+
+    Mistral's region is EOS-bounded (empty `end_marker`), so completion
+    happens at finalize time. The split_payload override carves the JSON
+    array into per-call sub-blocks that flow through the same streamer
+    machinery used by Hermes.
+    """
+
+    def _feed(self, chunks: list[str]) -> tuple[ChatOutputStreamer, list]:
+        streamer = ChatOutputStreamer(MistralToolCallParser())
+        deltas = []
+        cumulative = ""
+        for chunk in chunks:
+            cumulative += chunk
+            d = streamer.extract_streaming(cumulative)
+            if d is not None:
+                deltas.append(d)
+        final = streamer.finalize()
+        if final is not None:
+            deltas.append(final)
+        return streamer, deltas
+
+    def test_emits_name_before_args_for_single_call(self):
+        chunks = list('[TOOL_CALLS][{"name": "get_weather", "arguments": {"city": "Paris"}}]')
+        streamer, deltas = self._feed(chunks)
+
+        tool_deltas = [tc for d in deltas for tc in d.tool_calls]
+        assert tool_deltas[0].function is not None
+        assert tool_deltas[0].function.name == "get_weather"
+        assert tool_deltas[0].id is not None
+        assert tool_deltas[0].function.arguments is None
+        joined_args = "".join(d.function.arguments or "" for d in tool_deltas[1:])
+        assert json.loads(joined_args) == {"city": "Paris"}
+        # Region is EOS-bounded → finalize closes it out.
+        assert len(streamer.result.tool_calls) == 1
+
+    def test_two_calls_in_one_envelope_finalize_with_distinct_indices(self):
+        text = '[TOOL_CALLS][{"name": "a", "arguments": {"x": 1}}, {"name": "b", "arguments": {"y": 2}}]'
+        streamer, deltas = self._feed([text])
+
+        tool_deltas = [tc for d in deltas for tc in d.tool_calls]
+        indices = {d.index for d in tool_deltas}
+        assert indices == {0, 1}
+        names = [d.function.name for d in tool_deltas if d.function and d.function.name]
+        assert names == ["a", "b"]
+        assert [tc.function.name for tc in streamer.result.tool_calls] == ["a", "b"]
+
+    def test_preamble_holds_back_marker_prefix(self):
+        # `[T` could be the start of `[TOOL_CALLS]`; the streamer must hold
+        # it until the byte after `[T` proves it is or isn't the marker.
+        streamer = ChatOutputStreamer(MistralToolCallParser())
+        mid = streamer.extract_streaming("hello [T")
+        assert mid is not None and mid.content == "hello "
+        final = streamer.finalize()
+        assert final is not None and final.content == "[T"
+
+    def test_no_envelope_streams_as_pure_content(self):
+        _, deltas = self._feed(["plain ", "answer ", "no tools"])
+        assert "".join(d.content or "" for d in deltas) == "plain answer no tools"
+
+    def test_unterminated_array_finalizes_complete_calls(self):
+        # The model emitted one full call and started a second that never
+        # closed. The first should finalize; the second should be dropped.
+        text = '[TOOL_CALLS][{"name": "done", "arguments": {"x": 1}}, {"name": "wip"'
+        streamer, _ = self._feed([text])
+        assert [tc.function.name for tc in streamer.result.tool_calls] == ["done"]
+
+
+class TestSplitPayloadDefault:
+    """Regression: the default `split_payload` keeps Hermes one-call-per-region behavior."""
+
+    def test_default_returns_single_entry(self):
+        parser = HermesToolCallParser()
+        assert parser.split_payload("anything", True) == [("anything", True)]
+        assert parser.split_payload("anything", False) == [("anything", False)]


### PR DESCRIPTION
Adds the `mistral` tool-call parser to the cross-loader registry. The chat-template auto-detector already returns "mistral" for templates that use the `[TOOL_CALLS]` envelope; today that name hits the warn- and-disable path because no parser is registered. This wires it up so auto-detection actually enables tool calling for Mistral-family models on the transformers and llama.cpp loaders.

Mistral's envelope wraps a JSON array of N call objects with no trailing closing marker, which required two small extensions to the shared streamer:

- An empty `end_marker` now means the region extends to EOS and completes at finalize time, instead of staying perpetually open.
- `ToolCallParser.split_payload` lets a parser carve one region into multiple per-call sub-blocks. The default returns `[(payload, ...)]` so existing parsers (Hermes) behave identically.

The Mistral parser overrides `split_payload` with a string-aware brace-depth walker so commas/braces inside argument JSON strings do not break the split.

