### PR TITLE
refactor(vllm): always use ray placement groups for multi-slot deploys

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -54,7 +54,7 @@ The Docker image's `CMD` (`scripts/start.sh`) starts the Ray head (auto-detectin
 
 ## Architecture quick map
 
-- `mship_deploy.py` — Ray init + deploy loop. Contains non-obvious GPU allocation logic in `build_actor_options` for vLLM `tensor_parallel_size > 1` (mp vs ray backend behave differently; `num_gpus` is sometimes ignored and replaced by `VLLM_RAY_PER_WORKER_GPUS`).
+- `mship_deploy.py` — Ray init + deploy loop. `build_deployment_options` (in `modelship/deploy/actor_options.py`) handles GPU allocation: multi-slot vLLM deploys (`tp*pp > 1`) always build a Ray Serve placement group (one whole-GPU bundle per slot, STRICT_PACK) that vLLM's ray executor inherits via `get_current_placement_group()`. Single-slot deploys use a scalar `num_gpus` on the outer actor. Fractional `num_gpus` (`<1`) is single-GPU only — combining it with TP/PP is rejected at config time (Ray packs fractional PG bundles onto the same physical GPU).
 - `modelship/openai/api.py` — FastAPI gateway. Uses `RequestWatcher` + `DisconnectEvent` Ray actor to propagate client disconnects across process boundaries.
 - `modelship/infer/model_deployment.py` — the single `@serve.deployment` actor class; lazily imports the right backend based on `config.loader`.
 - `modelship/infer/infer_config.py` — pydantic config schemas **and** `RawRequestProxy` / `DisconnectEvent`. `RawRequestProxy` exists because FastAPI `Request` cannot cross Ray process boundaries; any new attribute vLLM reads from `raw_request` must be added there.
@@ -85,8 +85,8 @@ Commit messages matter: use Conventional Commits prefixes so the changelog gener
 ## Gotchas
 
 - `config/models.yaml` is gitignored; `mship_deploy.py` errors out with a pointer to `config/examples/` if missing.
-- vLLM version is pinned (`vllm==0.20.1`). Do not bump casually — the TP scheduling logic in `mship_deploy.py:build_actor_options` defaults to the Ray V2 executor.
-- `llama_cpp` loader is CPU-only today; `num_gpus > 0` is silently warned and forced to 0 in `mship_deploy.py:build_actor_options`.
+- vLLM version is pinned (`vllm==0.20.1`). Do not bump casually — the TP scheduling logic in `mship_deploy.py:build_deployment_options` defaults to the Ray V2 executor.
+- `llama_cpp` loader is CPU-only today; `num_gpus > 0` is silently warned and forced to 0 in `mship_deploy.py:build_deployment_options`.
 - Metrics are on by default on port **8079** (not 8000). Disable with `--no-metrics` or `MSHIP_METRICS=false`.
 - Log level `TRACE` (below `DEBUG`) is a custom level and logs full request/response payloads.
 - Docker images are multi-arch (amd64 + arm64). The CPU image uses the unified `Dockerfile` with `--build-arg MSHIP_VARIANT=cpu` and has a different tag suffix (`:latest-cpu`).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,7 +45,7 @@ Docker's `scripts/start.sh` starts Ray (auto-detecting CPUs/GPUs unless `RAY_HEA
 
 ## Architecture map
 
-- `mship_deploy.py` — Ray init + deploy loop. `build_actor_options` has non-obvious GPU allocation for vLLM `tensor_parallel_size > 1` (mp vs ray backend differ; `num_gpus` is sometimes replaced by `VLLM_RAY_PER_WORKER_GPUS`). `llama_cpp` loader is CPU-only — `num_gpus > 0` is silently forced to 0.
+- `mship_deploy.py` — Ray init + deploy loop. `build_deployment_options` (in `modelship/deploy/actor_options.py`) handles GPU allocation: multi-slot vLLM deploys (`tp*pp > 1`) always build a Ray Serve placement group (one whole-GPU bundle per slot, STRICT_PACK) that vLLM's ray executor inherits via `get_current_placement_group()`. Single-slot deploys use a scalar `num_gpus` on the outer actor (fractional sharing supported). Fractional `num_gpus` with `tp*pp > 1` is rejected at config time — Ray packs fractional PG bundles onto the same physical GPU. `llama_cpp` loader is CPU-only — `num_gpus > 0` is silently forced to 0.
 - `modelship/openai/api.py` — FastAPI gateway. Uses `RequestWatcher` + `DisconnectEvent` Ray actor to propagate client disconnects across process boundaries and cancel in-flight inference.
 - `modelship/infer/model_deployment.py` — the single `@serve.deployment` actor class; lazily imports the right backend from `config.loader`.
 - `modelship/infer/infer_config.py` — pydantic config schemas plus `RawRequestProxy` / `DisconnectEvent`. `RawRequestProxy` exists because FastAPI `Request` can't cross Ray process boundaries. **Any new attribute vLLM reads from `raw_request` must be added there.**
@@ -65,7 +65,7 @@ Under `tests/`, `pytest-asyncio` for async. Tests **mock out Ray Serve** — the
 
 ## Sharp edges
 
