### PR TITLE
feat: qwen3-coder tool parser and custom-loader preflight

### DIFF
--- a/docs/model-configuration.md
+++ b/docs/model-configuration.md
@@ -219,7 +219,7 @@ The `transformers` loader uses PyTorch with HuggingFace Transformers. Supports c
 | `trust_remote_code` | bool | `false` | Allow remote code execution |
 | `model_kwargs` | object | `{}` | Extra keyword arguments passed to the model constructor |
 | `pipeline_kwargs` | object | `{}` | Extra keyword arguments passed to the pipeline at inference time |
-| `tool_call_parser` | string | auto | Parser used to turn raw model output into OpenAI `tool_calls`. Currently supported: `hermes` (Hermes-2-Pro / Qwen2.5-Instruct / many community fine-tunes that emit `<tool_call>{...}</tool_call>` markers), `mistral` (Mistral 7B Instruct v0.3+ / Mistral Small/Large that emit `[TOOL_CALLS][...]`), `llama3_json` (Llama-3.1 / Llama-3.2 Instruct emitting bare `{"name": "...", "parameters": {...}}`). Auto-detected from the chat template when omitted. |
+| `tool_call_parser` | string | auto | Parser used to turn raw model output into OpenAI `tool_calls`. Currently supported: `hermes` (Hermes-2-Pro / Qwen2.5-Instruct / many community fine-tunes that emit `<tool_call>{...}</tool_call>` markers), `qwen3_coder` (Qwen3-Coder family — same `<tool_call>` envelope but an XML body of `<function=name><parameter=key>value</parameter></function>`; parameter values are returned as strings), `mistral` (Mistral 7B Instruct v0.3+ / Mistral Small/Large that emit `[TOOL_CALLS][...]`), `llama3_json` (Llama-3.1 / Llama-3.2 Instruct emitting bare `{"name": "...", "parameters": {...}}`). Auto-detected from the chat template when omitted. |
 
 ### Chat / Text Generation (CPU)
 

--- a/modelship/infer/custom/custom_infer.py
+++ b/modelship/infer/custom/custom_infer.py
@@ -9,6 +9,7 @@ from modelship.infer.custom.openai.serving_transcription import (
     OpenAIServingTranslation,
 )
 from modelship.infer.infer_config import ModelshipModelConfig, ModelUsecase, RawRequestProxy
