### PR TITLE
feat(parsers): add Gemma 4 and FunctionGemma tool/reasoning parsers

### DIFF
--- a/modelship/openai/parsers/output.py
+++ b/modelship/openai/parsers/output.py
@@ -343,7 +343,7 @@ class ChatOutputStreamer:
                         )
                     )
 
-                args = self._tool_parser.extract_partial_args(sub_payload)
+                args = self._tool_parser.extract_partial_args(sub_payload, is_complete=sub_complete)
                 if args is not None and len(args) > len(self._sent_args[i]):
                     diff = args[len(self._sent_args[i]) :]
                     self._sent_args[i] = args

--- a/modelship/openai/parsers/reasoning/parsers/__init__.py
+++ b/modelship/openai/parsers/reasoning/parsers/__init__.py
@@ -1,4 +1,5 @@
 from modelship.openai.parsers.reasoning.parsers.base import ReasoningParser
 from modelship.openai.parsers.reasoning.parsers.deepseek import DeepseekR1ReasoningParser
+from modelship.openai.parsers.reasoning.parsers.gemma import Gemma4ReasoningParser
 
-__all__ = ["DeepseekR1ReasoningParser", "ReasoningParser"]
+__all__ = ["DeepseekR1ReasoningParser", "Gemma4ReasoningParser", "ReasoningParser"]

--- a/modelship/openai/parsers/reasoning/parsers/gemma.py
+++ b/modelship/openai/parsers/reasoning/parsers/gemma.py
@@ -1,0 +1,19 @@
+"""Gemma 4 "Thinking Mode" reasoning parser.
+
+Gemma 4 uses a "channel" mechanism to separate internal reasoning from
+the final answer. Reasoning is wrapped in `<|channel>thought\\n...<channel|>`.
+"""
+
+from __future__ import annotations
+
+from modelship.openai.parsers.reasoning.parsers.base import ReasoningParser
+
+
+class Gemma4ReasoningParser(ReasoningParser):
+    name = "gemma4"
+    # We include 'thought\n' in the start marker so ChatOutputStreamer
+    # strips it from the reasoning payload, consistent with vLLM's
+    # implementation.
+    start_marker = "<|channel>thought\n"
+    end_marker = "<channel|>"
+    markers_are_specials = True

--- a/modelship/openai/parsers/reasoning/registry.py
+++ b/modelship/openai/parsers/reasoning/registry.py
@@ -9,10 +9,15 @@ built-in reasoning parsers and consumes only the resolved name.
 
 from __future__ import annotations
 
-from modelship.openai.parsers.reasoning.parsers import DeepseekR1ReasoningParser, ReasoningParser
+from modelship.openai.parsers.reasoning.parsers import (
+    DeepseekR1ReasoningParser,
+    Gemma4ReasoningParser,
+    ReasoningParser,
+)
 
 _PARSERS: dict[str, ReasoningParser] = {
     DeepseekR1ReasoningParser.name: DeepseekR1ReasoningParser(),
+    Gemma4ReasoningParser.name: Gemma4ReasoningParser(),
 }
 
 

--- a/modelship/openai/parsers/reasoning/utils.py
+++ b/modelship/openai/parsers/reasoning/utils.py
@@ -17,6 +17,8 @@ def detect_reasoning_parser(model_path: str | Path) -> str | None:
 
 def classify_template(template: str) -> str | None:
     """Map a chat-template string to a reasoning parser name based on markers."""
+    if "<|channel>thought" in template:
+        return "gemma4"
     if "<think>" in template or "</think>" in template:
         return "deepseek_r1"
     return None

--- a/modelship/openai/parsers/tool_calling/parsers/__init__.py
+++ b/modelship/openai/parsers/tool_calling/parsers/__init__.py
@@ -1,6 +1,17 @@
 from modelship.openai.parsers.tool_calling.parsers.base import ToolCallParser
+from modelship.openai.parsers.tool_calling.parsers.gemma import (
+    FunctionGemmaToolCallParser,
+    Gemma4ToolCallParser,
+)
 from modelship.openai.parsers.tool_calling.parsers.hermes import HermesToolCallParser
 from modelship.openai.parsers.tool_calling.parsers.llama3_json import Llama3JsonToolCallParser
 from modelship.openai.parsers.tool_calling.parsers.mistral import MistralToolCallParser
 
-__all__ = ["HermesToolCallParser", "Llama3JsonToolCallParser", "MistralToolCallParser", "ToolCallParser"]
+__all__ = [
+    "FunctionGemmaToolCallParser",
+    "Gemma4ToolCallParser",
+    "HermesToolCallParser",
+    "Llama3JsonToolCallParser",
+    "MistralToolCallParser",
+    "ToolCallParser",
+]

--- a/modelship/openai/parsers/tool_calling/parsers/base.py
+++ b/modelship/openai/parsers/tool_calling/parsers/base.py
@@ -64,7 +64,7 @@ class ToolCallParser(ABC):
         """
 
     @abstractmethod
-    def extract_partial_args(self, partial_payload: str) -> str | None:
+    def extract_partial_args(self, partial_payload: str, is_complete: bool = False) -> str | None:
         """Return the arguments substring as the client should see it so far.
 
         The streamer takes a length-diff of successive returns and forwards
@@ -72,6 +72,11 @@ class ToolCallParser(ABC):
         that could plausibly be the envelope closer landing ahead of the
         family's end marker — otherwise those bytes leak into the args
         stream and the client receives malformed JSON.
