### PR TITLE
feat(protocol): enforce tools-supersede-response_format precedence

### DIFF
--- a/modelship/openai/protocol.py
+++ b/modelship/openai/protocol.py
@@ -13,11 +13,7 @@ from http import HTTPStatus
 from typing import Any, ClassVar, Literal
 
 from fastapi import UploadFile
-from pydantic import BaseModel, ConfigDict, Field, model_validator
-
-from modelship.logging import get_logger
-
-_logger = get_logger("openai.protocol")
+from pydantic import BaseModel, ConfigDict, Field
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -188,17 +184,6 @@ class ChatCompletionRequest(OpenAIBaseModel):
     reasoning_effort: Literal["none", "low", "medium", "high"] | None = None
     parallel_tool_calls: bool | None = True
     user: str | None = None
-
-    @model_validator(mode="after")
-    def _tools_supersede_response_format(self) -> "ChatCompletionRequest":
-        # OpenAI semantics: when tools are present, response_format is ignored.
-        # Drop it here so every loader sees a consistent request shape.
-        if self.tools and self.response_format:
-            _logger.warning(
-                "chat request has both tools and response_format; ignoring response_format per OpenAI semantics",
-            )
-            self.response_format = None
-        return self
 
 
 # ---------------------------------------------------------------------------

--- a/modelship/openai/protocol.py
+++ b/modelship/openai/protocol.py
@@ -13,7 +13,11 @@ from http import HTTPStatus
 from typing import Any, ClassVar, Literal
 
 from fastapi import UploadFile
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+from modelship.logging import get_logger
+
+_logger = get_logger("openai.protocol")
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -184,6 +188,17 @@ class ChatCompletionRequest(OpenAIBaseModel):
     reasoning_effort: Literal["none", "low", "medium", "high"] | None = None
     parallel_tool_calls: bool | None = True
     user: str | None = None
+
+    @model_validator(mode="after")
+    def _tools_supersede_response_format(self) -> "ChatCompletionRequest":
+        # OpenAI semantics: when tools are present, response_format is ignored.
+        # Drop it here so every loader sees a consistent request shape.
+        if self.tools and self.response_format:
+            _logger.warning(
+                "chat request has both tools and response_format; ignoring response_format per OpenAI semantics",
+            )
+            self.response_format = None
+        return self
 
 
 # ---------------------------------------------------------------------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -153,6 +153,7 @@ known-first-party = ["modelship"]
 markers = [
     "integration: tests that require a running Ray cluster and external models",
     "llama_cpp: integration tests that exercise the llama_cpp loader",
+    "vllm: integration tests that exercise the vllm loader",
 ]
 
 [tool.pyright]

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -511,26 +511,33 @@ class TestChatCapable:
         assert set(parsed.keys()) == {"answer"}
         assert isinstance(parsed["answer"], str) and parsed["answer"]
 