+from modelship.infer.preflight import discover_hardware, merge_with_user_overrides, run_preflight
 from modelship.logging import get_logger
 from modelship.openai.protocol import (
     ErrorResponse,
@@ -41,6 +42,16 @@ class CustomInfer(BaseInfer):
         plugin = self.model_config.plugin
         if plugin is not None:
             module = cast("PluginProto", importlib.import_module(plugin))
+            recommendation = run_preflight(self.model_config, discover_hardware())
+            if recommendation:
+                logger.info("preflight recommendation for '%s': %s", self.model_config.name, recommendation)
+                self.model_config.plugin_config = merge_with_user_overrides(
+                    recommendation,
+                    self.model_config.plugin_config or {},
+                    model_name=self.model_config.name,
+                )
+            else:
+                logger.info("preflight recommendation for '%s': none", self.model_config.name)
             self.custom_engine = module.ModelPlugin(model_config=self.model_config)
             await self.custom_engine.start()
             self._set_max_context_length(self.custom_engine.max_context_length())

--- a/modelship/infer/preflight/base.py
+++ b/modelship/infer/preflight/base.py
@@ -143,7 +143,9 @@ def _pynvml_node_discover() -> list[GPUInfo]:
 def run_preflight(config: ModelshipModelConfig, hw: HardwareProfile) -> dict[str, Any]:
     """Look up the loader's estimator and run it. Returns `{}` if no estimator
     is registered or the estimator declines (no resolved path, missing config,
-    etc.). Never raises — preflight failures must not block a deploy."""
+    etc.). For `loader='custom'`, dispatches to the plugin's
+    `ModelPlugin.preflight()` classmethod via a registered adapter.
+    Never raises — preflight failures must not block a deploy."""
     # Register-on-first-call so importing this module doesn't pull in
     # backend-specific deps (vllm, transformers) when they're not installed.
     _ensure_registered()
@@ -179,7 +181,27 @@ def merge_with_user_overrides(
     return {**recommendation, **user_overrides}
 
 
+class _CustomPluginPreflight:
+    """Dispatch adapter for `loader='custom'`. Imports `config.plugin` and
+    delegates to its `ModelPlugin.preflight()` classmethod. The outer
+    `run_preflight()` already swallows exceptions, so import or attribute
+    errors propagate up to be logged there."""
+
+    def recommend(self, config: ModelshipModelConfig, hw: HardwareProfile) -> dict[str, Any]:
+        if config.plugin is None:
+            return {}
+        import importlib
+
+        module = importlib.import_module(config.plugin)
+        plugin_cls = getattr(module, "ModelPlugin", None)
+        if plugin_cls is None:
+            return {}
+        return plugin_cls.preflight(config, hw) or {}
+
+
 def _ensure_registered() -> None:
+    if ModelLoader.custom not in _REGISTRY:
+        register(ModelLoader.custom, _CustomPluginPreflight())
     if ModelLoader.vllm in _REGISTRY:
         return
     try:

--- a/modelship/openai/parsers/tool_calling/parsers/__init__.py
+++ b/modelship/openai/parsers/tool_calling/parsers/__init__.py
@@ -6,6 +6,7 @@ from modelship.openai.parsers.tool_calling.parsers.gemma import (
 from modelship.openai.parsers.tool_calling.parsers.hermes import HermesToolCallParser
 from modelship.openai.parsers.tool_calling.parsers.llama3_json import Llama3JsonToolCallParser
 from modelship.openai.parsers.tool_calling.parsers.mistral import MistralToolCallParser
+from modelship.openai.parsers.tool_calling.parsers.qwen3_coder import Qwen3CoderToolCallParser
 
 __all__ = [
     "FunctionGemmaToolCallParser",
@@ -13,5 +14,6 @@ __all__ = [
     "HermesToolCallParser",
     "Llama3JsonToolCallParser",
     "MistralToolCallParser",
+    "Qwen3CoderToolCallParser",
     "ToolCallParser",
 ]

--- a/modelship/openai/parsers/tool_calling/parsers/qwen3_coder.py
+++ b/modelship/openai/parsers/tool_calling/parsers/qwen3_coder.py
@@ -1,0 +1,124 @@
+"""Qwen3-Coder XML-style tool call parser.
+
+Qwen3-Coder reuses the same ``<tool_call>`` / ``</tool_call>`` envelope as
+Hermes but the body is an XML-ish nested structure instead of a JSON
+object:
+
+    <tool_call>
+    <function=function_name>
+    <parameter=param_a>
+    value_a
+    </parameter>
+    <parameter=param_b>
+    42
+    </parameter>
+    </function>
+    </tool_call>
+
+Disambiguation from Hermes happens upstream in
+:func:`modelship.openai.parsers.tool_calling.utils.classify_template`: a
+chat template that mentions ``<function=`` or ``<parameter=`` is routed
+to this parser; otherwise the same ``<tool_call>`` marker falls through
+to Hermes.
+
+Each ``<tool_call>...</tool_call>`` envelope holds exactly one
+``<function=...>`` block; multiple tool calls arrive as multiple
+back-to-back envelopes, which the streamer already treats as independent
+regions, so no :meth:`split_payload` override is needed.
+
+Parameter values are kept as strings — Qwen3-Coder treats them as
+textual blobs without explicit type markers. Callers that need typed
+arguments (numbers, booleans, nested JSON) can JSON-decode the value in
+their tool handler. Streaming-safe coercion would require schema-aware
+disambiguation we don't have at this layer.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+
+from modelship.openai.parsers.tool_calling.parsers.base import ToolCallParser
+
+_FUNC_OPEN_RE = re.compile(r"<function=([^>]+)>")
+_PARAM_OPEN_RE = re.compile(r"<parameter=([^>]+)>")
+_PARAM_CLOSE = "</parameter>"
+_FUNC_CLOSE = "</function>"
+
+# Trailing characters withheld from the streamed JSON so a closing brace,
+# quote, or comma never lands ahead of more arguments bytes. The streamer
+# takes a length-diff of successive returns, so anything emitted here must
+# be a monotonic prefix of the final clean output.
+_STREAM_STRIP_TAIL = ("}", '"', ",")
+
+
+class Qwen3CoderToolCallParser(ToolCallParser):
+    name = "qwen3_coder"
+    start_marker = "<tool_call>"
+    end_marker = "</tool_call>"
+
+    def extract_partial_name(self, partial_payload: str) -> str | None:
+        m = _FUNC_OPEN_RE.search(partial_payload)
+        return m.group(1).strip() if m else None
+
+    def extract_partial_args(self, partial_payload: str, is_complete: bool = False) -> str | None:
+        fm = _FUNC_OPEN_RE.search(partial_payload)
+        if fm is None:
+            return None
+
+        body = partial_payload[fm.end() :]
+        end_func = body.find(_FUNC_CLOSE)
+        if end_func != -1:
+            body = body[:end_func]
+
+        args: dict[str, str] = {}
+        pos = 0
+        while True:
+            pm = _PARAM_OPEN_RE.search(body, pos)
+            if pm is None:
+                break
+            key = pm.group(1).strip()
+            val_start = pm.end()
+            close = body.find(_PARAM_CLOSE, val_start)
+            if close == -1:
+                # In-flight parameter value. Withhold any trailing bytes
+                # that could be a proper prefix of ``</parameter>`` or of
+                # the next ``<parameter=`` opener, so the streamed value
+                # is a monotonic prefix of its eventual final form.
+                raw = body[val_start:]
+                cut = min(_safe_overlap(raw, _PARAM_CLOSE), _safe_overlap(raw, "<parameter="))
+                raw = raw[:cut]
+                stripped = raw.strip()
+                if stripped:
+                    args[key] = stripped
+                break
+            args[key] = body[val_start:close].strip()
+            pos = close + len(_PARAM_CLOSE)
+
+        if not args:
+            return "{}" if is_complete else ""
+
+        full_json = json.dumps(args, ensure_ascii=False)
+        if is_complete:
+            return full_json
+
+        safe_json = full_json
+        while safe_json and safe_json[-1] in _STREAM_STRIP_TAIL:
+            safe_json = safe_json[:-1]
+        return safe_json
+
+
+def _safe_overlap(buf: str, marker: str) -> int:
+    """Index up to which ``buf`` can be flushed without splitting ``marker``.
+
+    Returns the position past the last byte safe to commit; trailing bytes
+    that could be a proper prefix of ``marker`` are excluded so partial
+    output stays a monotonic prefix of the eventual final value.
+    """
+    if not marker:
+        return len(buf)
+    max_overlap = min(len(buf), len(marker) - 1)
+    for k in range(max_overlap, 0, -1):
+        if buf.endswith(marker[:k]):
+            return len(buf) - k
+    return len(buf)