+
+        ``is_complete`` is True when the streamer has confirmed the tool call
+        is fully terminated (or at the end of generation). This allows parsers
+        that construct JSON dynamically (e.g., from custom syntax) to flush
+        withheld structural bytes.
         """
 
     def split_payload(self, payload: str, is_complete: bool) -> list[tuple[str, bool]]:

--- a/modelship/openai/parsers/tool_calling/parsers/gemma.py
+++ b/modelship/openai/parsers/tool_calling/parsers/gemma.py
@@ -1,0 +1,347 @@
+"""Tool call parsers for Google Gemma models.
+
+Gemma 4 uses a custom serialization format (not JSON) for tool calls:
+`<|tool_call|>call:func_name{key:<|"|>value<|"|>,num:42}<tool_call|>`
+
+FunctionGemma (Gemma 2) uses:
+`<start_function_call>call:func_name{key:<escape>value<escape>}<end_function_call>`
+"""
+
+from __future__ import annotations
+
+import json
+
+from modelship.openai.parsers.tool_calling.parsers.base import ToolCallParser
+
+STRING_DELIM = '<|"|>'
+ESCAPE_DELIM = "<escape>"
+
+
+class Gemma4ToolCallParser(ToolCallParser):
+    name = "gemma4"
+    start_marker = "<|tool_call>"
+    end_marker = "<tool_call|>"
+    markers_are_specials = True
+
+    def extract_partial_name(self, partial_payload: str) -> str | None:
+        """Extract function name from 'call:func_name{...'."""
+        if not partial_payload.startswith("call:"):
+            return None
+        # Name ends at the first '{'
+        if "{" not in partial_payload:
+            return None
+        name_part = partial_payload[5 : partial_payload.find("{")]
+        return name_part.strip() or None
+
+    def extract_partial_args(self, partial_payload: str, is_complete: bool = False) -> str | None:
+        """Parse Gemma 4 custom format and return standard JSON string."""
+        if "{" not in partial_payload:
+            return None
+
+        raw_args = partial_payload[partial_payload.find("{") + 1 :]
+        # Strip trailing '}' if present (it's the structural end of the call)
+        if raw_args.endswith("}"):
+            raw_args = raw_args[:-1]
+
+        try:
+            # We parse the custom syntax into a dict and dump it to JSON.
+            # partial=not is_complete tells the parser to withhold incomplete values
+            # at the very end of the stream to avoid flickering types.
+            args_dict = _parse_gemma4_args(raw_args, partial=not is_complete)
+            if not args_dict:
+                return "{}" if is_complete else ""
+
+            full_json = json.dumps(args_dict, ensure_ascii=False)
+
+            if is_complete:
+                return full_json
+
+            # The streamer takes a suffix-diff. To prevent it from emitting
+            # the closing braces of the JSON object prematurely (which might
+            # move if more keys arrive), we withhold trailing JSON structural
+            # characters during streaming.
+            safe_json = full_json
+            while safe_json and safe_json[-1] in ("}", "]", '"', ",", " ", ":", "<", "|", "\\", ">"):
+                safe_json = safe_json[:-1]
+
+            return safe_json
+        except Exception:
+            return ""
+
+    def split_payload(self, payload: str, is_complete: bool) -> list[tuple[str, bool]]:
+        """Gemma 4 can concatenate multiple calls: `call:a{...}call:b{...}`."""
+        # Find all occurrences of "call:" at the top level (not inside braces)
+        calls: list[tuple[str, bool]] = []
+        pos = 0
+        n = len(payload)
+
+        while pos < n:
+            start = payload.find("call:", pos)
+            if start == -1:
+                break
+
+            # Find the end of this call. We look for the NEXT "call:" or end of string.
+            # But we must be careful not to find "call:" inside a string or nested object.
+            # For simplicity, we search for the next "call:" and assume it's a new call
+            # if it's preceded by a "}".
+            next_call = payload.find("call:", start + 5)
+            while next_call != -1:
+                # Basic check: a new call should be preceded by a closing brace
+                # from the previous call.
+                preceding = payload[start:next_call].rstrip()
+                if preceding.endswith("}"):
+                    break
+                next_call = payload.find("call:", next_call + 5)
+
+            if next_call == -1:
+                # This is the last call in the payload.
+                sub_payload = payload[start:]
+                calls.append((sub_payload, is_complete))
+                break
+            else:
+                sub_payload = payload[start:next_call]
+                calls.append((sub_payload, True))  # Inner calls are complete
+                pos = next_call
+
+        return calls or [(payload, is_complete)]
+
+
+class FunctionGemmaToolCallParser(Gemma4ToolCallParser):
+    """Parses FunctionGemma (Gemma 2) output which uses `<escape>` instead of `<|"|>`."""
+
+    name = "function_gemma"
+    start_marker = "<start_function_call>"
+    end_marker = "<end_function_call>"
+    markers_are_specials = False  # These are generally emitted as literal strings or special tokens depending on the specific tuning. We assume text.
+
+    def extract_partial_args(self, partial_payload: str, is_complete: bool = False) -> str | None:
+        """Parse FunctionGemma custom format and return standard JSON string."""
+        if "{" not in partial_payload:
+            return None
+
+        raw_args = partial_payload[partial_payload.find("{") + 1 :]
+        # Strip trailing '}' if present
+        if raw_args.endswith("}"):
+            raw_args = raw_args[:-1]
+
+        try:
+            args_dict = _parse_function_gemma_args(raw_args, partial=not is_complete)
+            if not args_dict:
+                return "{}" if is_complete else ""
+
+            full_json = json.dumps(args_dict, ensure_ascii=False)
+
+            if is_complete:
+                return full_json
+
+            safe_json = full_json
+            while safe_json and safe_json[-1] in ("}", "]", '"', ",", " ", ":", "<", "|", "\\", ">"):
+                safe_json = safe_json[:-1]
+
+            return safe_json
+        except Exception:
+            return ""
+
+
+def _parse_gemma4_value(value_str: str) -> object:
+    value_str = value_str.strip()
+    if not value_str:
+        return value_str
+    if value_str == "true":
+        return True
+    if value_str == "false":
+        return False
+    if value_str.lower() in ("null", "none", "nil"):
+        return None
+    try:
+        if "." in value_str:
+            return float(value_str)
+        return int(value_str)
+    except ValueError:
+        pass
+    return value_str
+
+
+def _parse_gemma4_args(args_str: str, *, partial: bool = False) -> dict:
+    if not args_str or not args_str.strip():
+        return {}
+
+    result = {}
+    i = 0
+    n = len(args_str)
+
+    while i < n:
+        # Skip whitespace and commas
+        while i < n and args_str[i] in (" ", ",", "\n", "\t"):
+            i += 1
+        if i >= n:
+            break
+
+        # Parse key
+        key_start = i
+        while i < n and args_str[i] != ":":
+            i += 1
+        if i >= n:
+            break
+        key = args_str[key_start:i].strip()
+        i += 1  # skip ':'
+
+        if i >= n:
+            if not partial:
+                result[key] = ""
+            break
+
+        while i < n and args_str[i] in (" ", "\n", "\t"):
+            i += 1
+        if i >= n:
+            if not partial:
+                result[key] = ""
+            break
+
+        # String value: <|"|>...<|"|>
+        if args_str[i:].startswith(STRING_DELIM):
+            i += len(STRING_DELIM)
+            val_start = i
+            end_pos = args_str.find(STRING_DELIM, i)
+            if end_pos == -1:
+                result[key] = args_str[val_start:]
+                break
+            result[key] = args_str[val_start:end_pos]
+            i = end_pos + len(STRING_DELIM)
+        # Nested object
+        elif args_str[i] == "{":
+            depth = 1
+            obj_start = i + 1
+            i += 1
+            while i < n and depth > 0:
+                if args_str[i:].startswith(STRING_DELIM):
+                    i += len(STRING_DELIM)
+                    nd = args_str.find(STRING_DELIM, i)
+                    i = n if nd == -1 else nd + len(STRING_DELIM)
+                    continue
+                if args_str[i] == "{":
+                    depth += 1
+                elif args_str[i] == "}":
+                    depth -= 1
+                i += 1
+            if depth > 0:
+                result[key] = _parse_gemma4_args(args_str[obj_start:i], partial=True)
+            else:
+                result[key] = _parse_gemma4_args(args_str[obj_start : i - 1])
+        # Array
+        elif args_str[i] == "[":
+            depth = 1
+            arr_start = i + 1
+            i += 1
+            while i < n and depth > 0:
+                if args_str[i:].startswith(STRING_DELIM):
+                    i += len(STRING_DELIM)
+                    nd = args_str.find(STRING_DELIM, i)
+                    i = n if nd == -1 else nd + len(STRING_DELIM)
+                    continue
+                if args_str[i] == "[":
+                    depth += 1
+                elif args_str[i] == "]":
+                    depth -= 1
+                i += 1
+            if depth > 0:
+                result[key] = _parse_gemma4_array(args_str[arr_start:i], partial=True)
+            else:
+                result[key] = _parse_gemma4_array(args_str[arr_start : i - 1])
+        # Bare value
+        else:
+            val_start = i
+            while i < n and args_str[i] not in (",", "}", "]"):
+                i += 1
+            if partial and i >= n:
+                break
+            result[key] = _parse_gemma4_value(args_str[val_start:i])
+
+    return result
+
+
+def _parse_gemma4_array(arr_str: str, *, partial: bool = False) -> list:
+    items = []
+    i = 0
+    n = len(arr_str)
+    while i < n:
+        while i < n and arr_str[i] in (" ", ",", "\n", "\t"):
+            i += 1
+        if i >= n:
+            break
+        if arr_str[i:].startswith(STRING_DELIM):
+            i += len(STRING_DELIM)
+            end_pos = arr_str.find(STRING_DELIM, i)
+            if end_pos == -1:
+                items.append(arr_str[i:])
+                break
+            items.append(arr_str[i:end_pos])
+            i = end_pos + len(STRING_DELIM)
+        elif arr_str[i] == "{":
+            # ... port object/array recursion if needed, omitting for brevity in initial implementation
+            # but keeping basic structure.
+            i += 1  # skip { for now
+            pass
+        else:
+            val_start = i
+            while i < n and arr_str[i] not in (",", "]"):
+                i += 1
+            if partial and i >= n:
+                break
+            items.append(_parse_gemma4_value(arr_str[val_start:i]))
+    return items
+
+
+def _parse_function_gemma_args(args_str: str, *, partial: bool = False) -> dict:
+    """Same as _parse_gemma4_args but uses <escape>."""
+    if not args_str or not args_str.strip():
+        return {}
+
+    result = {}
+    i = 0
+    n = len(args_str)
+
+    while i < n:
+        while i < n and args_str[i] in (" ", ",", "\n", "\t"):
+            i += 1
+        if i >= n:
+            break
+
+        key_start = i
+        while i < n and args_str[i] != ":":
+            i += 1
+        if i >= n:
+            break
+        key = args_str[key_start:i].strip()
+        i += 1
+
+        if i >= n:
+            if not partial:
+                result[key] = ""
+            break
+
+        while i < n and args_str[i] in (" ", "\n", "\t"):
+            i += 1
+        if i >= n:
+            if not partial:
+                result[key] = ""
+            break
+
+        if args_str[i:].startswith(ESCAPE_DELIM):
+            i += len(ESCAPE_DELIM)
+            val_start = i
+            end_pos = args_str.find(ESCAPE_DELIM, i)
+            if end_pos == -1:
+                result[key] = args_str[val_start:]
+                break
+            result[key] = args_str[val_start:end_pos]
+            i = end_pos + len(ESCAPE_DELIM)
+        else:
+            val_start = i
+            while i < n and args_str[i] not in (",", "}", "]"):
+                i += 1
+            if partial and i >= n:
+                break
+            result[key] = _parse_gemma4_value(args_str[val_start:i])
+
+    return result

--- a/modelship/openai/parsers/tool_calling/parsers/gemma.py
+++ b/modelship/openai/parsers/tool_calling/parsers/gemma.py
@@ -1,10 +1,14 @@
 """Tool call parsers for Google Gemma models.
 
 Gemma 4 uses a custom serialization format (not JSON) for tool calls:
