### PR TITLE
feat: llama3_json tool-call parser

### DIFF
--- a/docs/model-configuration.md
+++ b/docs/model-configuration.md
@@ -219,7 +219,7 @@ The `transformers` loader uses PyTorch with HuggingFace Transformers. Supports c
 | `trust_remote_code` | bool | `false` | Allow remote code execution |
 | `model_kwargs` | object | `{}` | Extra keyword arguments passed to the model constructor |
 | `pipeline_kwargs` | object | `{}` | Extra keyword arguments passed to the pipeline at inference time |
-| `tool_call_parser` | string | `hermes` | Parser used to turn raw model output into OpenAI `tool_calls`. Currently supported: `hermes` (Hermes-2-Pro / Qwen2.5-Instruct / many community fine-tunes that emit `<tool_call>{...}</tool_call>` markers). |
+| `tool_call_parser` | string | auto | Parser used to turn raw model output into OpenAI `tool_calls`. Currently supported: `hermes` (Hermes-2-Pro / Qwen2.5-Instruct / many community fine-tunes that emit `<tool_call>{...}</tool_call>` markers), `mistral` (Mistral 7B Instruct v0.3+ / Mistral Small/Large that emit `[TOOL_CALLS][...]`), `llama3_json` (Llama-3.1 / Llama-3.2 Instruct emitting bare `{"name": "...", "parameters": {...}}`). Auto-detected from the chat template when omitted. |
 
 ### Chat / Text Generation (CPU)
 

--- a/modelship/deploy/config.py
+++ b/modelship/deploy/config.py
@@ -8,7 +8,7 @@ from modelship.infer.infer_config import ModelLoader, ModelshipConfig, ModelUsec
 from modelship.infer.model_resolver import resolve_model_source
 from modelship.logging import get_logger
 from modelship.openai.parsers.reasoning.utils import classify_template as classify_reasoning_template
-from modelship.openai.parsers.tool_calling.registry import available_parsers
+from modelship.openai.parsers.tool_calling.registry import available_parsers, get_parser
 from modelship.openai.parsers.tool_calling.utils import classify_template
 from modelship.openai.parsers.utils import read_chat_template
 
@@ -134,6 +134,7 @@ def resolve_all_tool_parsers(yml_conf: ModelshipConfig) -> None:
                     f"which is not registered. Available: {sorted(registered) or '(none)'}."
                 )
             cfg._resolved_tool_call_parser = explicit
+            cfg._resolved_skip_special_tokens = _skip_specials_for(explicit)
             logger.info("Using explicit tool_call_parser=%r for '%s'", explicit, cfg.name)
             continue
 
@@ -161,7 +162,20 @@ def resolve_all_tool_parsers(yml_conf: ModelshipConfig) -> None:
             )
             continue
         cfg._resolved_tool_call_parser = detected
+        cfg._resolved_skip_special_tokens = _skip_specials_for(detected)
         logger.info("Auto-detected tool_call_parser=%r for '%s'", detected, cfg.name)
+
+
+def _skip_specials_for(parser_name: str) -> bool | None:
+    """Resolve the ``skip_special_tokens`` setting a loader should use.
+
+    Returns ``False`` when the parser declares ``markers_are_specials``
+    (its marker is registered as a special token and would be stripped by
+    the loader's default detokenization) — the loader must keep specials
+    in the stream and noise-strip the rest itself. Returns ``None``
+    otherwise so the loader keeps its own default (``True``).
+    """
+    return False if get_parser(parser_name).markers_are_specials else None
 
 
 def _is_explicit_reasoning_opt_out(cfg) -> bool:

--- a/modelship/deploy/config.py
+++ b/modelship/deploy/config.py
@@ -7,6 +7,7 @@ from modelship.deploy.actor_options import resolve_plugin_wheel
 from modelship.infer.infer_config import ModelLoader, ModelshipConfig, ModelUsecase
 from modelship.infer.model_resolver import resolve_model_source
 from modelship.logging import get_logger
+from modelship.openai.parsers.reasoning.registry import get_parser as get_reasoning_parser
 from modelship.openai.parsers.reasoning.utils import classify_template as classify_reasoning_template
 from modelship.openai.parsers.tool_calling.registry import available_parsers, get_parser
 from modelship.openai.parsers.tool_calling.utils import classify_template
@@ -134,7 +135,7 @@ def resolve_all_tool_parsers(yml_conf: ModelshipConfig) -> None:
                     f"which is not registered. Available: {sorted(registered) or '(none)'}."
                 )
             cfg._resolved_tool_call_parser = explicit
-            cfg._resolved_skip_special_tokens = _skip_specials_for(explicit)
+            _merge_skip_specials(cfg, explicit, is_reasoning=False)
             logger.info("Using explicit tool_call_parser=%r for '%s'", explicit, cfg.name)
             continue
 
@@ -162,11 +163,11 @@ def resolve_all_tool_parsers(yml_conf: ModelshipConfig) -> None:
             )
             continue
         cfg._resolved_tool_call_parser = detected
-        cfg._resolved_skip_special_tokens = _skip_specials_for(detected)
+        _merge_skip_specials(cfg, detected, is_reasoning=False)
         logger.info("Auto-detected tool_call_parser=%r for '%s'", detected, cfg.name)
 
 
-def _skip_specials_for(parser_name: str) -> bool | None:
+def _skip_specials_for(parser_name: str, is_reasoning: bool = False) -> bool | None:
     """Resolve the ``skip_special_tokens`` setting a loader should use.
 
     Returns ``False`` when the parser declares ``markers_are_specials``
@@ -175,7 +176,18 @@ def _skip_specials_for(parser_name: str) -> bool | None:
     in the stream and noise-strip the rest itself. Returns ``None``
     otherwise so the loader keeps its own default (``True``).
     """
-    return False if get_parser(parser_name).markers_are_specials else None
+    get_fn = get_reasoning_parser if is_reasoning else get_parser
+    return False if get_fn(parser_name).markers_are_specials else None
+
+
+def _merge_skip_specials(cfg, parser_name: str, is_reasoning: bool = False) -> None:
+    """Update ``_resolved_skip_special_tokens`` if the parser requires it.
+
+    Once set to ``False`` (keep specials), it is never reset to ``None``.
+    """
+    if cfg._resolved_skip_special_tokens is False:
+        return
+    cfg._resolved_skip_special_tokens = _skip_specials_for(parser_name, is_reasoning=is_reasoning)
 
 
 def _is_explicit_reasoning_opt_out(cfg) -> bool:
@@ -216,6 +228,7 @@ def resolve_all_reasoning_parsers(yml_conf: ModelshipConfig) -> None:
 
         if explicit is not None:
             cfg._resolved_reasoning_parser = explicit
+            _merge_skip_specials(cfg, explicit, is_reasoning=True)
             logger.info("Using explicit reasoning_parser=%r for '%s'", explicit, cfg.name)
             continue
 
@@ -232,4 +245,5 @@ def resolve_all_reasoning_parsers(yml_conf: ModelshipConfig) -> None:
         if detected is None:
             continue
         cfg._resolved_reasoning_parser = detected
+        _merge_skip_specials(cfg, detected, is_reasoning=True)
         logger.info("Auto-detected reasoning_parser=%r for '%s'", detected, cfg.name)

--- a/modelship/infer/infer_config.py
+++ b/modelship/infer/infer_config.py
@@ -109,6 +109,15 @@ class ModelshipModelConfig(BaseModel):
     _resolved_tool_call_parser: str | None = PrivateAttr(default=None)
     _resolved_reasoning_parser: str | None = PrivateAttr(default=None)
     _resolved_chat_template: str | None = PrivateAttr(default=None)
+    # Pinned at startup from the resolved tool-call parser's
+    # ``markers_are_specials`` flag. Loaders that detokenize raw model
+    # output (transformers' ``TextIteratorStreamer``) consult this to
+    # decide whether to flip ``skip_special_tokens=False`` — required for
+    # parsers like Mistral whose ``[TOOL_CALLS]`` marker is registered as a
+    # special token in the tokenizer and would otherwise be stripped before
+    # the parser sees it. ``None`` means the loader should keep its own
+    # default.
+    _resolved_skip_special_tokens: bool | None = PrivateAttr(default=None)
 
     @model_validator(mode="after")
     def check_custom_requires_plugin(self):

--- a/modelship/infer/transformers/openai/serving_chat.py
+++ b/modelship/infer/transformers/openai/serving_chat.py
@@ -52,10 +52,8 @@ class OpenAIServingChat(OpenAIServing):
         # auto-detection found no usable parser; tool calls in requests will be
         # dropped with a warning at request time, and reasoning will simply
         # not be extracted.
-        if tool_call_parser is not None:
-            get_parser(tool_call_parser)
-        if reasoning_parser is not None:
-            get_reasoning_parser(reasoning_parser)
+        tool_parser = get_parser(tool_call_parser) if tool_call_parser is not None else None
+        reasoning = get_reasoning_parser(reasoning_parser) if reasoning_parser is not None else None
         # Resolve the streamer's ``skip_special_tokens`` setting. Default
         # ``True`` matches HF's example code and is correct for parsers
         # whose markers are regular text (Hermes ``<tool_call>``,
@@ -64,30 +62,39 @@ class OpenAIServingChat(OpenAIServing):
         # passes ``False`` so the marker survives detokenization, and we
         # noise-strip every OTHER registered special from each chunk
         # ourselves so clients never see ``<|im_end|>`` /