-- `vllm==0.20.1` is pinned. Don't bump casually — TP scheduling in `mship_deploy.py:build_actor_options` defaults to the Ray V2 executor.
+- `vllm==0.20.1` is pinned. Don't bump casually — TP scheduling in `mship_deploy.py:build_deployment_options` defaults to the Ray V2 executor.
 - Metrics live on port **8079** (not 8000). `MSHIP_METRICS=false` or `--no-metrics` disables.
 - `TRACE` is a custom log level below `DEBUG`; it logs full request/response payloads.
 - Docker CPU image uses the unified `Dockerfile` with `--build-arg MSHIP_VARIANT=cpu` and has a `:latest-cpu` tag suffix.

--- a/docs/model-configuration.md
+++ b/docs/model-configuration.md
@@ -69,7 +69,7 @@ python mship_deploy.py --config config/tts.yaml --gateway-name "tts-api"
 | `usecase` | string | `generate`, `embed`, `transcription`, `translation`, `tts`, or `image` |
 | `loader` | string | `vllm`, `transformers`, `diffusers`, `llama_cpp`, or `custom` |
 | `plugin` | string | Plugin module name (required when `loader: custom`); automatically loaded from wheels when referenced |
-| `num_gpus` | float | Fraction of a GPU to allocate (0.0-1.0); also sets vLLM `gpu_memory_utilization` |
+| `num_gpus` | float \| int | GPU allocation. Fractional `< 1` shares one GPU (also sets vLLM `gpu_memory_utilization`); integer `≥ 1` requests that many whole GPUs (for `vllm`, this auto-sets `tensor_parallel_size = num_gpus` unless tp/pp is already specified). |
 | `num_cpus` | float | CPU units to allocate (default `0.1`) |
 | `num_replicas` | int | Number of identical Ray Serve replicas for this deployment (default `1`) |
 | `vllm_engine_kwargs` | object | Passed directly to the vLLM engine (see below) |
@@ -134,8 +134,7 @@ The `vllm` loader supports chat/generation, embeddings, transcription, and trans
 | `dtype` | string | `auto` | Model dtype (`auto`, `float16`, `bfloat16`) |
 | `tokenizer` | string | model default | Custom tokenizer path |
 | `trust_remote_code` | bool | `false` | Allow remote code execution |
-| `gpu_memory_utilization` | float | `0.9` | VRAM fraction (overridden by `num_gpus` when set) |
-| `distributed_executor_backend` | string | auto | `ray` or `mp` for multi-GPU |
+| `gpu_memory_utilization` | float | `0.9` | VRAM fraction (overridden by `num_gpus` when `num_gpus < 1`) |
 | `quantization` | string | — | Quantization method (e.g. `awq`, `gptq`) |
 | `enable_auto_tool_choice` | bool | — | Enable automatic tool/function calling |
 | `tool_call_parser` | string | — | Tool call parser (e.g. `llama3_json`, `hermes`) |
@@ -171,16 +170,30 @@ models:
 
 ### Multi-GPU with Tensor Parallelism
 
+`num_gpus: 2` is shorthand for "use 2 whole GPUs" — tensor parallelism is
+auto-derived (`tensor_parallel_size: 2`). Setting both is redundant; setting
+only `tensor_parallel_size` (and/or `pipeline_parallel_size`) is fine too.
+Each slot always owns one whole GPU.
+
 ```yaml
 models:
   - name: llama-70b
     model: meta-llama/Llama-3.1-70B-Instruct
     usecase: generate
     loader: vllm
-    vllm_engine_kwargs:
-      tensor_parallel_size: 2
-      distributed_executor_backend: ray
+    num_gpus: 2
 ```
+
+Multi-slot deploys always use vLLM's ray distributed executor: each TP/PP
+slot runs as its own Ray worker actor inside a Ray Serve placement group
+(STRICT_PACK, one whole-GPU bundle per slot, all on one node for NVLink).
+
+> **Note:** Fractional `num_gpus` (`< 1`) is **single-GPU only**. Combining
+> `num_gpus < 1` with `tensor_parallel_size > 1` or `pipeline_parallel_size > 1`
+> is rejected at config time, because Ray packs fractional placement-group
+> bundles onto the same physical GPU — which breaks tensor parallelism. To
+> share GPUs use `num_gpus: 0.x` with `tp: 1`; to do TP use whole-GPU
+> integer `num_gpus`.
 
 ### Embeddings
 

--- a/modelship/deploy/actor_options.py
+++ b/modelship/deploy/actor_options.py
@@ -1,7 +1,9 @@
 """Ray Serve actor option construction for model deployments.
 
-Centralises the GPU-allocation decisions for vLLM tensor parallelism (mp vs ray
-backends) and the plugin-wheel runtime_env injection for custom-loader models.
+Centralises the GPU-allocation decisions and the plugin-wheel runtime_env
+injection for custom-loader models. Multi-slot vLLM deploys always use a
+Ray Serve placement group (one whole-GPU bundle per slot) that vLLM
+inherits via its ray distributed executor.
 """
 
 from __future__ import annotations
@@ -47,81 +49,38 @@ def resolve_plugin_wheel(plugin: str) -> Path:
     return wheels[-1].resolve()
 
 