-`<|tool_call|>call:func_name{key:<|"|>value<|"|>,num:42}<tool_call|>`
+`<|tool_call>call:func_name{key:<|"|>value<|"|>,num:42}<tool_call|>`
 
-FunctionGemma (Gemma 2) uses:
+FunctionGemma (Gemma 2/3 fine-tune) uses:
 `<start_function_call>call:func_name{key:<escape>value<escape>}<end_function_call>`
+
+The two formats share the same envelope shape and only differ in the string
+delimiter, so both parsers reuse the same custom-syntax parser parameterized
+on ``string_delim``.
 """
 
 from __future__ import annotations
@@ -16,12 +20,22 @@ from modelship.openai.parsers.tool_calling.parsers.base import ToolCallParser
 STRING_DELIM = '<|"|>'
 ESCAPE_DELIM = "<escape>"
 
+# Trailing characters withheld from streaming JSON output so a closing
+# brace / quote / structural byte never lands ahead of more args bytes.
+# The streamer takes a length-diff of successive returns, so anything
+# emitted here must be a monotonic prefix of the final clean output.
+_STREAM_STRIP_TAIL = ("}", "]", '"', ",", " ", ":", "<", "|", "\\", ">")
+
 
 class Gemma4ToolCallParser(ToolCallParser):
     name = "gemma4"
     start_marker = "<|tool_call>"
     end_marker = "<tool_call|>"
     markers_are_specials = True
+    # String delimiter used inside the call body. Subclasses override
+    # this when the family uses a different delimiter token (e.g.
+    # FunctionGemma's ``<escape>``).
+    string_delim: str = STRING_DELIM
 
     def extract_partial_name(self, partial_payload: str) -> str | None:
         """Extract function name from 'call:func_name{...'."""
@@ -34,7 +48,7 @@ class Gemma4ToolCallParser(ToolCallParser):
         return name_part.strip() or None
 
     def extract_partial_args(self, partial_payload: str, is_complete: bool = False) -> str | None:
-        """Parse Gemma 4 custom format and return standard JSON string."""
+        """Parse the custom syntax into a dict and dump it to JSON."""
         if "{" not in partial_payload:
             return None
 
@@ -44,10 +58,11 @@ class Gemma4ToolCallParser(ToolCallParser):
             raw_args = raw_args[:-1]
 
         try:
-            # We parse the custom syntax into a dict and dump it to JSON.
-            # partial=not is_complete tells the parser to withhold incomplete values
-            # at the very end of the stream to avoid flickering types.
-            args_dict = _parse_gemma4_args(raw_args, partial=not is_complete)
+            # ``partial=not is_complete`` tells the parser to withhold
+            # ambiguous trailing bytes (unterminated string values, trailing
+            # bare values) so partial output stays a monotonic prefix of the
+            # eventual final value.
+            args_dict = _parse_args(raw_args, partial=not is_complete, string_delim=self.string_delim)
             if not args_dict:
                 return "{}" if is_complete else ""
 
@@ -61,7 +76,7 @@ class Gemma4ToolCallParser(ToolCallParser):
             # move if more keys arrive), we withhold trailing JSON structural
             # characters during streaming.
             safe_json = full_json
-            while safe_json and safe_json[-1] in ("}", "]", '"', ",", " ", ":", "<", "|", "\\", ">"):
+            while safe_json and safe_json[-1] in _STREAM_STRIP_TAIL:
                 safe_json = safe_json[:-1]
 
             return safe_json
@@ -69,7 +84,7 @@ class Gemma4ToolCallParser(ToolCallParser):
             return ""
 
     def split_payload(self, payload: str, is_complete: bool) -> list[tuple[str, bool]]:
-        """Gemma 4 can concatenate multiple calls: `call:a{...}call:b{...}`."""
+        """Multiple calls can be concatenated: `call:a{...}call:b{...}`."""
         # Find all occurrences of "call:" at the top level (not inside braces)
         calls: list[tuple[str, bool]] = []
         pos = 0
@@ -107,43 +122,22 @@ class Gemma4ToolCallParser(ToolCallParser):
 
 
 class FunctionGemmaToolCallParser(Gemma4ToolCallParser):
-    """Parses FunctionGemma (Gemma 2) output which uses `<escape>` instead of `<|"|>`."""
+    """Parses FunctionGemma output which uses `<escape>` instead of `<|"|>`.
+
+    The envelope and string-delim tokens (``<start_function_call>``,
+    ``<end_function_call>``, ``<escape>``) are registered as special tokens
+    on the FunctionGemma tokenizer, so ``markers_are_specials = True`` so
+    the transformers loader keeps them visible to the parser.
+    """
 
     name = "function_gemma"
     start_marker = "<start_function_call>"
     end_marker = "<end_function_call>"
-    markers_are_specials = False  # These are generally emitted as literal strings or special tokens depending on the specific tuning. We assume text.
-
-    def extract_partial_args(self, partial_payload: str, is_complete: bool = False) -> str | None:
-        """Parse FunctionGemma custom format and return standard JSON string."""
-        if "{" not in partial_payload:
-            return None
-
-        raw_args = partial_payload[partial_payload.find("{") + 1 :]
-        # Strip trailing '}' if present
-        if raw_args.endswith("}"):
-            raw_args = raw_args[:-1]
-
-        try:
-            args_dict = _parse_function_gemma_args(raw_args, partial=not is_complete)
-            if not args_dict:
-                return "{}" if is_complete else ""
-
-            full_json = json.dumps(args_dict, ensure_ascii=False)
-
-            if is_complete:
-                return full_json
-
-            safe_json = full_json
-            while safe_json and safe_json[-1] in ("}", "]", '"', ",", " ", ":", "<", "|", "\\", ">"):
-                safe_json = safe_json[:-1]
-
-            return safe_json
-        except Exception:
-            return ""
+    markers_are_specials = True
+    string_delim = ESCAPE_DELIM
 
 
-def _parse_gemma4_value(value_str: str) -> object:
+def _parse_value(value_str: str) -> object:
     value_str = value_str.strip()
     if not value_str:
         return value_str
@@ -162,13 +156,33 @@ def _parse_gemma4_value(value_str: str) -> object:
     return value_str
 
 
-def _parse_gemma4_args(args_str: str, *, partial: bool = False) -> dict:
+def _safe_overlap(buf: str, marker: str) -> int:
+    """Index up to which ``buf`` can be flushed without splitting ``marker``.
+
+    Returns the position past the last byte safe to commit; trailing bytes
+    that could be a proper prefix of ``marker`` are excluded so a partial
+    parse of an unterminated string value never includes transient bytes
+    that will disappear once the delim arrives. This keeps partial output
+    a monotonic prefix of the eventual final output, which the streamer's
+    suffix-diff relies on.
+    """
+    if not marker:
+        return len(buf)
+    max_overlap = min(len(buf), len(marker) - 1)
+    for k in range(max_overlap, 0, -1):
+        if buf.endswith(marker[:k]):
+            return len(buf) - k
+    return len(buf)
+
+
+def _parse_args(args_str: str, *, partial: bool = False, string_delim: str = STRING_DELIM) -> dict:
     if not args_str or not args_str.strip():
         return {}
 
-    result = {}
+    result: dict = {}
     i = 0
     n = len(args_str)
+    delim_len = len(string_delim)
 
     while i < n:
         # Skip whitespace and commas
@@ -198,26 +212,32 @@ def _parse_gemma4_args(args_str: str, *, partial: bool = False) -> dict:
                 result[key] = ""
             break
 
-        # String value: <|"|>...<|"|>
-        if args_str[i:].startswith(STRING_DELIM):
-            i += len(STRING_DELIM)
+        # String value: <delim>...<delim>
+        if args_str[i:].startswith(string_delim):
+            i += delim_len
             val_start = i
-            end_pos = args_str.find(STRING_DELIM, i)
+            end_pos = args_str.find(string_delim, i)
             if end_pos == -1:
-                result[key] = args_str[val_start:]
+                val = args_str[val_start:]
+                if partial:
+                    # The closing delim hasn't arrived yet — trim any trailing
+                    # bytes that could be a proper prefix of the delim so the
+                    # partial value is a prefix of the eventual final value.
+                    val = val[: _safe_overlap(val, string_delim)]
+                result[key] = val
                 break
             result[key] = args_str[val_start:end_pos]
-            i = end_pos + len(STRING_DELIM)
+            i = end_pos + delim_len
         # Nested object
         elif args_str[i] == "{":
             depth = 1
             obj_start = i + 1
             i += 1
             while i < n and depth > 0:
-                if args_str[i:].startswith(STRING_DELIM):
-                    i += len(STRING_DELIM)
-                    nd = args_str.find(STRING_DELIM, i)
-                    i = n if nd == -1 else nd + len(STRING_DELIM)
+                if args_str[i:].startswith(string_delim):
+                    i += delim_len
+                    nd = args_str.find(string_delim, i)
+                    i = n if nd == -1 else nd + delim_len
                     continue
                 if args_str[i] == "{":
                     depth += 1
@@ -225,19 +245,19 @@ def _parse_gemma4_args(args_str: str, *, partial: bool = False) -> dict:
                     depth -= 1
                 i += 1
             if depth > 0:
-                result[key] = _parse_gemma4_args(args_str[obj_start:i], partial=True)
+                result[key] = _parse_args(args_str[obj_start:i], partial=True, string_delim=string_delim)
             else:
-                result[key] = _parse_gemma4_args(args_str[obj_start : i - 1])
+                result[key] = _parse_args(args_str[obj_start : i - 1], string_delim=string_delim)
         # Array
         elif args_str[i] == "[":
             depth = 1
             arr_start = i + 1
             i += 1
             while i < n and depth > 0:
-                if args_str[i:].startswith(STRING_DELIM):
-                    i += len(STRING_DELIM)
-                    nd = args_str.find(STRING_DELIM, i)
-                    i = n if nd == -1 else nd + len(STRING_DELIM)
+                if args_str[i:].startswith(string_delim):
+                    i += delim_len
+                    nd = args_str.find(string_delim, i)
+                    i = n if nd == -1 else nd + delim_len
                     continue
                 if args_str[i] == "[":
                     depth += 1
@@ -245,9 +265,9 @@ def _parse_gemma4_args(args_str: str, *, partial: bool = False) -> dict:
                     depth -= 1
                 i += 1
             if depth > 0:
-                result[key] = _parse_gemma4_array(args_str[arr_start:i], partial=True)
+                result[key] = _parse_array(args_str[arr_start:i], partial=True, string_delim=string_delim)
             else:
-                result[key] = _parse_gemma4_array(args_str[arr_start : i - 1])
+                result[key] = _parse_array(args_str[arr_start : i - 1], string_delim=string_delim)
         # Bare value
         else:
             val_start = i
@@ -255,93 +275,80 @@ def _parse_gemma4_args(args_str: str, *, partial: bool = False) -> dict:
                 i += 1
             if partial and i >= n:
                 break
-            result[key] = _parse_gemma4_value(args_str[val_start:i])
+            result[key] = _parse_value(args_str[val_start:i])
 
     return result
 
 
-def _parse_gemma4_array(arr_str: str, *, partial: bool = False) -> list:
-    items = []
+def _parse_array(arr_str: str, *, partial: bool = False, string_delim: str = STRING_DELIM) -> list:
+    items: list = []
     i = 0
     n = len(arr_str)
+    delim_len = len(string_delim)
     while i < n:
         while i < n and arr_str[i] in (" ", ",", "\n", "\t"):
             i += 1
         if i >= n:
             break
-        if arr_str[i:].startswith(STRING_DELIM):
-            i += len(STRING_DELIM)
-            end_pos = arr_str.find(STRING_DELIM, i)
+        # String value
+        if arr_str[i:].startswith(string_delim):
+            i += delim_len
+            val_start = i
+            end_pos = arr_str.find(string_delim, i)
             if end_pos == -1:
-                items.append(arr_str[i:])
+                val = arr_str[val_start:]
+                if partial:
+                    val = val[: _safe_overlap(val, string_delim)]
+                items.append(val)
                 break
-            items.append(arr_str[i:end_pos])
-            i = end_pos + len(STRING_DELIM)
+            items.append(arr_str[val_start:end_pos])
+            i = end_pos + delim_len
+        # Nested object
         elif arr_str[i] == "{":
-            # ... port object/array recursion if needed, omitting for brevity in initial implementation
-            # but keeping basic structure.
-            i += 1  # skip { for now
-            pass
+            depth = 1
+            obj_start = i + 1
+            i += 1
+            while i < n and depth > 0:
+                if arr_str[i:].startswith(string_delim):
+                    i += delim_len
+                    nd = arr_str.find(string_delim, i)
+                    i = n if nd == -1 else nd + delim_len
+                    continue
+                if arr_str[i] == "{":
+                    depth += 1
+                elif arr_str[i] == "}":
+                    depth -= 1
+                i += 1
+            if depth > 0:
+                items.append(_parse_args(arr_str[obj_start:i], partial=True, string_delim=string_delim))
+            else:
+                items.append(_parse_args(arr_str[obj_start : i - 1], string_delim=string_delim))
+        # Nested array
+        elif arr_str[i] == "[":
+            depth = 1
+            inner_start = i + 1
+            i += 1
+            while i < n and depth > 0:
+                if arr_str[i:].startswith(string_delim):
+                    i += delim_len
+                    nd = arr_str.find(string_delim, i)
+                    i = n if nd == -1 else nd + delim_len
+                    continue
+                if arr_str[i] == "[":
+                    depth += 1
+                elif arr_str[i] == "]":
+                    depth -= 1
+                i += 1
+            if depth > 0:
+                items.append(_parse_array(arr_str[inner_start:i], partial=True, string_delim=string_delim))
+            else:
+                items.append(_parse_array(arr_str[inner_start : i - 1], string_delim=string_delim))
+        # Bare value
         else:
             val_start = i
             while i < n and arr_str[i] not in (",", "]"):
                 i += 1
             if partial and i >= n:
                 break
-            items.append(_parse_gemma4_value(arr_str[val_start:i]))
+            items.append(_parse_value(arr_str[val_start:i]))
     return items
-
-
-def _parse_function_gemma_args(args_str: str, *, partial: bool = False) -> dict:
-    """Same as _parse_gemma4_args but uses <escape>."""
-    if not args_str or not args_str.strip():
-        return {}
-
-    result = {}
-    i = 0
-    n = len(args_str)
-
-    while i < n:
-        while i < n and args_str[i] in (" ", ",", "\n", "\t"):
-            i += 1
-        if i >= n:
-            break
-
-        key_start = i
-        while i < n and args_str[i] != ":":
-            i += 1
-        if i >= n:
-            break
-        key = args_str[key_start:i].strip()
-        i += 1
-
-        if i >= n:
-            if not partial:
-                result[key] = ""
-            break
-
-        while i < n and args_str[i] in (" ", "\n", "\t"):
-            i += 1
-        if i >= n:
-            if not partial:
-                result[key] = ""
-            break
-
-        if args_str[i:].startswith(ESCAPE_DELIM):
-            i += len(ESCAPE_DELIM)
-            val_start = i
-            end_pos = args_str.find(ESCAPE_DELIM, i)
-            if end_pos == -1:
-                result[key] = args_str[val_start:]
-                break
-            result[key] = args_str[val_start:end_pos]
-            i = end_pos + len(ESCAPE_DELIM)
-        else:
-            val_start = i
-            while i < n and args_str[i] not in (",", "}", "]"):
-                i += 1
-            if partial and i >= n:
-                break
-            result[key] = _parse_gemma4_value(args_str[val_start:i])
-
-    return result

--- a/modelship/openai/parsers/tool_calling/parsers/gemma.py
+++ b/modelship/openai/parsers/tool_calling/parsers/gemma.py
@@ -15,7 +15,10 @@ from __future__ import annotations
 
 import json
 
+from modelship.logging import get_logger
 from modelship.openai.parsers.tool_calling.parsers.base import ToolCallParser
+
+logger = get_logger("openai.parsers.tool_calling.gemma")
 
 STRING_DELIM = '<|"|>'
 ESCAPE_DELIM = "<escape>"
@@ -80,7 +83,8 @@ class Gemma4ToolCallParser(ToolCallParser):
                 safe_json = safe_json[:-1]
 
             return safe_json
-        except Exception:
+        except (RecursionError, ValueError, TypeError, IndexError) as e:
+            logger.debug("Failed to parse %s args %r: %s", self.name, raw_args, e)
             return ""
 
     def split_payload(self, payload: str, is_complete: bool) -> list[tuple[str, bool]]:

--- a/modelship/openai/parsers/tool_calling/parsers/hermes.py
+++ b/modelship/openai/parsers/tool_calling/parsers/hermes.py
@@ -30,7 +30,7 @@ class HermesToolCallParser(ToolCallParser):
         if m is None:
             return None
         args = partial_payload[m.end() :].rstrip()
-        if not is_complete and args.endswith("}"):
+        if args.endswith("}"):
             # The block envelope is `{"name":"x","arguments":<args>}`. The
             # closing brace of the envelope arrives in the byte stream before
             # `</tool_call>` does, so we cannot tell whether any given
@@ -39,6 +39,8 @@ class HermesToolCallParser(ToolCallParser):
             # if the model goes on to emit more args bytes, the held brace is
             # recovered on the next pass; if instead it goes on to emit
             # `</tool_call>`, the held brace was the envelope closer and
-            # discarding it was correct.
+            # discarding it was correct. At ``is_complete=True`` the trailing
+            # `}` is always the envelope closer (the args object's own closer
+            # is preceded by it), so the strip still applies.
             args = args[:-1].rstrip()
         return args or None

--- a/modelship/openai/parsers/tool_calling/parsers/hermes.py
+++ b/modelship/openai/parsers/tool_calling/parsers/hermes.py
@@ -25,12 +25,12 @@ class HermesToolCallParser(ToolCallParser):
         m = self._NAME_RE.search(partial_payload)
         return m.group(1) if m else None
 
-    def extract_partial_args(self, partial_payload: str) -> str | None:
+    def extract_partial_args(self, partial_payload: str, is_complete: bool = False) -> str | None:
         m = self._ARGS_RE.search(partial_payload)
         if m is None:
             return None
         args = partial_payload[m.end() :].rstrip()
-        if args.endswith("}"):
+        if not is_complete and args.endswith("}"):
             # The block envelope is `{"name":"x","arguments":<args>}`. The
             # closing brace of the envelope arrives in the byte stream before
             # `</tool_call>` does, so we cannot tell whether any given

--- a/modelship/openai/parsers/tool_calling/parsers/llama3_json.py
+++ b/modelship/openai/parsers/tool_calling/parsers/llama3_json.py
@@ -96,13 +96,14 @@ class Llama3JsonToolCallParser(ToolCallParser):
         if m is None:
             return None
         args = partial_payload[m.end() :].rstrip()
-        if not is_complete and args.endswith("}"):
-            # Mirror Hermes's trailing-`}` withhold: the per-call envelope
-            # is ``{"name": "x", "parameters": <args>}``. The closing brace
-            # of the envelope arrives in the byte stream alongside (or
-            # before) the args object's closer. Withhold one trailing `}`
-            # so the streamed args view never contains the envelope's
-            # closer; if more args bytes follow, the held brace is
-            # recovered on the next pass.
+        if args.endswith("}"):
+            # Mirror Hermes's trailing-`}` strip: the per-call envelope is
+            # ``{"name": "x", "parameters": <args>}``. The closing brace of
+            # the envelope arrives in the byte stream alongside (or before)
+            # the args object's closer, so always strip one trailing `}` —
+            # at ``is_complete=True`` it is the envelope closer, and
+            # mid-stream we withhold the ambiguous brace so the streamed
+            # args view never contains it. If more args bytes follow, the
+            # held brace is recovered on the next pass.
             args = args[:-1].rstrip()
         return args or None

--- a/modelship/openai/parsers/tool_calling/parsers/llama3_json.py
+++ b/modelship/openai/parsers/tool_calling/parsers/llama3_json.py
@@ -91,12 +91,12 @@ class Llama3JsonToolCallParser(ToolCallParser):
         m = self._NAME_RE.search(partial_payload)
         return m.group(1) if m else None
 
-    def extract_partial_args(self, partial_payload: str) -> str | None:
+    def extract_partial_args(self, partial_payload: str, is_complete: bool = False) -> str | None:
         m = self._ARGS_RE.search(partial_payload)
         if m is None:
             return None
         args = partial_payload[m.end() :].rstrip()
-        if args.endswith("}"):
+        if not is_complete and args.endswith("}"):
             # Mirror Hermes's trailing-`}` withhold: the per-call envelope
             # is ``{"name": "x", "parameters": <args>}``. The closing brace
             # of the envelope arrives in the byte stream alongside (or

--- a/modelship/openai/parsers/tool_calling/parsers/mistral.py
+++ b/modelship/openai/parsers/tool_calling/parsers/mistral.py
@@ -97,11 +97,13 @@ class MistralToolCallParser(ToolCallParser):
         if m is None:
             return None
         args = partial_payload[m.end() :].rstrip()
-        if not is_complete and args.endswith("}"):
+        if args.endswith("}"):
             # Mirror Hermes: the per-call envelope is
             # `{"name":"x","arguments":<args>}` and the closing brace of
             # the envelope arrives in the byte stream alongside (or before)
-            # the args object's closer. Withhold one trailing `}` so the
-            # streamed args view never contains the envelope's closer.
+            # the args object's closer. Always strip one trailing `}` — at
+            # ``is_complete=True`` it is the envelope closer, and mid-stream
+            # we withhold the ambiguous brace so the streamed args view
+            # never contains it.
             args = args[:-1].rstrip()
         return args or None

--- a/modelship/openai/parsers/tool_calling/parsers/mistral.py
+++ b/modelship/openai/parsers/tool_calling/parsers/mistral.py
@@ -92,12 +92,12 @@ class MistralToolCallParser(ToolCallParser):
         m = self._NAME_RE.search(partial_payload)
         return m.group(1) if m else None
 
-    def extract_partial_args(self, partial_payload: str) -> str | None:
+    def extract_partial_args(self, partial_payload: str, is_complete: bool = False) -> str | None:
         m = self._ARGS_RE.search(partial_payload)
         if m is None:
             return None
         args = partial_payload[m.end() :].rstrip()
-        if args.endswith("}"):
+        if not is_complete and args.endswith("}"):
             # Mirror Hermes: the per-call envelope is
             # `{"name":"x","arguments":<args>}` and the closing brace of
             # the envelope arrives in the byte stream alongside (or before)

--- a/modelship/openai/parsers/tool_calling/registry.py
+++ b/modelship/openai/parsers/tool_calling/registry.py
@@ -10,6 +10,8 @@ function-calling chat handler) bypass the registry entirely.
 from __future__ import annotations
 
 from modelship.openai.parsers.tool_calling.parsers import (
+    FunctionGemmaToolCallParser,
+    Gemma4ToolCallParser,
     HermesToolCallParser,
     Llama3JsonToolCallParser,
     MistralToolCallParser,
@@ -17,6 +19,8 @@ from modelship.openai.parsers.tool_calling.parsers import (
 )
 
 _PARSERS: dict[str, ToolCallParser] = {
+    FunctionGemmaToolCallParser.name: FunctionGemmaToolCallParser(),
+    Gemma4ToolCallParser.name: Gemma4ToolCallParser(),
     HermesToolCallParser.name: HermesToolCallParser(),
     Llama3JsonToolCallParser.name: Llama3JsonToolCallParser(),
     MistralToolCallParser.name: MistralToolCallParser(),

--- a/modelship/openai/parsers/tool_calling/utils.py
+++ b/modelship/openai/parsers/tool_calling/utils.py
@@ -10,6 +10,8 @@ from modelship.openai.parsers.utils import read_chat_template
 def detect_tool_parser(model_path: str | Path) -> str | None:
     """Return the name of the tool-call parser required by the model or None.
 