--- a/modelship/openai/parsers/tool_calling/parsers/qwen3_coder.py
+++ b/modelship/openai/parsers/tool_calling/parsers/qwen3_coder.py
@@ -45,11 +45,13 @@ _PARAM_OPEN_RE = re.compile(r"<parameter=([^>]+)>")
 _PARAM_CLOSE = "</parameter>"
 _FUNC_CLOSE = "</function>"
 
-# Trailing characters withheld from the streamed JSON so a closing brace,
-# quote, or comma never lands ahead of more arguments bytes. The streamer
-# takes a length-diff of successive returns, so anything emitted here must
-# be a monotonic prefix of the final clean output.
-_STREAM_STRIP_TAIL = ("}", '"', ",")
+# Structural suffix that ``json.dumps`` always emits for a non-empty dict
+# whose last value is a string: the closing quote of that value plus the
+# closing brace of the object. Stripping exactly these two bytes exposes
+# the in-flight value as a monotonic prefix without touching content
+# inside the value — a character-wise loop would eat trailing ``,``,
+# ``}``, or ``"`` that are actually part of the parameter value.
+_STREAM_STRIP_TAIL = '"}'
 
 
 class Qwen3CoderToolCallParser(ToolCallParser):
@@ -102,10 +104,9 @@ class Qwen3CoderToolCallParser(ToolCallParser):
         if is_complete:
             return full_json
 