-        # ``<|eot_id|>`` / etc. leak into content.
+        # ``<|eot_id|>`` / etc. leak into content. Reasoning-parser
+        # markers go in the keep set too — a family could register
+        # ``<think>``/``</think>`` as specials, and the reasoning parser
+        # needs to see them.
         self._skip_special_tokens = True if skip_special_tokens is None else skip_special_tokens
         self._noise_specials: tuple[str, ...] = ()
         if not self._skip_special_tokens:
             keep = {
                 m
                 for m in (
-                    get_parser(tool_call_parser).start_marker if tool_call_parser else "",
-                    get_parser(tool_call_parser).end_marker if tool_call_parser else "",
+                    tool_parser.start_marker if tool_parser else "",
+                    tool_parser.end_marker if tool_parser else "",
+                    reasoning.start_marker if reasoning else "",
+                    reasoning.end_marker if reasoning else "",
                 )
                 if m
             }
             # ``added_tokens_decoder`` is the authoritative list of every
             # token (special + ordinary) registered on the tokenizer, with
             # a per-entry ``special`` flag. We strip the ``special=True``
-            # entries that are NOT our parser's marker. Sort by length
+            # entries that are NOT in the keep set. Sort by length
             # descending so a longer marker (e.g. ``<|start_header_id|>``)
             # is replaced before a substring of it could cause false
-            # partial matches.
+            # partial matches. Use ``getattr`` because some non-fast or
+            # custom tokenizers may not expose this attribute — in that
+            # case noise stripping silently degrades to a no-op rather
+            # than blowing up at startup.
+            added_tokens = getattr(self.tokenizer, "added_tokens_decoder", {}) or {}
             self._noise_specials = tuple(
                 sorted(
                     (
                         tok.content
-                        for tok in self.tokenizer.added_tokens_decoder.values()
+                        for tok in added_tokens.values()
                         if tok.special and tok.content and tok.content not in keep
                     ),
                     key=len,

--- a/modelship/infer/transformers/openai/serving_chat.py
+++ b/modelship/infer/transformers/openai/serving_chat.py
@@ -36,6 +36,7 @@ class OpenAIServingChat(OpenAIServing):
         capabilities: TransformersCapabilities,
         tool_call_parser: str | None = None,
         reasoning_parser: str | None = None,
+        skip_special_tokens: bool | None = None,
     ):
         self.pipeline = pipeline
         self.model_name = model_name
@@ -55,6 +56,44 @@ class OpenAIServingChat(OpenAIServing):
             get_parser(tool_call_parser)
         if reasoning_parser is not None:
             get_reasoning_parser(reasoning_parser)
+        # Resolve the streamer's ``skip_special_tokens`` setting. Default
+        # ``True`` matches HF's example code and is correct for parsers
+        # whose markers are regular text (Hermes ``<tool_call>``,
+        # llama3_json ``{"name"``). For parsers whose markers are
+        # registered specials (Mistral ``[TOOL_CALLS]``), the resolver
+        # passes ``False`` so the marker survives detokenization, and we
+        # noise-strip every OTHER registered special from each chunk
+        # ourselves so clients never see ``<|im_end|>`` /
+        # ``<|eot_id|>`` / etc. leak into content.
+        self._skip_special_tokens = True if skip_special_tokens is None else skip_special_tokens
+        self._noise_specials: tuple[str, ...] = ()
+        if not self._skip_special_tokens:
+            keep = {
+                m
+                for m in (
+                    get_parser(tool_call_parser).start_marker if tool_call_parser else "",
+                    get_parser(tool_call_parser).end_marker if tool_call_parser else "",
+                )
+                if m
+            }
+            # ``added_tokens_decoder`` is the authoritative list of every
+            # token (special + ordinary) registered on the tokenizer, with
+            # a per-entry ``special`` flag. We strip the ``special=True``
+            # entries that are NOT our parser's marker. Sort by length
+            # descending so a longer marker (e.g. ``<|start_header_id|>``)
+            # is replaced before a substring of it could cause false
+            # partial matches.
+            self._noise_specials = tuple(
+                sorted(
+                    (
+                        tok.content
+                        for tok in self.tokenizer.added_tokens_decoder.values()
+                        if tok.special and tok.content and tok.content not in keep
+                    ),
+                    key=len,
+                    reverse=True,
+                )
+            )
 
     async def warmup(self) -> None:
         logger.info("Warming up chat model: %s", self.model_name)
@@ -131,6 +170,7 @@ class OpenAIServingChat(OpenAIServing):
             text=completion_text,
             parser_name=parser_name,
             reasoning_parser_name=reasoning_parser_name,
+            noise_specials=self._noise_specials,
             prompt_tokens=prompt_tokens,
             completion_tokens=completion_tokens,
             max_tokens=max_tokens,
@@ -176,6 +216,11 @@ class OpenAIServingChat(OpenAIServing):
         kwargs = {**self.config.pipeline_kwargs}
         if max_tokens is not None:
             kwargs["max_new_tokens"] = max_tokens
+        # Mirror the streamer's setting on the non-streaming path so the
+        # pipeline's internal detokenize doesn't pre-strip the parser's
+        # marker (the pipeline defaults ``skip_special_tokens=True``).
+        if not self._skip_special_tokens:
+            kwargs["skip_special_tokens"] = False
         if tools:
             # The standard text-generation pipeline does not forward `tools` to
             # `apply_chat_template`, so we render the prompt ourselves and feed
@@ -218,7 +263,11 @@ class OpenAIServingChat(OpenAIServing):
         reasoning_parser_name: str | None,
         include_usage: bool,
     ) -> AsyncGenerator[str, None]:
-        streamer = TextIteratorStreamer(self.tokenizer, skip_prompt=True, skip_special_tokens=True)  # type: ignore[arg-type]
+        streamer = TextIteratorStreamer(  # type: ignore[arg-type]
+            self.tokenizer,
+            skip_prompt=True,
+            skip_special_tokens=self._skip_special_tokens,
+        )
 
         kwargs = {**self.config.pipeline_kwargs}
         if max_tokens is not None:
@@ -242,6 +291,7 @@ class OpenAIServingChat(OpenAIServing):
                 model_name=self.model_name,
                 text_chunks=_async_iter(streamer),
                 parser_name=parser_name,
+                noise_specials=self._noise_specials,
                 reasoning_parser_name=reasoning_parser_name,
                 count_tokens=lambda text: len(self.tokenizer.encode(text, add_special_tokens=False)),
                 prompt_tokens=self._count_prompt_tokens(messages, tools),

--- a/modelship/infer/transformers/transformers_infer.py
+++ b/modelship/infer/transformers/transformers_infer.py
@@ -89,6 +89,7 @@ class TransformersInfer(BaseInfer):
             # field None) and captured explicit overrides. Read both directly.
             tool_call_parser = self.model_config._resolved_tool_call_parser
             reasoning_parser = self.model_config._resolved_reasoning_parser
+            skip_special_tokens = self.model_config._resolved_skip_special_tokens
             self.serving_chat = OpenAIServingChat(
                 pipe,
                 self.model_config.name,
@@ -96,6 +97,7 @@ class TransformersInfer(BaseInfer):
                 capabilities,
                 tool_call_parser=tool_call_parser,
                 reasoning_parser=reasoning_parser,
+                skip_special_tokens=skip_special_tokens,
             )
             self._serving.append(self.serving_chat)
 

--- a/modelship/openai/parsers/output.py
+++ b/modelship/openai/parsers/output.py
@@ -78,12 +78,23 @@ class ChatOutputStreamer:
         self,
         tool_call_parser: ToolCallParser | None,
         reasoning_parser: ReasoningParser | None = None,
+        noise_specials: tuple[str, ...] = (),
     ):
         if tool_call_parser is None and reasoning_parser is None:
             raise ValueError("ChatOutputStreamer requires at least one parser (tool-call or reasoning)")
         self._tool_parser = tool_call_parser
         self._tool_start = tool_call_parser.start_marker if tool_call_parser else ""
         self._tool_end = tool_call_parser.end_marker if tool_call_parser else ""
+        self._tool_consume_start = tool_call_parser.consume_start_marker if tool_call_parser else True
+        # Loader-supplied list of registered special tokens to silently
+        # drop before scanning. Used when the loader runs detokenization
+        # with ``skip_special_tokens=False`` to keep the parser's marker
+        # visible — every OTHER special (``<|im_end|>``, ``<|eot_id|>``,
+        # ``[INST]``, etc.) is junk from the client's perspective and
+        # must not leak into content/reasoning views. Sorted long-first
+        # so a longer marker is replaced before a substring of it can
+        # cause a false partial match.
+        self._noise_specials: tuple[str, ...] = tuple(sorted(noise_specials, key=len, reverse=True))
         self._reasoning = reasoning_parser
         self._reasoning_start = reasoning_parser.start_marker if reasoning_parser else ""
         self._reasoning_end = reasoning_parser.end_marker if reasoning_parser else ""
@@ -98,6 +109,7 @@ class ChatOutputStreamer:
 
     def extract_streaming(self, current_text: str) -> DeltaMessage | None:
         """Run one diff pass against ``current_text`` and return any new deltas."""
+        current_text = self._strip_noise(current_text)
         self._last_text = current_text
         regions = self._scan(current_text, hold_marker_tail=True)
         content_delta = self._diff_content(regions)
@@ -132,6 +144,20 @@ class ChatOutputStreamer:
     # ------------------------------------------------------------------
     # Single-pass scanner
     # ------------------------------------------------------------------