+    - Returns "gemma4" if `<|tool_call>` markers are found.
+    - Returns "function_gemma" if `<start_function_call>` markers are found.
     - Returns "hermes" if `<tool_call>` markers are found.
     - Returns "mistral" if `[TOOL_CALLS]` markers are found.
     - Returns "llama3_json" if `<|python_tag|>` markers are found.
@@ -24,8 +26,14 @@ def detect_tool_parser(model_path: str | Path) -> str | None:
 
 def classify_template(template: str) -> str | None:
     """Map a chat-template string to a parser name based on tool-call markers."""
-    if "tools" not in template and "tool_calls" not in template:
+    if "tools" not in template and "tool_calls" not in template and "function" not in template:
         return None
+
+    if "<|tool_call>" in template:
+        return "gemma4"
+
+    if "<start_function_call>" in template:
+        return "function_gemma"
 
     if "<tool_call>" in template:
         return "hermes"

--- a/tests/test_gemma4_parsers.py
+++ b/tests/test_gemma4_parsers.py
@@ -103,3 +103,84 @@ class TestFunctionGemmaToolCallParser:
         result = streamer.result
         assert len(result.tool_calls) == 1
         assert json.loads(result.tool_calls[0].function.arguments) == {"location": "Tokyo"}
+
+    def test_markers_are_specials_is_true(self):
+        # FunctionGemma's envelope and string-delim tokens are registered
+        # specials on the tokenizer; the transformers loader keys off this
+        # flag to switch ``skip_special_tokens=False`` and keep the markers
+        # visible to the parser.
+        assert FunctionGemmaToolCallParser.markers_are_specials is True
+
+
+class TestGemmaNestedStructures:
+    """Custom-syntax parser handles nested objects and arrays correctly."""
+
+    def test_array_of_objects(self):
+        parser = Gemma4ToolCallParser()
+        text = "<|tool_call>call:f{items:[{a:1},{a:2}]}<tool_call|>"
+        result = parser.parse(text)
+        assert json.loads(result.tool_calls[0].function.arguments) == {"items": [{"a": 1}, {"a": 2}]}
+
+    def test_array_of_mixed_types(self):
+        parser = Gemma4ToolCallParser()
+        text = '<|tool_call>call:f{items:[<|"|>x<|"|>,{n:1},<|"|>y<|"|>]}<tool_call|>'
+        result = parser.parse(text)
+        assert json.loads(result.tool_calls[0].function.arguments) == {"items": ["x", {"n": 1}, "y"]}
+
+    def test_nested_arrays(self):
+        parser = Gemma4ToolCallParser()
+        text = "<|tool_call>call:f{grid:[[1,2],[3,4]]}<tool_call|>"
+        result = parser.parse(text)
+        assert json.loads(result.tool_calls[0].function.arguments) == {"grid": [[1, 2], [3, 4]]}
+
+    def test_function_gemma_array_of_objects(self):
+        parser = FunctionGemmaToolCallParser()
+        text = "<start_function_call>call:f{items:[{a:1},{a:2}]}<end_function_call>"
+        result = parser.parse(text)
+        assert json.loads(result.tool_calls[0].function.arguments) == {"items": [{"a": 1}, {"a": 2}]}
+
+
+class TestGemmaStreamingMonotonicity:
+    """Partial string parsing must yield monotonic prefixes of the final value.
+
+    Regression: when a chunk ends mid-way through the closing string delim
+    (e.g. ``<es`` for FunctionGemma's ``<escape>``), the partial parse used
+    to include those bytes in the string value, producing a stripped JSON
+    longer than the eventual clean output — and the streamer's
+    length-greater diff machinery could not retract the transient bytes,
+    leaving the client stuck with a malformed value.
+    """
+
+    def test_function_gemma_chunk_mid_closing_delim(self):
+        parser = FunctionGemmaToolCallParser()
+        streamer = ChatOutputStreamer(parser)
+        chunks = [
+            "<start_function_call>call:f{location:<escape>Tokyo<es",
+            "<start_function_call>call:f{location:<escape>Tokyo<escape>}<end_function_call>",
+        ]
+        seen = ""
+        for c in chunks:
+            d = streamer.extract_streaming(c)
+            if d and d.tool_calls:
+                for t in d.tool_calls:
+                    if t.function and t.function.arguments:
+                        seen += t.function.arguments
+        streamer.finalize()
+        assert json.loads(seen) == {"location": "Tokyo"}
+
+    def test_gemma4_chunk_mid_closing_delim(self):
+        parser = Gemma4ToolCallParser()
+        streamer = ChatOutputStreamer(parser)
+        chunks = [
+            '<|tool_call>call:f{x:<|"|>val<',
+            '<|tool_call>call:f{x:<|"|>val<|"|>}<tool_call|>',
+        ]
+        seen = ""
+        for c in chunks:
+            d = streamer.extract_streaming(c)
+            if d and d.tool_calls:
+                for t in d.tool_calls:
+                    if t.function and t.function.arguments:
+                        seen += t.function.arguments
+        streamer.finalize()
+        assert json.loads(seen) == {"x": "val"}