-def _resolve_num_gpus(config: ModelshipModelConfig, env_vars: dict[str, str]) -> float:
-    """Decide how many GPU units the outer Ray actor should request.
+def _world_size(config: ModelshipModelConfig) -> int:
+    if config.loader != ModelLoader.vllm:
+        return 1
+    tp = config.vllm_engine_kwargs.tensor_parallel_size
+    pp = config.vllm_engine_kwargs.pipeline_parallel_size
+    return tp * pp
 
-    The result depends on loader, vLLM tensor- and pipeline-parallel sizes, and
-    the chosen distributed-executor backend. Mutates *env_vars* in place to add
-    VLLM_RAY_PER_WORKER_GPUS when the ray-backend path needs it, and may set
-    config.vllm_engine_kwargs.distributed_executor_backend to "ray" as the
-    default when the world size (tp * pp) is greater than 1.
+
+def total_gpu_reservation(deploy_opts: dict) -> float:
+    """Sum the GPU units this deployment (actor + any PG bundles) will consume.
+
+    Used by the coordinator's resource tracker, which can't read the PG
+    bundle list as a single scalar.
     """
-    if config.loader == ModelLoader.llama_cpp:
-        if config.num_gpus > 0:
-            logger.warning(
-                "num_gpus=%s is ignored for model '%s': llama_cpp loader currently only supports CPU.",
-                config.num_gpus,
-                config.name,
-            )
-        return 0
-
-    tp = config.vllm_engine_kwargs.tensor_parallel_size if config.vllm_engine_kwargs else 1
-    pp = config.vllm_engine_kwargs.pipeline_parallel_size if config.vllm_engine_kwargs else 1
-    world_size = tp * pp
-    tp_backend = config.vllm_engine_kwargs.distributed_executor_backend if config.vllm_engine_kwargs else None
-
-    # vLLM validates world_size against the outer actor's visible GPUs before consulting
-    # the executor backend. With world_size>1 and no backend set, the outer actor has 0 GPUs
-    # (ray-backend path below) and ParallelConfig blows up. Default to ray so the outer
-    # actor is a coordinator and vLLM uses Ray V2 executor (new default in 0.20.0).
-    if world_size > 1 and tp_backend is None and config.vllm_engine_kwargs is not None:
-        config.vllm_engine_kwargs.distributed_executor_backend = "ray"
-        tp_backend = "ray"
-        logger.info(
-            "Defaulting distributed_executor_backend='ray' for model '%s' "
-            "(tensor_parallel_size=%d, pipeline_parallel_size=%d).",
-            config.name,
-            tp,
-            pp,
-        )
-
-    if config.num_gpus == 0:
-        return 0
-    if world_size > 1 and tp_backend == "mp":
-        # mp backend: the main actor forks worker subprocesses, each owning one
-        # physical GPU. Allocate world_size whole units so Ray exposes all devices via
-        # CUDA_VISIBLE_DEVICES. num_gpus is not used for Ray allocation in this path —
-        # gpu_memory_utilization is passed directly to vLLM instead.
-        if config.num_gpus > 0:
-            logger.warning(
-                "num_gpus=%s is ignored for model '%s': with vllm mp backend and "
-                "tensor_parallel_size=%d pipeline_parallel_size=%d, Ray GPU allocation "
-                "is determined by their product.",
-                config.num_gpus,
-                config.name,
-                tp,
-                pp,
-            )
-        return float(world_size)
-    if world_size > 1:
-        # ray backend: vLLM spawns world_size worker Ray actors that each claim
-        # their own fractional GPU. The outer actor is a coordinator only and needs
-        # no GPU units. VLLM_RAY_PER_WORKER_GPUS tells vLLM what fraction each
-        # worker actor should request.
-        if config.num_gpus > 0:
-            env_vars["VLLM_RAY_PER_WORKER_GPUS"] = str(config.num_gpus)
-        return 0
-    return config.num_gpus
+    if "placement_group_bundles" in deploy_opts:
+        return float(sum(b.get("GPU", 0) for b in deploy_opts["placement_group_bundles"]))
+    return float(deploy_opts.get("ray_actor_options", {}).get("num_gpus", 0) or 0)
 
 
-def build_actor_options(config: ModelshipModelConfig, plugin_wheel: Path | None = None) -> dict:
+def build_deployment_options(config: ModelshipModelConfig, plugin_wheel: Path | None = None) -> dict:
+    """Return a kwargs dict for `Deployment.options(**...)`.
+
+    Always contains ``ray_actor_options``; for multi-slot vLLM deploys also
+    contains ``placement_group_bundles`` and ``placement_group_strategy`` so
+    Ray Serve allocates one whole-GPU bundle per slot and vLLM's ray executor
+    inherits the PG.
+    """
     env_vars = build_cache_env_vars()
     for log_var in _LOG_PASSTHROUGH_ENV_VARS:
         val = os.environ.get(log_var)
         if val is not None:
             env_vars[log_var] = val
-
-    num_gpus = _resolve_num_gpus(config, env_vars)
 
     runtime_env: dict = {"env_vars": env_vars}
     if plugin_wheel is not None:
@@ -130,8 +89,36 @@ def build_actor_options(config: ModelshipModelConfig, plugin_wheel: Path | None 
         # wheel reuse the install.
         runtime_env["pip"] = [str(plugin_wheel)]
 
+    if config.loader == ModelLoader.llama_cpp:
+        if config.num_gpus > 0:
+            logger.warning(
+                "num_gpus=%s is ignored for model '%s': llama_cpp loader currently only supports CPU.",
+                config.num_gpus,
+                config.name,
+            )
+        return {"ray_actor_options": {"num_gpus": 0, "num_cpus": config.num_cpus, "runtime_env": runtime_env}}
+
+    world_size = _world_size(config)
+
+    if world_size == 1:
+        # Single slot: scalar Ray allocation. Fractional num_gpus (0 < n < 1)
+        # lets Ray pack other actors onto the same physical GPU.
+        return {
+            "ray_actor_options": {
+                "num_gpus": config.num_gpus,
+                "num_cpus": config.num_cpus,
+                "runtime_env": runtime_env,
+            }
+        }
+
+    # Multi-slot: one PG bundle per slot, STRICT_PACK keeps them on the same
+    # node (NVLink). Outer actor sits in bundle 0 with 0 GPU; vLLM's ray
+    # executor reuses the PG via get_current_placement_group() and pins each
+    # worker actor to its bundle. Each bundle requests a whole GPU, so Ray
+    # spreads across distinct physical GPUs.
+    bundles = [{"GPU": 1, "CPU": config.num_cpus} for _ in range(world_size)]
     return {
-        "num_gpus": num_gpus,
-        "num_cpus": config.num_cpus,
-        "runtime_env": runtime_env,
+        "ray_actor_options": {"num_gpus": 0, "num_cpus": config.num_cpus, "runtime_env": runtime_env},
+        "placement_group_bundles": bundles,
+        "placement_group_strategy": "STRICT_PACK",
     }

--- a/modelship/deploy/actor_options.py
+++ b/modelship/deploy/actor_options.py
@@ -63,9 +63,23 @@ def total_gpu_reservation(deploy_opts: dict) -> float:
     Used by the coordinator's resource tracker, which can't read the PG
     bundle list as a single scalar.
     """