+
+    def _strip_noise(self, text: str) -> str:
+        """Drop loader-supplied noise specials from ``text`` before scanning.
+
+        Idempotent — safe to call on cumulative text every diff pass.
+        Cumulative semantics also mean a special split across two HF
+        chunks reassembles before we see it, so no per-chunk holdback is
+        needed here.
+        """
+        if not self._noise_specials:
+            return text
+        for s in self._noise_specials:
+            text = text.replace(s, "")
+        return text
 
     def _scan(self, text: str, *, hold_marker_tail: bool) -> list[tuple[str, str, bool]]:
         """Walk ``text`` once, returning ordered ``(kind, payload, is_complete)`` regions.
@@ -183,7 +209,11 @@ class ChatOutputStreamer:
                 regions.append(("reasoning", text[payload_start:end], True))
                 pos = end + len(self._reasoning_end)
             else:
-                payload_start = next_pos + len(self._tool_start)
+                # ``consume_start_marker=False`` keeps the marker bytes at the
+                # head of the payload — used by JSON-shape parsers whose marker
+                # (e.g. ``{"name"``) is itself part of the object to parse.
+                consume = self._tool_consume_start
+                payload_start = next_pos + (len(self._tool_start) if consume else 0)
                 end = text.find(self._tool_end, payload_start) if self._tool_end else -1
                 if end < 0:
                     partial = text[payload_start:]
@@ -205,10 +235,13 @@ class ChatOutputStreamer:
 
         ``buf`` does not contain a full opening marker; the unsafe tail
         is the longest proper-prefix overlap with whichever opening
-        marker(s) the streamer is watching for.
+        marker(s) the streamer is watching for. Noise specials count too
+        — a trailing ``<|eot_i`` could become ``<|eot_id|>`` on the next
+        pass, and we must not ship the partial as content before the
+        cumulative buffer disambiguates.
         """
         cap = len(buf)
-        for marker in (self._tool_start, self._reasoning_start):
+        for marker in (self._tool_start, self._reasoning_start, *self._noise_specials):
             if not marker:
                 continue
             cap = min(cap, _safe_overlap_index(buf, marker))

--- a/modelship/openai/parsers/output.py
+++ b/modelship/openai/parsers/output.py
@@ -23,6 +23,7 @@ so behavior cannot drift between them.
 
 from __future__ import annotations
 
+import re
 from dataclasses import dataclass
 
 from modelship.openai.parsers.reasoning.parsers import ReasoningParser
@@ -95,6 +96,12 @@ class ChatOutputStreamer:
         # so a longer marker is replaced before a substring of it can
         # cause a false partial match.
         self._noise_specials: tuple[str, ...] = tuple(sorted(noise_specials, key=len, reverse=True))
+        if self._noise_specials:
+            pattern = "|".join(re.escape(s) for s in self._noise_specials)
+            self._noise_regex = re.compile(pattern)
+        else:
+            self._noise_regex = None
+
         self._reasoning = reasoning_parser
         self._reasoning_start = reasoning_parser.start_marker if reasoning_parser else ""
         self._reasoning_end = reasoning_parser.end_marker if reasoning_parser else ""
@@ -105,12 +112,19 @@ class ChatOutputStreamer:
         self._sent_args: list[str] = []
         self._finalized_indices: set[int] = set()
         self._finalized_calls: list[ToolCall] = []
+        self._last_raw_text = ""
+        self._stripped_head = ""
+        self._unstripped_tail = ""
         self._last_text = ""
 
     def extract_streaming(self, current_text: str) -> DeltaMessage | None:
         """Run one diff pass against ``current_text`` and return any new deltas."""
-        current_text = self._strip_noise(current_text)
+        delta_text = current_text[len(self._last_raw_text) :]
+        self._last_raw_text = current_text
+
+        current_text = self._strip_noise_delta(delta_text)
         self._last_text = current_text
+
         regions = self._scan(current_text, hold_marker_tail=True)
         content_delta = self._diff_content(regions)
         reasoning_delta = self._diff_reasoning(regions)
@@ -145,19 +159,35 @@ class ChatOutputStreamer:
     # Single-pass scanner
     # ------------------------------------------------------------------
 
-    def _strip_noise(self, text: str) -> str:
-        """Drop loader-supplied noise specials from ``text`` before scanning.
+    def _strip_noise_delta(self, delta_text: str) -> str:
+        """Drop loader-supplied noise specials from new text deltas.
 
-        Idempotent — safe to call on cumulative text every diff pass.
-        Cumulative semantics also mean a special split across two HF
-        chunks reassembles before we see it, so no per-chunk holdback is
-        needed here.
+        Maintains state to handle noise tokens split across chunks.
         """
-        if not self._noise_specials:
-            return text
+        if self._noise_regex is None:
+            self._stripped_head += delta_text
+            return self._stripped_head
+
+        # 1. Combine the held-back tail from the last chunk with the new chunk
+        working_text = self._unstripped_tail + delta_text
+
+        # 2. Strip noise from this combined window using regex
+        working_text = self._noise_regex.sub("", working_text)
+
+        # 3. Determine how much of the working text is "safe" to commit.
+        # The unsafe portion is the end of the string that might form a prefix
+        # of any noise token.
+        safe_idx = len(working_text)
         for s in self._noise_specials:
-            text = text.replace(s, "")
-        return text
+            overlap = _safe_overlap_index(working_text, s)
+            safe_idx = min(safe_idx, overlap)
+
+        # 4. Commit the safe part and hold back the unsafe tail
+        self._stripped_head += working_text[:safe_idx]
+        self._unstripped_tail = working_text[safe_idx:]
+
+        # 5. Return the full accumulated string for the scanner
+        return self._stripped_head + self._unstripped_tail
 
     def _scan(self, text: str, *, hold_marker_tail: bool) -> list[tuple[str, str, bool]]:
         """Walk ``text`` once, returning ordered ``(kind, payload, is_complete)`` regions.

--- a/modelship/openai/parsers/reasoning/parsers/base.py
+++ b/modelship/openai/parsers/reasoning/parsers/base.py
@@ -27,3 +27,8 @@ class ReasoningParser(ABC):
     name: str
     start_marker: str
     end_marker: str
+    # Set True when the parser's marker(s) are registered as *special tokens*
+    # in the tokenizers of the model families this parser targets. Loaders
+    # that decode with ``skip_special_tokens=True`` by default would
+    # otherwise strip the marker before this parser ever sees it.
+    markers_are_specials: bool = False