--- a/tests/test_gemma4_parsers.py
+++ b/tests/test_gemma4_parsers.py
@@ -1,0 +1,105 @@
+import json
+
+from modelship.openai.parsers.output import ChatOutputStreamer
+from modelship.openai.parsers.reasoning.parsers.gemma import Gemma4ReasoningParser
+from modelship.openai.parsers.tool_calling.parsers.gemma import (
+    FunctionGemmaToolCallParser,
+    Gemma4ToolCallParser,
+)
+
+
+class TestGemma4ReasoningParser:
+    def test_extracts_reasoning_and_strips_label(self):
+        parser = Gemma4ReasoningParser()
+        streamer = ChatOutputStreamer(None, parser)
+
+        # Simulate model output: <|channel>thought\nI am reasoning<channel|>Final answer
+        text = "<|channel>thought\nI am reasoning<channel|>Final answer"
+        streamer.extract_streaming(text)
+        streamer.finalize()
+
+        result = streamer.result
+        assert result.reasoning == "I am reasoning"
+        assert result.content == "Final answer"
+
+
+class TestGemma4ToolCallParser:
+    def test_single_tool_call(self):
+        parser = Gemma4ToolCallParser()
+        # Simulate: <|tool_call>call:get_weather{location:<|"|>Tokyo<|"|>}<tool_call|>
+        text = '<|tool_call>call:get_weather{location:<|"|>Tokyo<|"|>}<tool_call|>'
+        result = parser.parse(text)
+
+        assert len(result.tool_calls) == 1
+        assert result.tool_calls[0].function.name == "get_weather"
+        assert json.loads(result.tool_calls[0].function.arguments) == {"location": "Tokyo"}
+
+    def test_multiple_concatenated_tool_calls(self):
+        parser = Gemma4ToolCallParser()
+        # Simulate: <|tool_call>call:a{x:1}call:b{y:2}<tool_call|>
+        text = '<|tool_call>call:get_weather{location:<|"|>Tokyo<|"|>}call:get_time{timezone:<|"|>JST<|"|>}<tool_call|>'
+        result = parser.parse(text)
+
+        assert len(result.tool_calls) == 2
+        assert result.tool_calls[0].function.name == "get_weather"
+        assert result.tool_calls[1].function.name == "get_time"
+        assert json.loads(result.tool_calls[0].function.arguments) == {"location": "Tokyo"}
+        assert json.loads(result.tool_calls[1].function.arguments) == {"timezone": "JST"}
+
+    def test_streaming_tool_call(self):
+        parser = Gemma4ToolCallParser()
+        streamer = ChatOutputStreamer(parser)
+
+        # Chunk 1: Start and name
+        d1 = streamer.extract_streaming("<|tool_call>call:get_weather{loc")
+        assert d1.tool_calls[0].function.name == "get_weather"
+
+        # Chunk 2: Partial arguments
+        d2 = streamer.extract_streaming('<|tool_call>call:get_weather{location:<|"|>Tok')
+        # "location": "Tok" -> length diff
+        assert "location" in d2.tool_calls[0].function.arguments
+
+        # Chunk 3: End of call
+        d3 = streamer.extract_streaming('<|tool_call>call:get_weather{location:<|"|>Tokyo<|"|>}<tool_call|>')
+        assert "yo" in d3.tool_calls[0].function.arguments
+
+        streamer.finalize()
+        result = streamer.result
+        assert len(result.tool_calls) == 1
+        assert json.loads(result.tool_calls[0].function.arguments) == {"location": "Tokyo"}
+
+
+class TestFunctionGemmaToolCallParser:
+    def test_single_tool_call(self):
+        parser = FunctionGemmaToolCallParser()
+        # Simulate: <start_function_call>call:get_weather{location:<escape>Tokyo<escape>}<end_function_call>
+        text = "<start_function_call>call:get_weather{location:<escape>Tokyo<escape>}<end_function_call>"
+        result = parser.parse(text)
+
+        assert len(result.tool_calls) == 1
+        assert result.tool_calls[0].function.name == "get_weather"
+        assert json.loads(result.tool_calls[0].function.arguments) == {"location": "Tokyo"}
+
+    def test_streaming_tool_call(self):
+        parser = FunctionGemmaToolCallParser()
+        streamer = ChatOutputStreamer(parser)
+
+        # Chunk 1: Start and name
+        d1 = streamer.extract_streaming("<start_function_call>call:get_weather{loc")
+        assert d1.tool_calls[0].function.name == "get_weather"
+
+        # Chunk 2: Partial arguments
+        d2 = streamer.extract_streaming("<start_function_call>call:get_weather{location:<escape>Tok")
+        # "location": "Tok" -> length diff
+        assert "location" in d2.tool_calls[0].function.arguments
+
+        # Chunk 3: End of call
+        d3 = streamer.extract_streaming(
+            "<start_function_call>call:get_weather{location:<escape>Tokyo<escape>}<end_function_call>"
+        )
+        assert "yo" in d3.tool_calls[0].function.arguments
+
+        streamer.finalize()
+        result = streamer.result
+        assert len(result.tool_calls) == 1
+        assert json.loads(result.tool_calls[0].function.arguments) == {"location": "Tokyo"}

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -157,6 +157,20 @@ MODEL_CONFIGS: dict[str, dict] = {
             "torch_dtype": "float32",
         },
     },