-        safe_json = full_json
-        while safe_json and safe_json[-1] in _STREAM_STRIP_TAIL:
-            safe_json = safe_json[:-1]
-        return safe_json
+        if full_json.endswith(_STREAM_STRIP_TAIL):
+            return full_json[: -len(_STREAM_STRIP_TAIL)]
+        return full_json
 
 
 def _safe_overlap(buf: str, marker: str) -> int:

--- a/modelship/openai/parsers/tool_calling/registry.py
+++ b/modelship/openai/parsers/tool_calling/registry.py
@@ -15,6 +15,7 @@ from modelship.openai.parsers.tool_calling.parsers import (
     HermesToolCallParser,
     Llama3JsonToolCallParser,
     MistralToolCallParser,
+    Qwen3CoderToolCallParser,
     ToolCallParser,
 )
 
@@ -24,6 +25,7 @@ _PARSERS: dict[str, ToolCallParser] = {
     HermesToolCallParser.name: HermesToolCallParser(),
     Llama3JsonToolCallParser.name: Llama3JsonToolCallParser(),
     MistralToolCallParser.name: MistralToolCallParser(),
+    Qwen3CoderToolCallParser.name: Qwen3CoderToolCallParser(),
 }
 
 

--- a/modelship/openai/parsers/tool_calling/utils.py
+++ b/modelship/openai/parsers/tool_calling/utils.py
@@ -12,6 +12,7 @@ def detect_tool_parser(model_path: str | Path) -> str | None:
 
     - Returns "gemma4" if `<|tool_call>` markers are found.
     - Returns "function_gemma" if `<start_function_call>` markers are found.
+    - Returns "qwen3_coder" if `<function=` or `<parameter=` markers are found.
     - Returns "hermes" if `<tool_call>` markers are found.
     - Returns "mistral" if `[TOOL_CALLS]` markers are found.
     - Returns "llama3_json" if `<|python_tag|>` markers are found.
@@ -34,6 +35,13 @@ def classify_template(template: str) -> str | None:
 
     if "<start_function_call>" in template:
         return "function_gemma"
+
+    # Qwen3-Coder shares the ``<tool_call>`` envelope with Hermes but the
+    # body is XML rather than JSON. The ``<function=`` / ``<parameter=``
+    # markers only appear in Qwen3-Coder templates, so check them before
+    # the ``<tool_call>`` -> hermes branch below.
+    if "<function=" in template or "<parameter=" in template:
+        return "qwen3_coder"
 
     if "<tool_call>" in template:
         return "hermes"