+    return _total_reservation(deploy_opts, "GPU", "num_gpus")
+
+
+def total_cpu_reservation(deploy_opts: dict) -> float:
+    """Sum the CPU units this deployment (actor + any PG bundles) will consume.
+
+    For multi-slot deploys the outer actor sits in bundle 0 and its CPU
+    request is satisfied from that bundle's reservation, so summing the
+    bundles gives the correct total — same shape as the GPU helper.
+    """
+    return _total_reservation(deploy_opts, "CPU", "num_cpus")
+
+
+def _total_reservation(deploy_opts: dict, bundle_key: str, actor_key: str) -> float:
     if "placement_group_bundles" in deploy_opts:
-        return float(sum(b.get("GPU", 0) for b in deploy_opts["placement_group_bundles"]))
-    return float(deploy_opts.get("ray_actor_options", {}).get("num_gpus", 0) or 0)
+        return float(sum(b.get(bundle_key, 0) for b in deploy_opts["placement_group_bundles"]))
+    return float(deploy_opts.get("ray_actor_options", {}).get(actor_key, 0) or 0)
 
 
 def build_deployment_options(config: ModelshipModelConfig, plugin_wheel: Path | None = None) -> dict:

--- a/modelship/deploy/strategy.py
+++ b/modelship/deploy/strategy.py
@@ -7,7 +7,7 @@ import ray
 from ray import serve
 from ray.serve.schema import LoggingConfig
 
-from modelship.deploy.actor_options import build_deployment_options, total_gpu_reservation
+from modelship.deploy.actor_options import build_deployment_options, total_cpu_reservation, total_gpu_reservation
 from modelship.infer.infer_config import ModelshipConfig, ModelshipModelConfig
 from modelship.infer.model_deployment import ModelDeployment
 from modelship.logging import get_logger
@@ -102,7 +102,7 @@ def try_reserve_and_deploy(config: ModelshipModelConfig, ctx: DeployContext) -> 
             ctx.operator_id,
             deployment_name,
             total_gpu_reservation(deploy_opts),
-            float(deploy_opts.get("ray_actor_options", {}).get("num_cpus", 0) or 0),
+            total_cpu_reservation(deploy_opts),
             ctx.probe,
         )
     )

--- a/modelship/deploy/strategy.py
+++ b/modelship/deploy/strategy.py
@@ -7,7 +7,7 @@ import ray
 from ray import serve
 from ray.serve.schema import LoggingConfig
 
-from modelship.deploy.actor_options import build_actor_options
+from modelship.deploy.actor_options import build_deployment_options, total_gpu_reservation
 from modelship.infer.infer_config import ModelshipConfig, ModelshipModelConfig
 from modelship.infer.model_deployment import ModelDeployment
 from modelship.logging import get_logger