+    "chat-transformers-function-gemma": {
+        "name": "chat-transformers-function-gemma",
+        # Google's FunctionGemma (Gemma 2 family) uses the `<start_function_call>`
+        # and `<escape>` syntax. It's a 270M parameter model, small enough
+        # to run on CPU+float32.
+        "model": "google/functiongemma-270m-it",
+        "usecase": "generate",
+        "loader": "transformers",
+        "num_cpus": 2,
+        "transformers_config": {
+            "device": "cpu",
+            "torch_dtype": "float32",
+        },
+    },
     "embed-model": {
         "name": "embed-model",
         "model": "nomic-ai/nomic-embed-text-v1.5",
@@ -1108,3 +1122,57 @@ class TestAudio:
         with open(audio_file, "rb") as f:
             transcription = client.audio.transcriptions.create(model="stt-model", file=f)
         assert "test" in transcription.text.lower()
+
+
+@pytest.mark.integration
+class TestChatTransformersFunctionGemma:
+    """End-to-end FunctionGemma (Gemma 2) tool calling through transformers.
+
+    Verifies that the `function_gemma` parser correctly intercepts the
+    `<start_function_call>` markers and `<escape>` syntax.
+    """
+
+    @pytest.fixture(autouse=True, scope="class")
+    def _deploy(self, model_deployer):
+        model_deployer.deploy("chat-transformers-function-gemma")
+
+    def test_tool_calling_transformers_function_gemma_loader(self, client):
+        completion = client.chat.completions.create(
+            model="chat-transformers-function-gemma",
+            messages=[{"role": "user", "content": "What is the weather in Paris?"}],
+            tools=[_WEATHER_TOOL],
+            tool_choice="auto",
+            max_tokens=128,
+        )
+        tool_calls = completion.choices[0].message.tool_calls
+        assert tool_calls, f"expected a tool call, got content={completion.choices[0].message.content!r}"
+        assert tool_calls[0].function.name == "get_weather"
+        assert "Paris" in tool_calls[0].function.arguments
+        assert completion.choices[0].finish_reason == "tool_calls"
+
+    def test_tool_calling_streaming_transformers_function_gemma_loader(self, client):
+        stream = client.chat.completions.create(
+            model="chat-transformers-function-gemma",
+            messages=[{"role": "user", "content": "What is the weather in Paris?"}],
+            tools=[_WEATHER_TOOL],
+            tool_choice="auto",
+            max_tokens=128,
+            stream=True,
+        )
+
+        collected = _collect_streaming_tool_call(stream)
+
+        assert collected["tool_calls"], (
+            f"expected at least one streamed tool call; got content={collected['content']!r}"
+        )
+        call_0 = collected["tool_calls"][0]
+        assert call_0["id"], "expected an id on the first tool-call delta"
+        assert call_0["name"] == "get_weather"
+        assert collected["name_deltas"] == 1, f"expected one name delta, got {collected['name_deltas']}"
+        assert collected["args_deltas"] >= 2, (
+            f"expected arguments to stream incrementally, got {collected['args_deltas']} args delta(s)"
+        )
+        parsed_args = json.loads(call_0["arguments"])
+        assert parsed_args.get("city")
+        assert "Paris" in parsed_args["city"]
+        assert collected["finish_reason"] == "tool_calls"


### PR DESCRIPTION
Implements `Gemma4ReasoningParser` (`<|channel>thought`) and `Gemma4ToolCallParser` (`<|tool_call>` with `<|"|>` delimiters). Adds `FunctionGemmaToolCallParser` for Gemma 2 (`<start_function_call>` with `<escape>` delimiters). Updates `ChatOutputStreamer` and `ToolCallParser` base signature to correctly handle structural byte withholding during suffix-diff streams by introducing an `is_complete` parameter.