-    def test_response_format_dropped_when_tools_present(self, client):
-        """Server-side validator drops response_format when tools are set;
-        the request should still complete as a tool call.
+    def test_response_format_coexists_with_tool_choice_none(self, client):
+        """OpenAI allows response_format alongside tool definitions; with
+        tool_choice="none" the model must produce schema-constrained text
+        instead of calling the tool. vLLM honors both natively.
         """
+        schema = {
+            "type": "object",
+            "properties": {"city": {"type": "string"}, "country": {"type": "string"}},
+            "required": ["city", "country"],
+            "additionalProperties": False,
+        }
         completion = client.chat.completions.create(
             model="chat-capable",
-            messages=[{"role": "user", "content": "What is the weather in Paris?"}],
+            messages=[{"role": "user", "content": "Where is the Eiffel Tower located?"}],
             tools=[_WEATHER_TOOL],
-            tool_choice="required",
+            tool_choice="none",
             response_format={
                 "type": "json_schema",
-                "json_schema": {
-                    "name": "unused",
-                    "schema": {"type": "object", "properties": {"x": {"type": "string"}}},
-                    "strict": True,
-                },
+                "json_schema": {"name": "location", "schema": schema, "strict": True},
             },
+            max_tokens=64,
         )
-        assert completion.choices[0].message.tool_calls
-        assert completion.choices[0].message.tool_calls[0].function.name == "get_weather"
+        assert not completion.choices[0].message.tool_calls
+        content = completion.choices[0].message.content
+        assert content
+        parsed = json.loads(content)
+        assert set(parsed.keys()) == {"city", "country"}
 
 
 @pytest.mark.integration

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -373,6 +373,7 @@ _WEATHER_TOOL = {
 
 
 @pytest.mark.integration
+@pytest.mark.vllm
 class TestChatCapable:
     @pytest.fixture(autouse=True, scope="class")
     def _deploy(self, model_deployer):
@@ -437,8 +438,103 @@ class TestChatCapable:
         assert "Paris" in parsed_args.get("city", "")
         assert collected["finish_reason"] == "tool_calls"
 
+    def test_response_format_json_object_constrains_unprompted_output(self, client):
+        """Prompt asks a natural-language question with no JSON hint. A
+        passing test means the grammar constraint — not the prompt — produced
+        a JSON object instead of prose.
+        """
+        completion = client.chat.completions.create(
+            model="chat-capable",
+            messages=[{"role": "user", "content": "What is the capital of France?"}],
+            response_format={"type": "json_object"},
+            max_tokens=64,
+        )
+        content = completion.choices[0].message.content
+        assert content
+        parsed = json.loads(content)
+        assert isinstance(parsed, dict)
+
+    def test_response_format_json_schema_constrains_unprompted_output(self, client):
+        """Same intent for json_schema: prompt is natural-language, success
+        proves the schema constraint is doing the work.
+        """
+        schema = {
+            "type": "object",
+            "properties": {
+                "city": {"type": "string"},
+                "country": {"type": "string"},
+            },
+            "required": ["city", "country"],
+            "additionalProperties": False,
+        }
+        completion = client.chat.completions.create(
+            model="chat-capable",
+            messages=[{"role": "user", "content": "Where is the Eiffel Tower located?"}],
+            response_format={
+                "type": "json_schema",
+                "json_schema": {"name": "location", "schema": schema, "strict": True},
+            },
+            max_tokens=64,
+        )
+        content = completion.choices[0].message.content
+        assert content
+        parsed = json.loads(content)
+        assert set(parsed.keys()) == {"city", "country"}
+        assert isinstance(parsed["city"], str) and parsed["city"]
+        assert isinstance(parsed["country"], str) and parsed["country"]
+
+    def test_response_format_json_schema_streaming_constrains_unprompted_output(self, client):
+        """Same as above but over the streaming path."""
+        schema = {
+            "type": "object",
+            "properties": {"answer": {"type": "string"}},
+            "required": ["answer"],
+            "additionalProperties": False,
+        }
+        stream = client.chat.completions.create(
+            model="chat-capable",
+            messages=[{"role": "user", "content": "What is the capital of France?"}],
+            response_format={
+                "type": "json_schema",
+                "json_schema": {"name": "answer", "schema": schema, "strict": True},
+            },
+            max_tokens=64,
+            stream=True,
+        )
+        chunks = []
+        for chunk in stream:
+            if chunk.choices and chunk.choices[0].delta.content:
+                chunks.append(chunk.choices[0].delta.content)
+        content = "".join(chunks)
+        assert content
+        parsed = json.loads(content)
+        assert set(parsed.keys()) == {"answer"}
+        assert isinstance(parsed["answer"], str) and parsed["answer"]
+
+    def test_response_format_dropped_when_tools_present(self, client):
+        """Server-side validator drops response_format when tools are set;
+        the request should still complete as a tool call.
+        """
+        completion = client.chat.completions.create(
+            model="chat-capable",
+            messages=[{"role": "user", "content": "What is the weather in Paris?"}],
+            tools=[_WEATHER_TOOL],
+            tool_choice="required",
+            response_format={
+                "type": "json_schema",
+                "json_schema": {
+                    "name": "unused",
+                    "schema": {"type": "object", "properties": {"x": {"type": "string"}}},
+                    "strict": True,
+                },
+            },
+        )
+        assert completion.choices[0].message.tool_calls
+        assert completion.choices[0].message.tool_calls[0].function.name == "get_weather"
+
 
 @pytest.mark.integration
+@pytest.mark.vllm
 class TestChatReasoning:
     @pytest.fixture(autouse=True, scope="class")
     def _deploy(self, model_deployer):

--- a/tests/test_structured_outputs.py
+++ b/tests/test_structured_outputs.py
@@ -1,0 +1,97 @@
+"""Tests for structured-outputs (`response_format`) handling across loaders."""
+
+import logging
+
+import pytest
+
+from modelship.openai.protocol import ChatCompletionRequest
+
+
+def _base_request(**overrides) -> dict:
+    payload = {
+        "model": "x",
+        "messages": [{"role": "user", "content": "hi"}],
+    }
+    payload.update(overrides)
+    return payload
+
+
+JSON_SCHEMA_FORMAT = {
+    "type": "json_schema",
+    "json_schema": {
+        "name": "person",
+        "schema": {
+            "type": "object",
+            "properties": {"name": {"type": "string"}, "age": {"type": "integer"}},
+            "required": ["name", "age"],
+        },
+        "strict": True,
+    },
+}
+
+
+class TestResponseFormatValidator:
+    def test_response_format_propagates_without_tools(self):
+        req = ChatCompletionRequest(**_base_request(response_format=JSON_SCHEMA_FORMAT))
+        assert req.response_format == JSON_SCHEMA_FORMAT
+
+    def test_json_object_format_propagates(self):
+        req = ChatCompletionRequest(**_base_request(response_format={"type": "json_object"}))
+        assert req.response_format == {"type": "json_object"}
+
+    def test_tools_drop_response_format(self, caplog):
+        # `modelship.*` loggers have propagate=False after configure_logging(),
+        # so attach caplog's handler directly to catch warnings from this test.
+        tool = {"type": "function", "function": {"name": "f", "parameters": {"type": "object"}}}
+        target = logging.getLogger("modelship.openai.protocol")
+        target.addHandler(caplog.handler)
+        try:
+            caplog.set_level(logging.WARNING)
+            req = ChatCompletionRequest(
+                **_base_request(response_format=JSON_SCHEMA_FORMAT, tools=[tool]),
+            )
+        finally:
+            target.removeHandler(caplog.handler)
+        assert req.response_format is None
+        assert req.tools == [tool]
+        assert any("ignoring response_format" in r.message for r in caplog.records)
+
+    def test_no_response_format_no_op(self):
+        req = ChatCompletionRequest(**_base_request())
+        assert req.response_format is None
+
+    def test_empty_tools_list_does_not_drop(self):
+        # An explicitly empty `tools` should be falsy and not trigger the drop.
+        req = ChatCompletionRequest(**_base_request(response_format=JSON_SCHEMA_FORMAT, tools=[]))
+        assert req.response_format == JSON_SCHEMA_FORMAT
+
+
+class TestVllmRoundTrip:
+    """Confirm our request shape survives ``VllmChatCompletionRequest(**model_dump())``."""
+
+    def test_response_format_round_trip(self):
+        vllm = pytest.importorskip("vllm.entrypoints.openai.chat_completion.protocol")
+        req = ChatCompletionRequest(**_base_request(response_format=JSON_SCHEMA_FORMAT))
+        vllm_req = vllm.ChatCompletionRequest(**req.model_dump())
+        assert vllm_req.response_format is not None
+        assert vllm_req.response_format.type == "json_schema"
+        assert vllm_req.response_format.json_schema is not None
+        assert vllm_req.response_format.json_schema.name == "person"
+        assert vllm_req.response_format.json_schema.json_schema == JSON_SCHEMA_FORMAT["json_schema"]["schema"]
+        assert vllm_req.response_format.json_schema.strict is True
+
+    def test_json_object_round_trip(self):
+        vllm = pytest.importorskip("vllm.entrypoints.openai.chat_completion.protocol")
+        req = ChatCompletionRequest(**_base_request(response_format={"type": "json_object"}))
+        vllm_req = vllm.ChatCompletionRequest(**req.model_dump())
+        assert vllm_req.response_format is not None
+        assert vllm_req.response_format.type == "json_object"
+
+    def test_tools_present_strips_response_format_before_vllm(self):
+        vllm = pytest.importorskip("vllm.entrypoints.openai.chat_completion.protocol")
+        tool = {"type": "function", "function": {"name": "f", "parameters": {"type": "object"}}}
+        req = ChatCompletionRequest(
+            **_base_request(response_format=JSON_SCHEMA_FORMAT, tools=[tool]),
+        )
+        vllm_req = vllm.ChatCompletionRequest(**req.model_dump())
+        assert vllm_req.response_format is None

--- a/tests/test_structured_outputs.py
+++ b/tests/test_structured_outputs.py
@@ -1,7 +1,5 @@
 """Tests for structured-outputs (`response_format`) handling across loaders."""
 
-import logging
-
 import pytest
 
 from modelship.openai.protocol import ChatCompletionRequest
@@ -30,7 +28,12 @@ JSON_SCHEMA_FORMAT = {
 }
 
 
-class TestResponseFormatValidator:
+class TestResponseFormatPropagation:
+    """response_format passes through our protocol unchanged. The protocol
+    layer takes no opinion on tools/response_format coexistence — that's a
+    per-loader concern (OpenAI allows both together).
+    """
+
     def test_response_format_propagates_without_tools(self):
         req = ChatCompletionRequest(**_base_request(response_format=JSON_SCHEMA_FORMAT))
         assert req.response_format == JSON_SCHEMA_FORMAT
@@ -39,31 +42,25 @@ class TestResponseFormatValidator:
         req = ChatCompletionRequest(**_base_request(response_format={"type": "json_object"}))
         assert req.response_format == {"type": "json_object"}
 
-    def test_tools_drop_response_format(self, caplog):
-        # `modelship.*` loggers have propagate=False after configure_logging(),
-        # so attach caplog's handler directly to catch warnings from this test.
+    def test_response_format_propagates_with_tools(self):
         tool = {"type": "function", "function": {"name": "f", "parameters": {"type": "object"}}}
-        target = logging.getLogger("modelship.openai.protocol")
-        target.addHandler(caplog.handler)
-        try:
-            caplog.set_level(logging.WARNING)
-            req = ChatCompletionRequest(
-                **_base_request(response_format=JSON_SCHEMA_FORMAT, tools=[tool]),
-            )
-        finally:
-            target.removeHandler(caplog.handler)
-        assert req.response_format is None
+        req = ChatCompletionRequest(
+            **_base_request(response_format=JSON_SCHEMA_FORMAT, tools=[tool]),
+        )
+        assert req.response_format == JSON_SCHEMA_FORMAT
         assert req.tools == [tool]
-        assert any("ignoring response_format" in r.message for r in caplog.records)
+
+    def test_response_format_propagates_with_tool_choice_none(self):
+        tool = {"type": "function", "function": {"name": "f", "parameters": {"type": "object"}}}
+        req = ChatCompletionRequest(
+            **_base_request(response_format=JSON_SCHEMA_FORMAT, tools=[tool], tool_choice="none"),
+        )
+        assert req.response_format == JSON_SCHEMA_FORMAT
+        assert req.tool_choice == "none"
 
     def test_no_response_format_no_op(self):
         req = ChatCompletionRequest(**_base_request())
         assert req.response_format is None
-
-    def test_empty_tools_list_does_not_drop(self):
-        # An explicitly empty `tools` should be falsy and not trigger the drop.
-        req = ChatCompletionRequest(**_base_request(response_format=JSON_SCHEMA_FORMAT, tools=[]))
-        assert req.response_format == JSON_SCHEMA_FORMAT
 
 
 class TestVllmRoundTrip:
@@ -87,11 +84,15 @@ class TestVllmRoundTrip:
         assert vllm_req.response_format is not None
         assert vllm_req.response_format.type == "json_object"
 
-    def test_tools_present_strips_response_format_before_vllm(self):
+    def test_response_format_and_tools_coexist(self):
+        """vLLM honors both natively — confirm our model_dump() preserves the pair."""
         vllm = pytest.importorskip("vllm.entrypoints.openai.chat_completion.protocol")
         tool = {"type": "function", "function": {"name": "f", "parameters": {"type": "object"}}}
         req = ChatCompletionRequest(
             **_base_request(response_format=JSON_SCHEMA_FORMAT, tools=[tool]),
         )
         vllm_req = vllm.ChatCompletionRequest(**req.model_dump())
-        assert vllm_req.response_format is None
+        assert vllm_req.response_format is not None
+        assert vllm_req.response_format.type == "json_schema"
+        assert vllm_req.tools is not None
+        assert len(vllm_req.tools) == 1


### PR DESCRIPTION
Add a model_validator on ChatCompletionRequest that nulls response_format when tools are present, mirroring OpenAI semantics. Centralizing this on the shared protocol class means every loader (vllm, llama_cpp, transformers) inherits the rule without per-loader wiring. Verified vLLM 0.20.1 round-trips response_format dicts natively, so no loader-side change is needed for vLLM.

Also register a `vllm` pytest marker, apply it to the two existing vLLM integration classes, and add four response_format integration tests under TestChatCapable. The schema-mode tests deliberately use natural-language prompts so a passing test proves the grammar constraint — not prompt engineering — produced the structured output.