@@ -94,15 +94,15 @@ def try_reserve_and_deploy(config: ModelshipModelConfig, ctx: DeployContext) -> 
     "skipped" (no progress, retry), "deployed", "transient" (deploy raised; retry),
     "fatal" (deployment reported a permanent error; skip permanently)."""
     wheel = ctx.plugin_wheels.get(config.plugin) if config.plugin else None
-    actor_opts = build_actor_options(config, plugin_wheel=wheel)
+    deploy_opts = build_deployment_options(config, plugin_wheel=wheel)
     deployment_name = config.deployment_name()
 
     reserved, _reason = ray.get(
         ctx.coordinator.try_reserve.remote(
             ctx.operator_id,
             deployment_name,
-            float(actor_opts.get("num_gpus", 0) or 0),
-            float(actor_opts.get("num_cpus", 0) or 0),
+            total_gpu_reservation(deploy_opts),
+            float(deploy_opts.get("ray_actor_options", {}).get("num_cpus", 0) or 0),
             ctx.probe,
         )
     )
@@ -116,9 +116,9 @@ def try_reserve_and_deploy(config: ModelshipModelConfig, ctx: DeployContext) -> 
             ModelDeployment.options(
                 name=deployment_name,
                 num_replicas=config.num_replicas,
-                ray_actor_options=actor_opts,
                 max_constructor_retry_count=1,
                 logging_config=ctx.serve_logging_config,
+                **deploy_opts,
             ).bind(config),
             name=deployment_name,
             route_prefix=None,

--- a/modelship/infer/infer_config.py
+++ b/modelship/infer/infer_config.py
@@ -183,9 +183,9 @@ class ModelshipModelConfig(BaseModel):
                 )
             if "num_gpus" in self.model_fields_set:
                 _logger.warning(
-                    "num_gpus=%d is redundant for model '%s' when "
-                    "tensor_parallel_size x pipeline_parallel_size=%d is set; "
-                    "the value is derived from tp x pp.",
+                    "num_gpus=%d is redundant for model '%s': it matches "
+                    "tensor_parallel_size x pipeline_parallel_size=%d, which "
+                    "already determines the GPU count. Safe to drop.",
                     ng_int,
                     self.name,
                     world_size,

--- a/modelship/infer/infer_config.py
+++ b/modelship/infer/infer_config.py
@@ -8,6 +8,10 @@ from fastapi import Request
 from pydantic import BaseModel, Field, PrivateAttr, model_validator
 from starlette.datastructures import Headers, State
 
+from modelship.logging import get_logger
+
+_logger = get_logger("config")
+
 # Length (hex chars) of the per-deployment fingerprint suffix. 10 hex chars =
 # 40 bits, collision-resistant for the realistic universe of model configs.
 FINGERPRINT_LEN = 10
@@ -47,8 +51,7 @@ class VllmEngineConfig(BaseModel):
     dtype: str = "auto"
     tokenizer: str | None = None
     trust_remote_code: bool = False
-    gpu_memory_utilization: float = 0.9  # overridden by num_gpus when not explicitly set in config
-    distributed_executor_backend: str | None = None
+    gpu_memory_utilization: float = 0.9  # overridden by num_gpus when num_gpus < 1
     task: str = "auto"
     model_impl: str | None = None
     enable_log_requests: bool | None = False
@@ -126,6 +129,72 @@ class ModelshipModelConfig(BaseModel):
             raise ValueError("loader='custom' requires plugin to be set")
         if self.loader != ModelLoader.custom and not self.model:
             raise ValueError(f"`model:` is required for loader={self.loader!r}")
+        return self
+
+    @model_validator(mode="after")
+    def normalize_num_gpus_and_tp(self):
+        """Enforce the num_gpus / tensor_parallel semantics for vLLM.
+
+        - num_gpus < 1 (fractional): single GPU sharing. tp=pp=1 only — Ray
+          cannot guarantee distinct physical-GPU placement for fractional
+          placement-group bundles, so TP across shared GPUs is rejected.
+        - num_gpus >= 1: must be an integer count of whole GPUs.
+        - When tp x pp > 1, the GPU count is implied by tp x pp; if the user
+          also set num_gpus, log a warning and use tp x pp (each slot owns a
+          whole GPU).
+        - When tp = pp = 1 and num_gpus >= 2 is set, auto-derive tp = num_gpus.
+        """
+        ng = self.num_gpus
+        if ng <= 0 or self.loader != ModelLoader.vllm:
+            return self
+
+        tp = self.vllm_engine_kwargs.tensor_parallel_size
+        pp = self.vllm_engine_kwargs.pipeline_parallel_size
+        world_size = tp * pp
+
+        if 0 < ng < 1:
+            if world_size > 1:
+                raise ValueError(
+                    f"num_gpus={ng!r} (fractional) is not compatible with "
+                    f"tensor_parallel_size x pipeline_parallel_size > 1 "
+                    f"(got {tp} x {pp}). Ray packs fractional placement-group "
+                    f"bundles onto the same physical GPU, which breaks tensor "
+                    f"parallelism. Use whole GPUs for multi-slot deploys "
+                    f"(e.g. num_gpus={world_size}) or drop the parallelism "
+                    f"settings to share a single GPU."
+                )
+            return self
+
+        # ng >= 1: integer-only.
+        if ng != int(ng):
+            raise ValueError(
+                f"num_gpus={ng!r} is not allowed: values >= 1 must be integers. "
+                f"Use a fractional value < 1 to share a single GPU, or an integer "
+                f"to request that many whole GPUs."
+            )
+        ng_int = int(ng)
+
+        if world_size > 1:
+            if ng_int != world_size:
+                raise ValueError(
+                    f"num_gpus={ng_int} does not match tensor_parallel_size x "
+                    f"pipeline_parallel_size={tp} x {pp}={world_size}. Either drop "
+                    f"num_gpus (it's derived from tp x pp) or set num_gpus={world_size}."
+                )
+            if "num_gpus" in self.model_fields_set:
+                _logger.warning(
+                    "num_gpus=%d is redundant for model '%s' when "
+                    "tensor_parallel_size x pipeline_parallel_size=%d is set; "
+                    "the value is derived from tp x pp.",
+                    ng_int,
+                    self.name,
+                    world_size,
+                )
+        else:
+            # tp=pp=1: auto-derive tp from num_gpus.
+            self.vllm_engine_kwargs.tensor_parallel_size = ng_int
+
+        self.num_gpus = 1.0
         return self
 
     def fingerprint(self) -> str:

--- a/modelship/infer/model_deployment.py
+++ b/modelship/infer/model_deployment.py
@@ -37,10 +37,10 @@ logger = get_logger("infer.deployment")
 def _reap_child_processes() -> None:
     """Kill any subprocesses still alive in this actor process.
 