--- a/tests/test_qwen3_coder_parser.py
+++ b/tests/test_qwen3_coder_parser.py
@@ -1,0 +1,178 @@
+"""Qwen3-Coder XML-style tool-call parser tests.
+
+Covers parsing of the ``<tool_call><function=...><parameter=...>…``
+envelope, multi-call back-to-back streams, streaming monotonicity at
+marker boundaries, and the ``classify_template`` disambiguation that
+keeps Qwen3-Coder templates from falling through to the Hermes parser.
+"""
+
+from __future__ import annotations
+
+import json
+
+from modelship.openai.parsers.output import ChatOutputStreamer
+from modelship.openai.parsers.tool_calling.parsers.qwen3_coder import Qwen3CoderToolCallParser
+from modelship.openai.parsers.tool_calling.utils import classify_template
+
+
+class TestQwen3CoderClassify:
+    """``classify_template`` must route Qwen3-Coder templates here, not to Hermes."""
+
+    def test_function_marker_routes_to_qwen3_coder(self):
+        # The chat template mentions tools (gating clause) and contains
+        # ``<function=`` — must not fall through to Hermes.
+        template = "{% if tools %}<tool_call>\n<function={{ name }}>{% endif %}"
+        assert classify_template(template) == "qwen3_coder"
+
+    def test_parameter_marker_routes_to_qwen3_coder(self):
+        template = "{% if tools %}<parameter={{ key }}>value</parameter>{% endif %}"
+        assert classify_template(template) == "qwen3_coder"
+
+    def test_hermes_template_without_function_marker_still_hermes(self):
+        # Plain Hermes-style template: ``<tool_call>`` envelope but no
+        # ``<function=`` body — must stay as hermes.
+        template = '{% if tools %}<tool_call>{"name": "x"}</tool_call>{% endif %}'
+        assert classify_template(template) == "hermes"
+
+
+class TestQwen3CoderParser:
+    def test_single_tool_call_one_param(self):
+        text = (
+            "<tool_call>\n<function=get_weather>\n<parameter=location>\nTokyo\n</parameter>\n</function>\n</tool_call>"
+        )
+        result = Qwen3CoderToolCallParser().parse(text)
+        assert len(result.tool_calls) == 1
+        assert result.tool_calls[0].function.name == "get_weather"
+        assert json.loads(result.tool_calls[0].function.arguments) == {"location": "Tokyo"}
+
+    def test_single_tool_call_multi_params(self):
+        text = (
+            "<tool_call>\n"
+            "<function=search>\n"
+            "<parameter=query>\nrust async runtimes\n</parameter>\n"
+            "<parameter=top_k>\n5\n</parameter>\n"
+            "</function>\n"
+            "</tool_call>"
+        )
+        result = Qwen3CoderToolCallParser().parse(text)
+        assert result.tool_calls[0].function.name == "search"
+        # Values are kept as strings — see parser module docstring on why.
+        assert json.loads(result.tool_calls[0].function.arguments) == {
+            "query": "rust async runtimes",
+            "top_k": "5",
+        }
+
+    def test_inline_values_without_newlines(self):
+        text = "<tool_call><function=ping><parameter=host>example.com</parameter></function></tool_call>"
+        result = Qwen3CoderToolCallParser().parse(text)
+        assert json.loads(result.tool_calls[0].function.arguments) == {"host": "example.com"}
+
+    def test_two_back_to_back_tool_calls(self):
+        # Each call is its own ``<tool_call>…</tool_call>`` envelope; the
+        # streamer treats them as independent regions.
+        text = (
+            "<tool_call>\n<function=a>\n<parameter=x>\n1\n</parameter>\n</function>\n</tool_call>"
+            "<tool_call>\n<function=b>\n<parameter=y>\n2\n</parameter>\n</function>\n</tool_call>"
+        )
+        result = Qwen3CoderToolCallParser().parse(text)
+        assert len(result.tool_calls) == 2
+        assert result.tool_calls[0].function.name == "a"
+        assert result.tool_calls[1].function.name == "b"
+        assert json.loads(result.tool_calls[0].function.arguments) == {"x": "1"}
+        assert json.loads(result.tool_calls[1].function.arguments) == {"y": "2"}
+
+    def test_no_tool_calls_returns_text_unchanged(self):
+        result = Qwen3CoderToolCallParser().parse("just a regular response")
+        assert result.tool_calls == []
+        assert result.content == "just a regular response"
+        assert result.has_tool_calls is False
+
+    def test_value_preserves_internal_whitespace(self):
+        # Leading/trailing whitespace stripped, internal preserved.
+        text = "<tool_call><function=run><parameter=code>\ndef f():\n    return 1\n</parameter></function></tool_call>"
+        result = Qwen3CoderToolCallParser().parse(text)
+        assert json.loads(result.tool_calls[0].function.arguments) == {
+            "code": "def f():\n    return 1",
+        }
+
+
+class TestQwen3CoderStreaming:
+    def test_streaming_basic(self):
+        parser = Qwen3CoderToolCallParser()
+        streamer = ChatOutputStreamer(parser)
+
+        d1 = streamer.extract_streaming("<tool_call>\n<function=get_weather>\n<param")
+        assert d1.tool_calls and d1.tool_calls[0].function.name == "get_weather"
+
+        # Partial parameter value visible.
+        streamer.extract_streaming("<tool_call>\n<function=get_weather>\n<parameter=location>\nTok")
+
+        # Final close.
+        streamer.extract_streaming(
+            "<tool_call>\n<function=get_weather>\n<parameter=location>\nTokyo\n</parameter>\n</function>\n</tool_call>"
+        )
+        streamer.finalize()
+
+        result = streamer.result
+        assert len(result.tool_calls) == 1
+        assert json.loads(result.tool_calls[0].function.arguments) == {"location": "Tokyo"}
+
+    def test_streaming_monotonic_concat_matches_final(self):
+        # The concatenation of all streamed arg deltas must equal the
+        # final arguments JSON (the streamer's prefix-extension contract).
+        parser = Qwen3CoderToolCallParser()
+        streamer = ChatOutputStreamer(parser)
+        chunks = [
+            "<tool_call>\n<function=run>\n<parameter=cmd>\nls",
+            "<tool_call>\n<function=run>\n<parameter=cmd>\nls -la",
+            "<tool_call>\n<function=run>\n<parameter=cmd>\nls -la\n</parameter>\n"
+            "<parameter=cwd>\n/tmp\n</parameter>\n</function>\n</tool_call>",
+        ]
+        seen = ""
+        for c in chunks:
+            d = streamer.extract_streaming(c)
+            if d and d.tool_calls:
+                for t in d.tool_calls:
+                    if t.function and t.function.arguments:
+                        seen += t.function.arguments
+        streamer.finalize()
+        assert json.loads(seen) == {"cmd": "ls -la", "cwd": "/tmp"}
+
+    def test_streaming_chunk_mid_parameter_close(self):
+        # Regression: a chunk that ends mid-``</parameter>`` (e.g.
+        # ``</param``) must not leak those bytes into the value stream.
+        parser = Qwen3CoderToolCallParser()
+        streamer = ChatOutputStreamer(parser)
+        chunks = [
+            "<tool_call>\n<function=f>\n<parameter=x>\nval</param",
+            "<tool_call>\n<function=f>\n<parameter=x>\nval</parameter>\n</function>\n</tool_call>",
+        ]
+        seen = ""
+        for c in chunks:
+            d = streamer.extract_streaming(c)
+            if d and d.tool_calls:
+                for t in d.tool_calls:
+                    if t.function and t.function.arguments:
+                        seen += t.function.arguments
+        streamer.finalize()
+        assert json.loads(seen) == {"x": "val"}
+
+    def test_streaming_chunk_mid_next_parameter_opener(self):
+        # Regression: between parameters, a chunk ending in ``<parameter``
+        # must not leak those bytes into the previous value.
+        parser = Qwen3CoderToolCallParser()
+        streamer = ChatOutputStreamer(parser)
+        chunks = [
+            "<tool_call>\n<function=f>\n<parameter=a>\nfirst\n</parameter>\n<parameter",
+            "<tool_call>\n<function=f>\n<parameter=a>\nfirst\n</parameter>\n"
+            "<parameter=b>\nsecond\n</parameter>\n</function>\n</tool_call>",
+        ]
+        seen = ""
+        for c in chunks:
+            d = streamer.extract_streaming(c)
+            if d and d.tool_calls:
+                for t in d.tool_calls:
+                    if t.function and t.function.arguments:
+                        seen += t.function.arguments
+        streamer.finalize()
+        assert json.loads(seen) == {"a": "first", "b": "second"}


### PR DESCRIPTION
Adds a Qwen3CoderToolCallParser for the XML-bodied <tool_call> envelope (<function=name><parameter=key>value</parameter></function>), wired into the parser registry and chat-template auto-detection ahead of the Hermes branch since both share the <tool_call> marker.

Also extends preflight to loader='custom' via a dispatch adapter that imports config.plugin and delegates to ModelPlugin.preflight(), with CustomInfer now applying the recommendation through merge_with_user_overrides before instantiating the plugin.