--- a/modelship/openai/parsers/streaming.py
+++ b/modelship/openai/parsers/streaming.py
@@ -56,6 +56,7 @@ def build_chat_completion_response(
     text: str,
     parser_name: str | None,
     reasoning_parser_name: str | None = None,
+    noise_specials: tuple[str, ...] = (),
     prompt_tokens: int,
     completion_tokens: int,
     max_tokens: int | None,
@@ -65,9 +66,17 @@ def build_chat_completion_response(
 
     Non-streaming counterpart of :func:`stream_chat_completion`. When
     both parser names are ``None``, ``text`` becomes the message
-    content as-is with no extraction.
+    content as-is with no extraction. ``noise_specials`` is forwarded to
+    the streamer so loaders that decode with ``skip_special_tokens=False``
+    can have unwanted special tokens (``<|eot_id|>``, ``[INST]``, etc.)
+    silently dropped before parsing.
     """
-    parsed = _parse_full(text, parser_name=parser_name, reasoning_parser_name=reasoning_parser_name)
+    parsed = _parse_full(
+        text,
+        parser_name=parser_name,
+        reasoning_parser_name=reasoning_parser_name,
+        noise_specials=noise_specials,
+    )
     finish_reason = finish_reason_for(parsed, completion_tokens, max_tokens)
     return ChatCompletionResponse(
         id=request_id,
@@ -100,6 +109,7 @@ async def stream_chat_completion(
     text_chunks: AsyncIterator[str],
     parser_name: str | None,
     reasoning_parser_name: str | None = None,
+    noise_specials: tuple[str, ...] = (),
     count_tokens: Callable[[str], int],
     prompt_tokens: int,
     max_tokens: int | None,
@@ -120,7 +130,11 @@ async def stream_chat_completion(
     usage; pass ``lambda _: 0`` if the loader doesn't have a tokenizer
     handy.
     """
-    streamer = _make_streamer(parser_name=parser_name, reasoning_parser_name=reasoning_parser_name)
+    streamer = _make_streamer(
+        parser_name=parser_name,
+        reasoning_parser_name=reasoning_parser_name,
+        noise_specials=noise_specials,
+    )
     accumulated = ""
 
     yield _delta_chunk(request_id, model_name, DeltaMessage(role="assistant"), created)
@@ -182,8 +196,18 @@ async def stream_chat_completion(
     yield "data: [DONE]\n\n"
 
 
-def _parse_full(text: str, *, parser_name: str | None, reasoning_parser_name: str | None) -> ParsedChatOutput:
-    streamer = _make_streamer(parser_name=parser_name, reasoning_parser_name=reasoning_parser_name)
+def _parse_full(
+    text: str,
+    *,
+    parser_name: str | None,
+    reasoning_parser_name: str | None,
+    noise_specials: tuple[str, ...] = (),
+) -> ParsedChatOutput:
+    streamer = _make_streamer(
+        parser_name=parser_name,
+        reasoning_parser_name=reasoning_parser_name,
+        noise_specials=noise_specials,
+    )
     if streamer is None:
         return ParsedChatOutput(content=text or None, reasoning=None, tool_calls=[])
     streamer.extract_streaming(text)
@@ -191,12 +215,17 @@ def _parse_full(text: str, *, parser_name: str | None, reasoning_parser_name: st
     return streamer.result
 
 
-def _make_streamer(*, parser_name: str | None, reasoning_parser_name: str | None) -> ChatOutputStreamer | None:
+def _make_streamer(
+    *,
+    parser_name: str | None,
+    reasoning_parser_name: str | None,
+    noise_specials: tuple[str, ...] = (),
+) -> ChatOutputStreamer | None:
     if parser_name is None and reasoning_parser_name is None:
         return None
     tool_parser = get_tool_call_parser(parser_name) if parser_name else None
     reasoning_parser = get_reasoning_parser(reasoning_parser_name) if reasoning_parser_name else None
-    return ChatOutputStreamer(tool_parser, reasoning_parser)
+    return ChatOutputStreamer(tool_parser, reasoning_parser, noise_specials=noise_specials)
 
 
 def _delta_chunk(request_id: str, model_name: str, delta: DeltaMessage, created: int) -> str:

--- a/modelship/openai/parsers/tool_calling/__init__.py
+++ b/modelship/openai/parsers/tool_calling/__init__.py
@@ -9,11 +9,17 @@ streaming helpers from ``modelship.openai.parsers.streaming``.
 """
 
 from modelship.openai.parsers.tool_calling.input import resolve_tools_for_request
-from modelship.openai.parsers.tool_calling.parsers import HermesToolCallParser, MistralToolCallParser, ToolCallParser
+from modelship.openai.parsers.tool_calling.parsers import (
+    HermesToolCallParser,
+    Llama3JsonToolCallParser,
+    MistralToolCallParser,
+    ToolCallParser,
+)
 from modelship.openai.parsers.tool_calling.registry import available_parsers, get_parser, register_parser
 
 __all__ = [
     "HermesToolCallParser",
+    "Llama3JsonToolCallParser",
     "MistralToolCallParser",
     "ToolCallParser",
     "available_parsers",

--- a/modelship/openai/parsers/tool_calling/parsers/__init__.py
+++ b/modelship/openai/parsers/tool_calling/parsers/__init__.py
@@ -1,5 +1,6 @@
 from modelship.openai.parsers.tool_calling.parsers.base import ToolCallParser
 from modelship.openai.parsers.tool_calling.parsers.hermes import HermesToolCallParser
+from modelship.openai.parsers.tool_calling.parsers.llama3_json import Llama3JsonToolCallParser
 from modelship.openai.parsers.tool_calling.parsers.mistral import MistralToolCallParser
 
-__all__ = ["HermesToolCallParser", "MistralToolCallParser", "ToolCallParser"]
+__all__ = ["HermesToolCallParser", "Llama3JsonToolCallParser", "MistralToolCallParser", "ToolCallParser"]

--- a/modelship/openai/parsers/tool_calling/parsers/base.py
+++ b/modelship/openai/parsers/tool_calling/parsers/base.py
@@ -34,6 +34,25 @@ class ToolCallParser(ABC):
     name: str
     start_marker: str
     end_marker: str
+    # When False, the streamer locates ``start_marker`` but does NOT skip past
+    # it: the marker bytes stay at the head of the payload fed to the
+    # extractors. Used by parsers (e.g. ``llama3_json``) whose marker is part
+    # of the JSON they need to parse — ``{"name"`` cannot be consumed without
+    # destroying the object's structure. Defaults to True to preserve the
+    # Hermes/Mistral semantics where the marker is an envelope tag stripped
+    # before the body.
+    consume_start_marker: bool = True
+    # Set True when the parser's marker(s) are registered as *special tokens*
+    # in the tokenizers of the model families this parser targets — the way
+    # ``[TOOL_CALLS]`` is in Mistral v3+ tokenizers
+    # (``added_tokens_decoder`` with ``special=True``). Loaders that decode
+    # with ``skip_special_tokens=True`` by default would otherwise strip the
+    # marker before this parser ever sees it, leaving the parser permanently
+    # idle. The transformers loader reads this flag at startup, flips its
+    # streamer's ``skip_special_tokens`` to ``False`` when set, and noise-
+    # strips every OTHER registered special from chunks itself. Hermes and
+    # llama3_json keep the default — their markers are regular text.
+    markers_are_specials: bool = False
 
     @abstractmethod
     def extract_partial_name(self, partial_payload: str) -> str | None:

--- a/modelship/openai/parsers/tool_calling/parsers/llama3_json.py
+++ b/modelship/openai/parsers/tool_calling/parsers/llama3_json.py
@@ -1,0 +1,108 @@
+"""Llama-3.1/3.2 JSON tool-call parser.
+
+Used by Llama-3.1 / Llama-3.2 Instruct models whose chat template renders a
+custom JSON tool call as a bare object — ``{"name": "fn", "parameters":
+{...}}`` followed by ``<|eot_id|>`` (the official Meta / vLLM
+``tool_chat_template_llama3.1_json.jinja`` shape). A leading
+``<|python_tag|>`` is *not* part of the JSON variant; it is reserved for
+built-in code-interpreter calls and would be stripped by HF's default
+``skip_special_tokens=True`` anyway. The parser starts at the literal
+substring ``{"name"`` so it sees the JSON regardless of whether the tag
+prefix was emitted upstream.
+
+Differences from Hermes / Mistral:
+
+- The marker ``{"name"`` is *part of* the JSON object, not an envelope
+  around it, so the parser sets :attr:`consume_start_marker` to False so
+  the streamer keeps the marker bytes at the head of the payload.
+- The arguments field name is ``parameters`` per Meta's spec; some
+  community fine-tunes emit ``arguments`` instead. The parser accepts
+  either and the streamer forwards the field bytes verbatim — clients
+  see the JSON the model produced.
+- Multi-call output uses ``; `` (semicolon-space) between top-level
+  objects, matching vLLM's convention.
+"""
+
+from __future__ import annotations
+
+import re
+
+from modelship.openai.parsers.tool_calling.parsers.base import ToolCallParser
+
+
+class Llama3JsonToolCallParser(ToolCallParser):
+    name = "llama3_json"
+    start_marker = '{"name"'
+    end_marker = ""
+    consume_start_marker = False
+
+    _NAME_RE = re.compile(r'"name"\s*:\s*"([^"]+)"')
+    _ARGS_RE = re.compile(r'"(?:parameters|arguments)"\s*:\s*')
+
+    def split_payload(self, payload: str, is_complete: bool) -> list[tuple[str, bool]]:
+        """Split ``{...}; {...}`` into per-call ``({...}, complete)`` entries.
+
+        Walks the payload once tracking string state and brace depth. Each
+        balanced top-level ``{...}`` becomes one complete sub-block; a
+        trailing partially-open object becomes one incomplete sub-block so
+        the streamer can begin emitting its name/args as bytes arrive. The
+        ``; `` separator between objects is skipped along with any other
+        whitespace at depth 0.
+
+        ``is_complete`` is the region's completion flag (True at finalize).
+        It only affects whether a trailing partial object is reported as
+        complete — closed objects are always complete on their own merits.
+        """
+        results: list[tuple[str, bool]] = []
+        depth = 0
+        in_str = False
+        escape = False
+        start: int | None = None
+        for i, c in enumerate(payload):
+            if escape:
+                escape = False
+                continue
+            if in_str:
+                if c == "\\":
+                    escape = True
+                elif c == '"':
+                    in_str = False
+                continue
+            if c == '"':
+                in_str = True
+            elif c == "{":
+                if depth == 0:
+                    start = i
+                depth += 1
+            elif c == "}":
+                depth -= 1
+                if depth == 0 and start is not None:
+                    results.append((payload[start : i + 1], True))
+                    start = None
+
+        if start is not None and depth > 0:
+            # Trailing partial object — only complete if the region is
+            # complete (finalize) AND we somehow ended balanced, which the
+            # closed-on-its-own-merits branch above would have caught.
+            results.append((payload[start:], is_complete and depth == 0))
+        return results
+
+    def extract_partial_name(self, partial_payload: str) -> str | None:
+        m = self._NAME_RE.search(partial_payload)
+        return m.group(1) if m else None
+
+    def extract_partial_args(self, partial_payload: str) -> str | None:
+        m = self._ARGS_RE.search(partial_payload)
+        if m is None:
+            return None
+        args = partial_payload[m.end() :].rstrip()
+        if args.endswith("}"):
+            # Mirror Hermes's trailing-`}` withhold: the per-call envelope
+            # is ``{"name": "x", "parameters": <args>}``. The closing brace
+            # of the envelope arrives in the byte stream alongside (or
+            # before) the args object's closer. Withhold one trailing `}`
+            # so the streamed args view never contains the envelope's
+            # closer; if more args bytes follow, the held brace is
+            # recovered on the next pass.
+            args = args[:-1].rstrip()
+        return args or None

--- a/modelship/openai/parsers/tool_calling/parsers/mistral.py
+++ b/modelship/openai/parsers/tool_calling/parsers/mistral.py
@@ -24,6 +24,13 @@ class MistralToolCallParser(ToolCallParser):
     name = "mistral"
     start_marker = "[TOOL_CALLS]"
     end_marker = ""
+    # ``[TOOL_CALLS]`` is registered in Mistral v3+ tokenizers'
+    # ``added_tokens_decoder`` with ``special=True`` — alongside ``[INST]``,
+    # ``[/INST]``, ``[AVAILABLE_TOOLS]``, etc. ``skip_special_tokens=True``
+    # strips it on the way out of detokenization, so loaders must opt in to
+    # keep it. See ``tests/test_mistral_specials_smoketest.py`` for the
+    # round-trip evidence.
+    markers_are_specials = True
 
     _NAME_RE = re.compile(r'"name"\s*:\s*"([^"]+)"')
     _ARGS_RE = re.compile(r'"arguments"\s*:\s*')

--- a/modelship/openai/parsers/tool_calling/registry.py
+++ b/modelship/openai/parsers/tool_calling/registry.py
@@ -9,10 +9,16 @@ function-calling chat handler) bypass the registry entirely.
 
 from __future__ import annotations
 
-from modelship.openai.parsers.tool_calling.parsers import HermesToolCallParser, MistralToolCallParser, ToolCallParser
+from modelship.openai.parsers.tool_calling.parsers import (
+    HermesToolCallParser,
+    Llama3JsonToolCallParser,
+    MistralToolCallParser,
+    ToolCallParser,
+)
 
 _PARSERS: dict[str, ToolCallParser] = {
     HermesToolCallParser.name: HermesToolCallParser(),
+    Llama3JsonToolCallParser.name: Llama3JsonToolCallParser(),
     MistralToolCallParser.name: MistralToolCallParser(),
 }
 

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -90,6 +90,56 @@ MODEL_CONFIGS: dict[str, dict] = {
             "torch_dtype": "float32",
         },
     },
+    "chat-transformers-llama3-json": {
+        "name": "chat-transformers-llama3-json",
+        # Llama-3.1-8B-Instruct emits the JSON-format tool call defined by
+        # Meta's spec — bare ``{"name": "...", "parameters": {...}}``. The
+        # chat template references ``<|python_tag|>``, so auto-detection
+        # resolves to ``llama3_json``. 8B is the smallest Llama-3.x
+        # variant Meta certifies for tool / function calling — Llama-3.2-1B
+        # has the same chat template but does not reliably emit the
+        # JSON-call shape on ``tool_choice="auto"``. Like the Mistral-7B
+        # transformers deployment, 8B in float32 is too memory-heavy for
+        # CPU+float32, so this is the second exception pinned to a full
+        # GPU (``device=cuda``, native bfloat16 via ``torch_dtype="auto"``).
+        # Requires ``HF_TOKEN`` for the gated repo.
+        "model": "meta-llama/Llama-3.1-8B-Instruct",
+        "usecase": "generate",
+        "loader": "transformers",
+        "num_cpus": 5,
+        "num_gpus": 1,
+        "transformers_config": {
+            "device": "cuda",
+        },
+    },
+    "chat-transformers-mistral": {
+        "name": "chat-transformers-mistral",
+        # Mistral-7B-Instruct-v0.3 emits ``[TOOL_CALLS]`` followed by a JSON
+        # array of tool calls. The marker is registered as a *special added
+        # token* on the tokenizer, so by default ``skip_special_tokens=True``
+        # in ``TextIteratorStreamer`` would strip it before the parser sees
+        # it. The fix in this PR detects this case via
+        # ``markers_are_specials`` on the parser, pins
+        # ``_resolved_skip_special_tokens=False`` on the model config, and
+        # the transformers loader flips both ``TextIteratorStreamer`` and
+        # the non-streaming ``pipeline()`` call accordingly.
+        #
+        # 7B is the smallest official Mistral that ships the v3+ tool
+        # protocol; the rest of the transformers suite runs on CPU+float32
+        # but a 7B model in float32 (~28GB) creates too much memory
+        # pressure on the integration host, so this deployment is the
+        # exception — pinned to a full GPU. ``torch_dtype`` is left at the
+        # ``"auto"`` default which picks the model's native bfloat16.
+        # Requires ``HF_TOKEN`` (gated repo).
+        "model": "mistralai/Mistral-7B-Instruct-v0.3",
+        "usecase": "generate",
+        "loader": "transformers",
+        "num_cpus": 5,
+        "num_gpus": 1,
+        "transformers_config": {
+            "device": "cuda",
+        },
+    },
     "chat-transformers-reasoning": {
         "name": "chat-transformers-reasoning",
         # Qwen3-0.6B safetensors — same family as the vLLM `chat-reasoning`
@@ -743,6 +793,162 @@ class TestChatLlamaCppReasoning:
             assert "</tool_call>" in reasoning, (
                 f"reasoning has an unmatched <tool_call> marker (open without close): {reasoning!r}"
             )
+
+
+@pytest.mark.integration
+class TestChatTransformersLlama3Json:
+    """End-to-end llama3_json tool calling through the transformers loader.
+
+    Llama-3.1-8B-Instruct on GPU emits the JSON-format tool call defined
+    by Meta's spec — bare ``{"name": "...", "parameters": {...}}``. The
+    auto-detector picks ``llama3_json`` from the chat template's
+    ``<|python_tag|>`` reference. This class is the first end-to-end
+    exercise of the ``llama3_json`` parser on real model output (vLLM
+    has its own native parser; transformers/llama_cpp run through the
+    cross-loader registry).
+    """
+
+    @pytest.fixture(autouse=True, scope="class")
+    def _deploy(self, model_deployer):
+        model_deployer.deploy("chat-transformers-llama3-json")
+
+    def test_tool_calling_transformers_llama3_json_loader(self, client):
+        """Round-trip a bare-JSON tool call through the transformers loader.
+
+        Verifies the parser surfaces ``message.tool_calls`` from a
+        ``{"name": "...", "parameters": {...}}`` response and canonicalizes
+        the ``parameters`` field bytes into ``arguments`` for the OpenAI
+        contract.
+        """
+        completion = client.chat.completions.create(
+            model="chat-transformers-llama3-json",
+            messages=[{"role": "user", "content": "What is the weather in Paris?"}],
+            tools=[_WEATHER_TOOL],
+            tool_choice="auto",
+            max_tokens=128,
+        )
+        tool_calls = completion.choices[0].message.tool_calls
+        assert tool_calls, f"expected a tool call, got content={completion.choices[0].message.content!r}"
+        assert tool_calls[0].function.name == "get_weather"
+        assert "Paris" in tool_calls[0].function.arguments
+        assert completion.choices[0].finish_reason == "tool_calls"
+
+    def test_tool_calling_streaming_transformers_llama3_json_loader(self, client):
+        """Stream a bare-JSON tool call and verify the OpenAI delta contract.
+
+        Same shape as the Hermes/Mistral streaming tests: exactly one name
+        delta, multiple incremental argument deltas, valid JSON on
+        concatenation, final ``finish_reason="tool_calls"``.
+        """
+        stream = client.chat.completions.create(
+            model="chat-transformers-llama3-json",
+            messages=[{"role": "user", "content": "What is the weather in Paris?"}],
+            tools=[_WEATHER_TOOL],
+            tool_choice="auto",
+            max_tokens=128,
+            stream=True,
+        )
+
+        collected = _collect_streaming_tool_call(stream)
+
+        assert collected["tool_calls"], (
+            f"expected at least one streamed tool call; got content={collected['content']!r}"
+        )
+        call_0 = collected["tool_calls"][0]
+        assert call_0["id"], "expected an id on the first tool-call delta"
+        assert call_0["name"] == "get_weather"
+        assert collected["name_deltas"] == 1, f"expected one name delta, got {collected['name_deltas']}"
+        assert collected["args_deltas"] >= 2, (
+            f"expected arguments to stream incrementally, got {collected['args_deltas']} args delta(s)"
+        )
+        parsed_args = json.loads(call_0["arguments"])
+        assert parsed_args.get("city")
+        assert "Paris" in parsed_args["city"]
+        assert collected["finish_reason"] == "tool_calls"
+
+
+@pytest.mark.integration
+class TestChatTransformersMistral:
+    """End-to-end Mistral tool calling through the transformers loader.
+
+    Regression coverage for the ``markers_are_specials`` fix. Mistral
+    tokenizers register ``[TOOL_CALLS]`` as a special added token, so
+    the default ``TextIteratorStreamer(skip_special_tokens=True)`` would
+    strip the marker before the parser sees it — the parser would
+    silently miss every tool call. The fix pins
+    ``_resolved_skip_special_tokens=False`` from the parser flag and
+    the transformers loader honors it (plus a streamer-side noise
+    stripper for the other specials that now leak through).
+
+    If this class fails with empty ``tool_calls`` and the marker text
+    visible in ``message.content``, the loader plumbing has regressed.
+    """
+
+    @pytest.fixture(autouse=True, scope="class")
+    def _deploy(self, model_deployer):
+        model_deployer.deploy("chat-transformers-mistral")
+
+    def test_tool_calling_transformers_mistral_loader(self, client):
+        """Round-trip a ``[TOOL_CALLS]``-prefixed tool call through the
+        transformers loader.
+
+        Verifies the parser surfaces ``message.tool_calls`` from a
+        ``[TOOL_CALLS][{"name": "...", "arguments": {...}}]`` response —
+        which only works if the marker survived the tokenizer's
+        special-token stripping.
+        """
+        completion = client.chat.completions.create(
+            model="chat-transformers-mistral",
+            messages=[{"role": "user", "content": "What is the weather in Paris?"}],
+            tools=[_WEATHER_TOOL],
+            tool_choice="auto",
+            max_tokens=128,
+        )
+        tool_calls = completion.choices[0].message.tool_calls
+        assert tool_calls, (
+            f"expected a tool call (Mistral [TOOL_CALLS] marker likely stripped before parser saw it); "
+            f"got content={completion.choices[0].message.content!r}"
+        )
+        assert tool_calls[0].function.name == "get_weather"
+        assert "Paris" in tool_calls[0].function.arguments
+        assert completion.choices[0].finish_reason == "tool_calls"
+        # The marker itself must never leak into content.
+        assert "[TOOL_CALLS]" not in (completion.choices[0].message.content or "")
+
+    def test_tool_calling_streaming_transformers_mistral_loader(self, client):
+        """Stream a Mistral tool call and verify the OpenAI delta contract.
+
+        Same shape as the Hermes/llama3_json streaming tests: exactly one
+        name delta, multiple incremental argument deltas, valid JSON on
+        concatenation, final ``finish_reason="tool_calls"``. The marker
+        must not leak into any content delta.
+        """
+        stream = client.chat.completions.create(
+            model="chat-transformers-mistral",
+            messages=[{"role": "user", "content": "What is the weather in Paris?"}],
+            tools=[_WEATHER_TOOL],
+            tool_choice="auto",
+            max_tokens=128,
+            stream=True,
+        )
+
+        collected = _collect_streaming_tool_call(stream)
+
+        assert collected["tool_calls"], (
+            f"expected at least one streamed tool call; got content={collected['content']!r}"
+        )
+        call_0 = collected["tool_calls"][0]
+        assert call_0["id"], "expected an id on the first tool-call delta"
+        assert call_0["name"] == "get_weather"
+        assert collected["name_deltas"] == 1, f"expected one name delta, got {collected['name_deltas']}"
+        assert collected["args_deltas"] >= 2, (
+            f"expected arguments to stream incrementally, got {collected['args_deltas']} args delta(s)"
+        )
+        parsed_args = json.loads(call_0["arguments"])
+        assert parsed_args.get("city")
+        assert "Paris" in parsed_args["city"]
+        assert collected["finish_reason"] == "tool_calls"
+        assert "[TOOL_CALLS]" not in collected["content"]
 
 
 @pytest.mark.integration

--- a/tests/test_mistral_specials_smoketest.py
+++ b/tests/test_mistral_specials_smoketest.py
@@ -1,0 +1,215 @@
+"""Smoke test for the hypothesis that ``[TOOL_CALLS]`` is stripped before our parser sees it.
+
+Background
+----------
+The ``MistralToolCallParser`` declares ``start_marker = "[TOOL_CALLS]"``.
+The transformers loader streams generation through ``TextIteratorStreamer``
+with ``skip_special_tokens=True`` ([modelship/infer/transformers/openai/serving_chat.py:221]).
+
+If a Mistral tokenizer registers ``[TOOL_CALLS]`` as an *additional special
+token*, then on a real Mistral model run, the marker would be stripped from
+the streamed text before reaching our parser — and our parser would never
+enter tool-call mode. Streamer-level unit tests don't catch this because
+they feed strings directly, bypassing the tokenizer round-trip.
+
+This file confirms or rejects the hypothesis in two parts:
+
+1. **Synthetic** (always runs): build a tokenizer with ``[TOOL_CALLS]``
+   registered as an additional special token, encode a sample tool-call
+   string, decode with each ``skip_special_tokens`` setting, and verify
+   that the stripping behavior is what we feared. This tests the HF
+   contract, not Mistral specifically — it tells us whether *any* tokenizer
+   that registers the marker as special would lose it on the transformers
+   loader path.
+
+2. **Real Mistral** (skipped if the tokenizer can't be loaded): load a
+   real Mistral tokenizer and check whether ``[TOOL_CALLS]`` actually
+   appears in its specials list. Skipped on missing HF auth or no
+   network, so this part is opt-in.
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+
+def _sample_tool_call_text() -> str:
+    return '[TOOL_CALLS][{"name": "get_weather", "arguments": {"city": "Paris"}}]'
+
+
+class TestSyntheticAdditionalSpecialTokenStripping:
+    """Pure HF behavior check — no network, no auth.
+
+    Take any small public tokenizer, add ``[TOOL_CALLS]`` as an additional
+    special token, and confirm that ``skip_special_tokens=True`` strips it
+    out of the decoded text. If this passes, the same will happen on any
+    real Mistral tokenizer that registers ``[TOOL_CALLS]`` as special —
+    which is the second test in this file.
+    """
+
+    @pytest.fixture(scope="class")
+    def tokenizer_with_tool_calls_special(self):
+        from transformers import AutoTokenizer
+
+        # Qwen2.5-0.5B's tokenizer is already used by the project's
+        # integration suite (no auth, small download). We only need its
+        # vocabulary; we then register `[TOOL_CALLS]` as a special token
+        # on top of it to mirror the Mistral configuration.
+        try:
+            tokenizer = AutoTokenizer.from_pretrained("Qwen/Qwen2.5-0.5B-Instruct")
+        except Exception as e:
+            pytest.skip(f"could not load the host tokenizer for the synthetic test: {e}")
+        tokenizer.add_special_tokens({"additional_special_tokens": ["[TOOL_CALLS]"]})
+        return tokenizer
+
+    def test_roundtrip_keeps_marker_when_skip_special_tokens_false(self, tokenizer_with_tool_calls_special):
+        text = _sample_tool_call_text()
+        ids = tokenizer_with_tool_calls_special.encode(text, add_special_tokens=False)
+        decoded = tokenizer_with_tool_calls_special.decode(ids, skip_special_tokens=False)
+        assert "[TOOL_CALLS]" in decoded, (
+            "with skip_special_tokens=False the marker MUST round-trip — if this fails, the test setup is wrong"
+        )
+
+    def test_roundtrip_strips_marker_when_skip_special_tokens_true(self, tokenizer_with_tool_calls_special):
+        """The hypothesis: when ``[TOOL_CALLS]`` is an additional special
+        token, ``skip_special_tokens=True`` removes it from the decoded
+        text — which is exactly what the transformers loader does today.
+
+        If this assertion holds, the just-merged Mistral parser cannot
+        activate on the transformers loader for any tokenizer that
+        registers the marker as special. The fix is loader-side
+        (per-parser flag flip + noise stripper, deferred from the
+        ``llama3_json`` PR).
+        """
+        text = _sample_tool_call_text()
+        ids = tokenizer_with_tool_calls_special.encode(text, add_special_tokens=False)
+        decoded = tokenizer_with_tool_calls_special.decode(ids, skip_special_tokens=True)
+        assert "[TOOL_CALLS]" not in decoded, (
+            "expected `[TOOL_CALLS]` to be stripped by skip_special_tokens=True; "
+            f"got decoded={decoded!r}. If this assertion fails, the hypothesis is wrong "
+            "and Mistral on the transformers loader is fine as-is."
+        )
+
+
+class TestRealMistralTokenizer:
+    """Verify the second half of the hypothesis on a real Mistral tokenizer.
+
+    Skipped unless a Mistral repo is reachable (typically requires
+    ``HF_TOKEN`` since ``mistralai/*`` repos are gated).
+    """
+
+    @pytest.fixture(scope="class")
+    def mistral_tokenizer(self):
+        from transformers import AutoTokenizer
+
+        # Try the canonical v0.3 first; fall back to other v3+ Mistral
+        # repos that ship the same `[TOOL_CALLS]` marker if v0.3 is
+        # unreachable.
+        candidates = [
+            "mistralai/Mistral-7B-Instruct-v0.3",
+            "mistralai/Mistral-Small-Instruct-2409",
+            "mistralai/Mistral-Nemo-Instruct-2407",
+        ]
+        last_err: Exception | None = None
+        for repo in candidates:
+            try:
+                return AutoTokenizer.from_pretrained(repo)
+            except Exception as e:
+                last_err = e
+        token_present = "set" if os.environ.get("HF_TOKEN") else "unset"
+        pytest.skip(
+            f"no Mistral tokenizer reachable from {candidates!r} (HF_TOKEN {token_present}); last error: {last_err!r}"
+        )
+
+    def test_tool_calls_is_a_special_added_token(self, mistral_tokenizer):
+        """Confirm ``[TOOL_CALLS]`` is registered as a special added token.
+
+        Mistral v3+ tokenizers register tool-protocol markers in
+        ``added_tokens_decoder`` with ``special=True``, NOT in
+        ``all_special_tokens`` (which only carries the bos/eos/unk core).
+        ``skip_special_tokens=True`` strips both groups. Checking
+        ``all_special_tokens`` alone misses this — the right attribute is
+        ``added_tokens_decoder``.
+        """
+        special_added: dict[int, str] = {
+            tid: tok.content for tid, tok in mistral_tokenizer.added_tokens_decoder.items() if tok.special
+        }
+        assert "[TOOL_CALLS]" in special_added.values(), (
+            "hypothesis disproved: `[TOOL_CALLS]` is NOT a special added token on this Mistral tokenizer "
+            f"(special_added={special_added!r}); the marker would survive skip_special_tokens=True and "
+            "the parser is fine."
+        )
+
+    def test_real_tokenizer_strips_marker_with_skip_special_tokens_true(self, mistral_tokenizer):
+        """End-to-end confirmation on a real Mistral tokenizer."""
+        text = _sample_tool_call_text()
+        ids = mistral_tokenizer.encode(text, add_special_tokens=False)
+        decoded = mistral_tokenizer.decode(ids, skip_special_tokens=True)
+        assert "[TOOL_CALLS]" not in decoded, (
+            f"expected `[TOOL_CALLS]` stripped on the real Mistral tokenizer; got decoded={decoded!r}."
+        )
+
+
+class TestLlamaCppHasSameBug:
+    """Confirm the same hypothesis on the llama_cpp loader path.
+
+    ``Llama.detokenize`` defaults to ``special=False``
+    (``inspect.signature`` proves it), and ``Llama.create_completion``
+    calls ``self.detokenize(...)`` without overriding that. So any
+    GGUF Mistral model running on the llama_cpp loader will also have
+    ``[TOOL_CALLS]`` stripped before our parser sees it.
+
+    This test is a *static* check — we don't need to load a real GGUF
+    Mistral to confirm the failure mode. The default value of the
+    detokenize parameter is the failure surface.
+
+    Why static and not behavioral: a behavioral test would require
+    downloading a Mistral GGUF (multi-GB) and running inference. The
+    purpose of the smoke test is to confirm the hypothesis cheaply.
+    The transformers fix in this PR addresses the transformers loader;
+    the llama_cpp fix is deferred to a follow-up because it requires
+    bypassing ``create_completion``'s text-only chunk shape (no token
+    IDs are exposed in the chunk dict, so we can't re-detokenize with
+    ``special=True`` without restructuring the call site).
+    """
+
+    def test_llama_detokenize_defaults_to_stripping_specials(self):
+        import inspect
+
+        from llama_cpp import Llama
+
+        sig = inspect.signature(Llama.detokenize)
+        special_param = sig.parameters.get("special")
+        assert special_param is not None, "Llama.detokenize unexpectedly lacks a `special` parameter"
+        assert special_param.default is False, (
+            f"hypothesis disproved: Llama.detokenize now defaults to special={special_param.default!r}; "
+            "llama_cpp may already preserve special tokens in its streaming text."
+        )
+
+    def test_llama_create_completion_does_not_override_special(self):
+        """``create_completion`` does not pass ``special=True`` when
+        detokenizing. Combined with the default-False above, this means
+        ``[TOOL_CALLS]`` is dropped before reaching ``chunk["choices"][0]["text"]``.
+        """
+        import inspect
+
+        from llama_cpp import Llama
+
+        # Find the streaming generator. Implementation detail name has
+        # changed across llama-cpp-python versions, so try both.
+        for attr in ("_create_completion", "create_completion"):
+            fn = getattr(Llama, attr, None)
+            if fn is None:
+                continue
+            src = inspect.getsource(fn)
+            # If `detokenize(` is called anywhere with `special=True`, the
+            # bug doesn't apply — but we expect every call site to omit it.
+            assert "detokenize(" in src, f"unexpected: {attr} doesn't reference detokenize"
+            assert "special=True" not in src, (
+                f"hypothesis disproved on {attr}: at least one detokenize call now passes special=True; "
+                "llama_cpp may emit specials in streamed text. Re-evaluate the loader fix scope."
+            )
+            return
+        pytest.fail("could not locate the llama-cpp-python streaming completion function")

--- a/tests/test_parser_resolution.py
+++ b/tests/test_parser_resolution.py
@@ -143,3 +143,34 @@ class TestResolveToolParsersStoresExplicit:
         cfg._resolved_chat_template = "{% if tools %}<tool_call>{% endif %}"
         resolve_all_tool_parsers(ModelshipConfig(models=[cfg]))
         assert cfg._resolved_tool_call_parser is None
+
+
+class TestResolveSkipSpecialTokens:
+    """``_resolved_skip_special_tokens`` is pinned by the parser's flag.
+
+    The transformers loader reads this at startup to decide whether to
+    flip ``TextIteratorStreamer(skip_special_tokens=False)``. ``None``
+    means "loader keeps its own default (True)"; ``False`` means "the
+    parser's marker is registered as a special token and would be
+    stripped — keep specials in the stream and noise-strip the rest."
+    """
+
+    def test_hermes_leaves_skip_specials_default(self):
+        cfg = _make_cfg(vllm_engine_kwargs=VllmEngineConfig(tool_call_parser="hermes"))
+        resolve_all_tool_parsers(ModelshipConfig(models=[cfg]))
+        assert cfg._resolved_skip_special_tokens is None
+
+    def test_llama3_json_leaves_skip_specials_default(self):
+        cfg = _make_cfg(vllm_engine_kwargs=VllmEngineConfig(tool_call_parser="llama3_json"))
+        resolve_all_tool_parsers(ModelshipConfig(models=[cfg]))
+        assert cfg._resolved_skip_special_tokens is None
+
+    def test_mistral_pins_skip_specials_false(self):
+        # Mistral parser's marker is a special added token; loader must
+        # keep specials so the parser sees `[TOOL_CALLS]`.
+        cfg = _make_cfg(
+            loader=ModelLoader.transformers,
+            transformers_config=TransformersConfig(tool_call_parser="mistral"),
+        )
+        resolve_all_tool_parsers(ModelshipConfig(models=[cfg]))
+        assert cfg._resolved_skip_special_tokens is False

--- a/tests/test_parser_resolution.py
+++ b/tests/test_parser_resolution.py
@@ -49,9 +49,9 @@ class TestClassifyReasoningTemplate:
 
 class TestResolveReasoningParsers:
     def test_explicit_parser_stored(self):
-        cfg = _make_cfg(vllm_engine_kwargs=VllmEngineConfig(reasoning_parser="qwen3"))
+        cfg = _make_cfg(vllm_engine_kwargs=VllmEngineConfig(reasoning_parser="deepseek_r1"))
         resolve_all_reasoning_parsers(ModelshipConfig(models=[cfg]))
-        assert cfg._resolved_reasoning_parser == "qwen3"
+        assert cfg._resolved_reasoning_parser == "deepseek_r1"
 
     def test_explicit_opt_out_leaves_none(self, monkeypatch):
         cfg = _make_cfg(vllm_engine_kwargs=VllmEngineConfig(enable_reasoning=False))
@@ -72,10 +72,10 @@ class TestResolveReasoningParsers:
         assert cfg._resolved_reasoning_parser is None
 
     def test_explicit_wins_over_auto(self):
-        cfg = _make_cfg(vllm_engine_kwargs=VllmEngineConfig(reasoning_parser="custom_x"))
+        cfg = _make_cfg(vllm_engine_kwargs=VllmEngineConfig(reasoning_parser="deepseek_r1"))
         cfg._resolved_chat_template = "<think>x</think>"
         resolve_all_reasoning_parsers(ModelshipConfig(models=[cfg]))
-        assert cfg._resolved_reasoning_parser == "custom_x"
+        assert cfg._resolved_reasoning_parser == "deepseek_r1"
 
     def test_skips_non_generate_usecase(self):
         cfg = _make_cfg(usecase=ModelUsecase.embed)

--- a/tests/test_tool_calling.py
+++ b/tests/test_tool_calling.py
@@ -14,7 +14,12 @@ from modelship.openai.parsers.tool_calling import (
     register_parser,
     resolve_tools_for_request,
 )
-from modelship.openai.parsers.tool_calling.parsers import HermesToolCallParser, MistralToolCallParser, ToolCallParser
+from modelship.openai.parsers.tool_calling.parsers import (
+    HermesToolCallParser,
+    Llama3JsonToolCallParser,
+    MistralToolCallParser,
+    ToolCallParser,
+)
 
 
 class TestRegistry:
@@ -23,6 +28,9 @@ class TestRegistry:
 
     def test_default_registry_includes_mistral(self):
         assert "mistral" in available_parsers()
+
+    def test_default_registry_includes_llama3_json(self):
+        assert "llama3_json" in available_parsers()
 
     def test_get_parser_returns_singleton(self):
         a = get_parser("hermes")
@@ -445,3 +453,231 @@ class TestSplitPayloadDefault:
         parser = HermesToolCallParser()
         assert parser.split_payload("anything", True) == [("anything", True)]
         assert parser.split_payload("anything", False) == [("anything", False)]
+
+
+class TestMarkersAreSpecialsFlag:
+    """Each parser's ``markers_are_specials`` flag gates the loader-side flip."""
+
+    def test_hermes_marker_is_regular_text(self):
+        assert HermesToolCallParser().markers_are_specials is False
+
+    def test_llama3_json_marker_is_regular_text(self):
+        from modelship.openai.parsers.tool_calling.parsers import Llama3JsonToolCallParser
+
+        assert Llama3JsonToolCallParser().markers_are_specials is False
+
+    def test_mistral_marker_is_a_special_token(self):
+        # Drives the transformers loader to flip ``skip_special_tokens=False``
+        # at startup so ``[TOOL_CALLS]`` survives detokenization.
+        assert MistralToolCallParser().markers_are_specials is True
+
+
+class TestStreamerNoiseStripping:
+    """When the loader keeps specials, the streamer drops every noise marker
+    (everything other than the parser's own start/end markers) before scanning.
+
+    The cumulative-text design means a special token that was split across
+    HF chunks is reassembled before the streamer ever sees it, so per-chunk
+    holdback isn't needed at this layer — we just ``replace`` over the full
+    accumulated buffer every diff pass.
+    """
+
+    def test_eos_token_does_not_leak_into_content(self):
+        streamer = ChatOutputStreamer(MistralToolCallParser(), noise_specials=("</s>", "<|eot_id|>"))
+        # Pure content path with the model's EOS appended.
+        d1 = streamer.extract_streaming("hello world</s>")
+        # Content delta should exclude the EOS bytes.
+        content = "".join(d.content or "" for d in [d1] if d is not None)
+        assert content == "hello world"
+
+    def test_tool_marker_is_kept_when_listed_as_keep(self):
+        # ``[TOOL_CALLS]`` is the parser's own start marker — even if it's
+        # also "special" in the tokenizer, it must survive because the
+        # loader includes it in the keep set, NOT in noise_specials.
+        streamer = ChatOutputStreamer(
+            MistralToolCallParser(),
+            noise_specials=("[INST]", "[/INST]", "</s>"),
+        )
+        text = '[TOOL_CALLS][{"name": "get_weather", "arguments": {"city": "Paris"}}]</s>'
+        streamer.extract_streaming(text)
+        streamer.finalize()
+        result = streamer.result
+        assert len(result.tool_calls) == 1
+        assert result.tool_calls[0].function.name == "get_weather"
+        # The trailing </s> must not have leaked into content.
+        assert result.content is None or "</s>" not in result.content
+
+    def test_noise_split_across_cumulative_passes_is_caught(self):
+        # First pass sees `<|eot_i`, the next pass sees the full `<|eot_id|>`.
+        # Because the streamer re-strips against the full cumulative buffer
+        # every diff pass, the partial isn't yielded and the full marker
+        # is removed once it arrives.
+        streamer = ChatOutputStreamer(MistralToolCallParser(), noise_specials=("<|eot_id|>",))
+        d1 = streamer.extract_streaming("done <|eot_i")
+        d2 = streamer.extract_streaming("done <|eot_id|>")
+        final = streamer.finalize()
+        all_content = "".join(d.content or "" for d in (d1, d2, final) if d is not None)
+        assert "<|eot_id|>" not in all_content
+        # The "<|eot_i" partial must not have been forwarded as content.
+        assert "<|eot_i" not in all_content
+
+    def test_empty_noise_specials_is_a_no_op(self):
+        streamer = ChatOutputStreamer(HermesToolCallParser(), noise_specials=())
+        d = streamer.extract_streaming("plain text")
+        assert d is not None and d.content == "plain text"
+
+
+class TestLlama3JsonParser:
+    parser = Llama3JsonToolCallParser()
+
+    def test_no_tool_calls_returns_text_unchanged(self):
+        result = self.parser.parse("just a regular response")
+        assert result.tool_calls == []
+        assert result.content == "just a regular response"
+        assert result.has_tool_calls is False
+
+    def test_single_tool_call_with_parameters_field(self):
+        # Meta's official Llama-3.1 JSON template uses ``parameters``.
+        text = '{"name": "get_weather", "parameters": {"city": "Paris"}}'
+        result = self.parser.parse(text)
+        assert len(result.tool_calls) == 1
+        assert result.tool_calls[0].function.name == "get_weather"
+        assert json.loads(result.tool_calls[0].function.arguments) == {"city": "Paris"}
+        assert result.content is None
+
+    def test_single_tool_call_with_arguments_field(self):
+        # Some community fine-tunes emit ``arguments`` instead — accept both.
+        text = '{"name": "get_weather", "arguments": {"city": "Paris"}}'
+        result = self.parser.parse(text)
+        assert len(result.tool_calls) == 1
+        assert result.tool_calls[0].function.name == "get_weather"
+        assert json.loads(result.tool_calls[0].function.arguments) == {"city": "Paris"}
+
+    def test_multiple_tool_calls_separated_by_semicolon(self):
+        # vLLM convention for multi-call output.
+        text = '{"name": "a", "parameters": {"x": 1}}; {"name": "b", "parameters": {"y": 2}}'
+        result = self.parser.parse(text)
+        assert [tc.function.name for tc in result.tool_calls] == ["a", "b"]
+        assert json.loads(result.tool_calls[0].function.arguments) == {"x": 1}
+        assert json.loads(result.tool_calls[1].function.arguments) == {"y": 2}
+
+    def test_tool_call_with_residual_text(self):
+        text = 'Sure, calling that.\n{"name": "ping", "parameters": {}}'
+        result = self.parser.parse(text)
+        assert len(result.tool_calls) == 1
+        assert result.content == "Sure, calling that.\n"
+
+    def test_whitespace_only_preamble_nulls_content(self):
+        text = '   \n{"name": "ping", "parameters": {}}'
+        result = self.parser.parse(text)
+        assert len(result.tool_calls) == 1
+        assert result.content is None
+
+    def test_object_arguments_passed_through(self):
+        text = '{"name": "x", "parameters": {"a": 1, "b": [2, 3]}}'
+        result = self.parser.parse(text)
+        assert json.loads(result.tool_calls[0].function.arguments) == {"a": 1, "b": [2, 3]}
+
+    def test_string_arguments_forwarded_verbatim(self):
+        text = '{"name": "x", "parameters": "{\\"a\\": 1}"}'
+        result = self.parser.parse(text)
+        assert result.tool_calls[0].function.arguments == '"{\\"a\\": 1}"'
+
+    def test_braces_inside_string_args_do_not_break_split(self):
+        # The split walker tracks string state so literal `{` / `}` inside
+        # string values must not move the brace-depth counter.
+        text = '{"name": "x", "parameters": {"q": "}{ literal"}}'
+        result = self.parser.parse(text)
+        assert len(result.tool_calls) == 1
+        assert json.loads(result.tool_calls[0].function.arguments) == {"q": "}{ literal"}
+
+    def test_block_without_extractable_name_is_dropped(self):
+        # The bare-JSON marker is `{"name"` — a payload that doesn't even
+        # contain `"name"` won't trip the marker, so no tool call surfaces.
+        text = '{"foo": "bar"}'
+        result = self.parser.parse(text)
+        assert result.tool_calls == []
+
+    def test_each_tool_call_gets_unique_id(self):
+        text = '{"name": "a", "parameters": {}}; {"name": "b", "parameters": {}}'
+        result = self.parser.parse(text)
+        assert result.tool_calls[0].id != result.tool_calls[1].id
+
+
+class TestLlama3JsonStreamer:
+    """Stream a Llama-3.1 JSON tool call incrementally and verify deltas.
+
+    The region is EOS-bounded (empty `end_marker`) like Mistral, so completion
+    happens at finalize time. The marker `{"name"` is NOT consumed by the
+    streamer so the JSON object stays intact for the body extractors.
+    """
+
+    def _feed(self, chunks: list[str]) -> tuple[ChatOutputStreamer, list]:
+        streamer = ChatOutputStreamer(Llama3JsonToolCallParser())
+        deltas = []
+        cumulative = ""
+        for chunk in chunks:
+            cumulative += chunk
+            d = streamer.extract_streaming(cumulative)
+            if d is not None:
+                deltas.append(d)
+        final = streamer.finalize()
+        if final is not None:
+            deltas.append(final)
+        return streamer, deltas
+
+    def test_emits_name_before_args_for_single_call(self):
+        chunks = list('{"name": "get_weather", "parameters": {"city": "Paris"}}')
+        streamer, deltas = self._feed(chunks)
+
+        tool_deltas = [tc for d in deltas for tc in d.tool_calls]
+        assert tool_deltas[0].function is not None
+        assert tool_deltas[0].function.name == "get_weather"
+        assert tool_deltas[0].id is not None
+        assert tool_deltas[0].function.arguments is None
+        joined_args = "".join(d.function.arguments or "" for d in tool_deltas[1:])
+        assert json.loads(joined_args) == {"city": "Paris"}
+        # Region is EOS-bounded → finalize closes it out.
+        assert len(streamer.result.tool_calls) == 1
+
+    def test_two_calls_separated_by_semicolon_finalize_with_distinct_indices(self):
+        text = '{"name": "a", "parameters": {"x": 1}}; {"name": "b", "parameters": {"y": 2}}'
+        streamer, deltas = self._feed([text])
+
+        tool_deltas = [tc for d in deltas for tc in d.tool_calls]
+        indices = {d.index for d in tool_deltas}
+        assert indices == {0, 1}
+        names = [d.function.name for d in tool_deltas if d.function and d.function.name]
+        assert names == ["a", "b"]
+        assert [tc.function.name for tc in streamer.result.tool_calls] == ["a", "b"]
+
+    def test_preamble_holds_back_marker_prefix(self):
+        # A leading `{` could be the first byte of `{"name"`; the streamer must
+        # hold it until the next byte proves it is or isn't the marker.
+        streamer = ChatOutputStreamer(Llama3JsonToolCallParser())
+        mid = streamer.extract_streaming("hello {")
+        assert mid is not None and mid.content == "hello "
+        final = streamer.finalize()
+        assert final is not None and final.content == "{"
+
+    def test_no_marker_streams_as_pure_content(self):
+        # Plain text response with no JSON at all goes through as content.
+        _, deltas = self._feed(["plain ", "answer ", "no tools"])
+        assert "".join(d.content or "" for d in deltas) == "plain answer no tools"
+
+    def test_unterminated_call_drops_partial_at_finalize(self):
+        # Model emitted a full call and started a second that never closed.
+        # The first should finalize; the second is dropped.
+        text = '{"name": "done", "parameters": {"x": 1}}; {"name": "wip"'
+        streamer, _ = self._feed([text])
+        assert [tc.function.name for tc in streamer.result.tool_calls] == ["done"]
+
+    def test_arguments_stream_incrementally(self):
+        prefix = '{"name": "ping", "parameters": '
+        suffix = '{"x": 42}}'
+        _, deltas = self._feed([prefix, *list(suffix)])
+
+        arg_deltas = [tc for d in deltas for tc in d.tool_calls if tc.function and tc.function.arguments is not None]
+        assert len(arg_deltas) >= 3
+        joined = "".join(d.function.arguments or "" for d in arg_deltas)
+        assert json.loads(joined) == {"x": 42}


### PR DESCRIPTION
Adds the Meta-spec bare-JSON tool-call parser ({"name": "...", "parameters": {...}}) used by Llama-3.1 / Llama-3.2 Instruct, wired through the cross-loader registry with auto-detection from the chat template's <|python_tag|> marker. Integration coverage runs against Llama-3.1-8B-Instruct on GPU — the smallest Llama-3.x variant that reliably emits the JSON-call shape on tool_choice="auto".