-    vLLM with distributed_executor_backend='mp' forks Worker_TP* subprocesses
-    before the AsyncLLM constructor returns. If init then raises (e.g. CUDA
-    OOM during graph capture), those workers never get reaped — they reparent
-    to PID 1 and hold their full GPU allocation until manually killed.
+    Some loaders (and vLLM's engine core process) fork helper subprocesses
+    before constructors return. If init then raises (e.g. CUDA OOM during
+    graph capture), those workers never get reaped — they reparent to PID 1
+    and hold their full GPU allocation until manually killed.
     """
     try:
         import psutil

--- a/modelship/infer/preflight/vllm.py
+++ b/modelship/infer/preflight/vllm.py
@@ -55,7 +55,11 @@ _MULTIMODAL_BATCHED_TOKENS_FLOOR = 8192
 class VllmPreflight:
     def recommend(self, config: ModelshipModelConfig, hw: HardwareProfile) -> dict[str, Any]:
         if not hw.gpus:
-            logger.info("preflight '%s': skipping — no GPUs visible to actor", config.name)
+            # discover_hardware()'s pynvml fallback should have found node-level
+            # GPUs even when the actor itself owns none (PG-coordinator case).
+            # An empty list here means the node is genuinely GPU-less or NVML
+            # discovery failed — nothing to recommend either way.
+            logger.info("preflight '%s': skipping — no GPUs discoverable on this node", config.name)
             return {}
 
         model_path = config._resolved_path

--- a/modelship/infer/vllm/vllm_infer.py
+++ b/modelship/infer/vllm/vllm_infer.py
@@ -7,7 +7,6 @@ from fastapi import UploadFile
 from starlette.requests import Request
 from starlette.responses import Response
 from vllm.config.model import ModelDType
-from vllm.config.parallel import DistributedExecutorBackend
 from vllm.engine.arg_utils import AsyncEngineArgs
 from vllm.entrypoints.logger import RequestLogger
 from vllm.entrypoints.openai.chat_completion.protocol import (
@@ -122,6 +121,14 @@ class VllmInfer(BaseInfer):
         self.vllm_engine_kwargs: VllmEngineConfig = VllmEngineConfig(**config_engine_kwargs)
         logger.info("initialising vllm engine with args: %s", self.vllm_engine_kwargs.model_dump())
 
+        # Force the ray executor for multi-slot deploys: the outer actor sits
+        # in a 0-GPU PG bundle, but vLLM's ParallelConfig validates world_size
+        # against the actor's visible GPUs before consulting the backend. The
+        # ray backend skips that check (workers claim their own bundles via the
+        # inherited placement group).
+        world_size = self.vllm_engine_kwargs.tensor_parallel_size * self.vllm_engine_kwargs.pipeline_parallel_size
+        distributed_executor_backend = "ray" if world_size > 1 else None
+
         engine_args = AsyncEngineArgs(
             model=self.vllm_engine_kwargs.model,
             tensor_parallel_size=self.vllm_engine_kwargs.tensor_parallel_size,
@@ -131,9 +138,7 @@ class VllmInfer(BaseInfer):
             tokenizer=self.vllm_engine_kwargs.tokenizer,
             trust_remote_code=self.vllm_engine_kwargs.trust_remote_code,
             gpu_memory_utilization=self.vllm_engine_kwargs.gpu_memory_utilization,
-            distributed_executor_backend=cast(
-                "DistributedExecutorBackend", self.vllm_engine_kwargs.distributed_executor_backend
-            ),
+            distributed_executor_backend=distributed_executor_backend,
             enable_log_requests=self.vllm_engine_kwargs.enable_log_requests
             if self.vllm_engine_kwargs.enable_log_requests is not None
             else False,

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -117,6 +117,101 @@ class TestModelshipModelConfig:
         )
         assert config.num_gpus == 0.70
 
+    def test_num_gpus_integer_required_above_one(self):
+        with pytest.raises(ValidationError, match="must be integers"):
+            ModelshipModelConfig(
+                name="test-llm",
+                model="some-model",
+                usecase=ModelUsecase.generate,
+                loader=ModelLoader.vllm,
+                num_gpus=1.5,
+            )
+
+    def test_num_gpus_auto_derives_tp(self):
+        # num_gpus=3 with default tp/pp -> tp becomes 3, num_gpus normalizes to per-slot share.
+        config = ModelshipModelConfig(
+            name="test-llm",
+            model="some-model",
+            usecase=ModelUsecase.generate,
+            loader=ModelLoader.vllm,
+            num_gpus=3,
+        )
+        assert config.vllm_engine_kwargs.tensor_parallel_size == 3
+        assert config.num_gpus == 1.0
+
+    def test_explicit_tp_matching_num_gpus_accepted(self):
+        config = ModelshipModelConfig(
+            name="test-llm",
+            model="some-model",
+            usecase=ModelUsecase.generate,
+            loader=ModelLoader.vllm,
+            num_gpus=4,
+            vllm_engine_kwargs=VllmEngineConfig(tensor_parallel_size=2, pipeline_parallel_size=2),
+        )
+        assert config.vllm_engine_kwargs.tensor_parallel_size == 2
+        assert config.vllm_engine_kwargs.pipeline_parallel_size == 2
+        assert config.num_gpus == 1.0
+
+    def test_explicit_tp_inconsistent_with_num_gpus_rejected(self):
+        with pytest.raises(ValidationError, match="does not match tensor_parallel_size"):
+            ModelshipModelConfig(
+                name="test-llm",
+                model="some-model",
+                usecase=ModelUsecase.generate,
+                loader=ModelLoader.vllm,
+                num_gpus=2,
+                vllm_engine_kwargs=VllmEngineConfig(tensor_parallel_size=3),
+            )
+
+    def test_fractional_num_gpus_with_tp_rejected(self):
+        with pytest.raises(ValidationError, match=r"fractional.*not compatible.*tensor_parallel"):
+            ModelshipModelConfig(
+                name="test-llm",
+                model="some-model",
+                usecase=ModelUsecase.generate,
+                loader=ModelLoader.vllm,
+                num_gpus=0.3,
+                vllm_engine_kwargs=VllmEngineConfig(tensor_parallel_size=2),
+            )
+
+    def test_fractional_num_gpus_with_pp_rejected(self):
+        with pytest.raises(ValidationError, match=r"fractional.*not compatible.*tensor_parallel"):
+            ModelshipModelConfig(
+                name="test-llm",
+                model="some-model",
+                usecase=ModelUsecase.generate,
+                loader=ModelLoader.vllm,
+                num_gpus=0.5,
+                vllm_engine_kwargs=VllmEngineConfig(pipeline_parallel_size=2),
+            )
+
+    def test_num_gpus_redundant_with_tp_logs_warning(self, caplog):
+        import logging
+
+        with caplog.at_level(logging.WARNING, logger="config"):
+            ModelshipModelConfig(
+                name="test-llm",
+                model="some-model",
+                usecase=ModelUsecase.generate,
+                loader=ModelLoader.vllm,
+                num_gpus=2,
+                vllm_engine_kwargs=VllmEngineConfig(tensor_parallel_size=2),
+            )
+        assert any("redundant" in rec.message for rec in caplog.records)
+
+    def test_non_vllm_loader_skips_tp_derivation(self):
+        # transformers has no parallelism config; num_gpus stays as-is for the
+        # loader to interpret directly (whole GPUs are fine for that path).
+        config = ModelshipModelConfig(
+            name="test-tts",
+            model="some-model",
+            usecase=ModelUsecase.tts,
+            loader=ModelLoader.custom,
+            plugin="myplugin",
+            num_gpus=2,
+        )
+        assert config.num_gpus == 2
+
     def test_all_usecases_valid(self):
         for usecase in ModelUsecase:
             config = ModelshipModelConfig(

--- a/tests/test_mship_deploy.py
+++ b/tests/test_mship_deploy.py
@@ -7,7 +7,7 @@ from unittest.mock import MagicMock, patch
 import mship_deploy
 import pytest
 
-from modelship.deploy.actor_options import build_actor_options, resolve_plugin_wheel
+from modelship.deploy.actor_options import build_deployment_options, resolve_plugin_wheel
 from modelship.infer.infer_config import ModelLoader, ModelshipModelConfig, ModelUsecase, VllmEngineConfig
 from modelship.utils import rand_suffix
 from modelship.utils.cli import parse_args
@@ -87,7 +87,7 @@ class TestRandSuffix:
             assert all(c.islower() or c.isdigit() for c in suffix)
 
 
-class TestBuildActorOptions:
+class TestBuildDeploymentOptions:
     def test_basic_options(self):
         config = ModelshipModelConfig(
             name="test-model",
@@ -97,11 +97,13 @@ class TestBuildActorOptions:
             num_gpus=1,
             num_cpus=2,
         )
-        opts = build_actor_options(config)
-        assert opts["num_gpus"] == 1
-        assert opts["num_cpus"] == 2
-        assert "env_vars" in opts["runtime_env"]
-        assert "pip" not in opts["runtime_env"]
+        opts = build_deployment_options(config)
+        actor = opts["ray_actor_options"]
+        assert actor["num_gpus"] == 1
+        assert actor["num_cpus"] == 2
+        assert "env_vars" in actor["runtime_env"]
+        assert "pip" not in actor["runtime_env"]
+        assert "placement_group_bundles" not in opts
 
     def test_with_plugin_wheel(self):
         config = ModelshipModelConfig(
@@ -112,8 +114,8 @@ class TestBuildActorOptions:
             plugin="myplugin",
         )
         wheel_path = Path("/tmp/myplugin-0.1.0-py3-none-any.whl")
-        opts = build_actor_options(config, plugin_wheel=wheel_path)
-        assert opts["runtime_env"]["pip"] == [str(wheel_path)]
+        opts = build_deployment_options(config, plugin_wheel=wheel_path)
+        assert opts["ray_actor_options"]["runtime_env"]["pip"] == [str(wheel_path)]
 
     def test_llama_cpp_force_cpu(self):
         config = ModelshipModelConfig(
@@ -123,41 +125,56 @@ class TestBuildActorOptions:
             loader=ModelLoader.llama_cpp,
             num_gpus=1,
         )
-        opts = build_actor_options(config)
-        assert opts["num_gpus"] == 0
+        opts = build_deployment_options(config)
+        assert opts["ray_actor_options"]["num_gpus"] == 0
 
-    def test_pipeline_parallel_defaults_to_ray_backend(self):
+    def test_pipeline_parallel_uses_placement_group(self):
+        # num_gpus=2 + pp=2 satisfies the world_size==num_gpus invariant; the
+        # outer actor sits in bundle 0 with no GPU and vLLM workers claim the
+        # rest via the inherited placement group.
         config = ModelshipModelConfig(
             name="test-model",
             model="some-model",
             usecase=ModelUsecase.generate,
             loader=ModelLoader.vllm,
-            num_gpus=1,
+            num_gpus=2,
             vllm_engine_kwargs=VllmEngineConfig(pipeline_parallel_size=2),
         )
-        opts = build_actor_options(config)
-        # Outer actor is a coordinator; worker actors claim the GPUs via
-        # VLLM_RAY_PER_WORKER_GPUS, same path as tp>1 takes.
-        assert opts["num_gpus"] == 0
-        assert opts["runtime_env"]["env_vars"]["VLLM_RAY_PER_WORKER_GPUS"] == "1.0"
-        assert config.vllm_engine_kwargs.distributed_executor_backend == "ray"
+        opts = build_deployment_options(config)
+        assert opts["ray_actor_options"]["num_gpus"] == 0
+        assert opts["placement_group_strategy"] == "STRICT_PACK"
+        bundles = opts["placement_group_bundles"]
+        assert len(bundles) == 2
+        assert all(b["GPU"] == 1.0 for b in bundles)
 
-    def test_tp_times_pp_with_mp_backend(self):
+    def test_tp_times_pp_builds_pg(self):
         config = ModelshipModelConfig(
             name="test-model",
             model="some-model",
             usecase=ModelUsecase.generate,
             loader=ModelLoader.vllm,
-            num_gpus=1,
+            num_gpus=4,
             vllm_engine_kwargs=VllmEngineConfig(
                 tensor_parallel_size=2,
                 pipeline_parallel_size=2,
-                distributed_executor_backend="mp",
             ),
         )
-        opts = build_actor_options(config)
-        # mp backend: outer actor owns world_size = tp * pp GPUs directly.
-        assert opts["num_gpus"] == 4
+        opts = build_deployment_options(config)
+        assert opts["ray_actor_options"]["num_gpus"] == 0
+        assert len(opts["placement_group_bundles"]) == 4
+        assert all(b["GPU"] == 1.0 for b in opts["placement_group_bundles"])
+
+    def test_single_slot_skips_placement_group(self):
+        config = ModelshipModelConfig(
+            name="test-model",
+            model="some-model",
+            usecase=ModelUsecase.generate,
+            loader=ModelLoader.vllm,
+            num_gpus=0.3,
+        )
+        opts = build_deployment_options(config)
+        assert opts["ray_actor_options"]["num_gpus"] == 0.3
+        assert "placement_group_bundles" not in opts
 
 
 class TestRemoveApps:

--- a/tests/test_mship_deploy.py
+++ b/tests/test_mship_deploy.py
@@ -7,7 +7,12 @@ from unittest.mock import MagicMock, patch
 import mship_deploy
 import pytest
 
-from modelship.deploy.actor_options import build_deployment_options, resolve_plugin_wheel
+from modelship.deploy.actor_options import (
+    build_deployment_options,
+    resolve_plugin_wheel,
+    total_cpu_reservation,
+    total_gpu_reservation,
+)
 from modelship.infer.infer_config import ModelLoader, ModelshipModelConfig, ModelUsecase, VllmEngineConfig
 from modelship.utils import rand_suffix
 from modelship.utils.cli import parse_args
@@ -175,6 +180,36 @@ class TestBuildDeploymentOptions:
         opts = build_deployment_options(config)
         assert opts["ray_actor_options"]["num_gpus"] == 0.3
         assert "placement_group_bundles" not in opts
+
+
+class TestReservationTotals:
+    def test_single_slot_uses_actor_options(self):
+        config = ModelshipModelConfig(
+            name="test-model",
+            model="some-model",
+            usecase=ModelUsecase.generate,
+            loader=ModelLoader.vllm,
+            num_gpus=0.5,
+            num_cpus=2,
+        )
+        opts = build_deployment_options(config)
+        assert total_gpu_reservation(opts) == 0.5
+        assert total_cpu_reservation(opts) == 2
+
+    def test_multi_slot_sums_pg_bundles(self):
+        # 4 slots, each bundle reserves num_cpus from the cluster; the outer
+        # actor's CPU sits inside bundle 0 and is not additive.
+        config = ModelshipModelConfig(
+            name="test-model",
+            model="some-model",
+            usecase=ModelUsecase.generate,
+            loader=ModelLoader.vllm,
+            num_gpus=4,
+            num_cpus=2,
+        )
+        opts = build_deployment_options(config)
+        assert total_gpu_reservation(opts) == 4
+        assert total_cpu_reservation(opts) == 8
 
 
 class TestRemoveApps:


### PR DESCRIPTION
Multi-slot vLLM deploys (`tp*pp > 1`) now always allocate one whole-GPU Ray Serve placement-group bundle per slot (STRICT_PACK) that vLLM's ray executor inherits via `get_current_placement_group()`. The `mp` backend path and the user-facing `distributed_executor_backend` knob are gone; with whole-GPU bundles on a single node, the two paths were physically equivalent and ray gives us better observability and worker isolation.

Config validator now:
- rejects fractional `num_gpus` (`< 1`) combined with `tp*pp > 1` (Ray packs fractional PG bundles onto the same physical GPU, breaking TP);
- requires integer `num_gpus` when `num_gpus >= 1`;
- auto-derives `tensor_parallel_size` from `num_gpus` when `tp = pp = 1`;
- warns when `num_gpus` is redundant with an explicit `tp*pp`.

`build_actor_options` is now `build_deployment_options` returning a `Deployment.options(**...)` kwargs dict (placement-group params aren't allowed inside `ray_actor_options`).

Smoke tests and the `smoke` pytest marker are removed; the behaviour they documented is now enforced at config time.

