### PR TITLE
feat(llama_cpp): structured outputs + tools/response_format compat gate

### DIFF
--- a/modelship/infer/llama_cpp/openai/serving_chat.py
+++ b/modelship/infer/llama_cpp/openai/serving_chat.py
@@ -10,6 +10,7 @@ from llama_cpp import Llama
 from modelship.infer.base_serving import OpenAIServing
 from modelship.infer.infer_config import RawRequestProxy
 from modelship.infer.llama_cpp.capabilities import LlamaCppCapabilities
+from modelship.infer.llama_cpp.structured import build_llama_grammar
 from modelship.infer.llama_cpp.utils import LlamaCppToolCallRenderer
 from modelship.logging import get_logger
 from modelship.openai.chat_utils import UnsupportedContentError, normalize_chat_messages
@@ -100,6 +101,22 @@ class OpenAIServingChat(OpenAIServing):
                 self.model_name,
             )
             tools = None
+
+        # Reasoning-enabled deployments emit `<think>...</think>` before content.
+        # A JSON grammar from response_format would exclude the `<` token and
+        # break reasoning emission. Reject upfront so the user picks a
+        # non-reasoning deployment for schema-constrained traffic.
+        if self.reasoning_parser and request.response_format:
+            fmt_type = request.response_format.get("type")
+            if fmt_type not in (None, "text"):
+                msg = (
+                    f"response_format with type={fmt_type!r} cannot be combined with a "
+                    f"reasoning-enabled deployment ({self.model_name!r}). The schema grammar "
+                    "prevents the reasoning parser's required tokens from being emitted. "
+                    "Use a non-reasoning deployment, or drop response_format."
+                )
+                logger.warning("chat request %s rejected: %s", request_id, msg)
+                return create_error_response(msg)
 
         tool_parser_name = self.tool_call_parser if tools else None
         # Renderer presence decides the path (see __init__ comment): when
@@ -285,6 +302,11 @@ class OpenAIServingChat(OpenAIServing):
         if "max_tokens" not in params and "max_completion_tokens" in params:
             params["max_tokens"] = params["max_completion_tokens"]
 
+        # Convert OpenAI-shaped response_format → LlamaGrammar. llama-cpp-python's
+        # own handler only recognizes {"type": "json_object", "schema": ...} and
+        # silently drops {"type": "json_schema", ...}, so we own the conversion.
+        grammar = build_llama_grammar(params.pop("response_format", None))
+
         kwargs: dict = {}
         dropped: list[str] = []
         for k, v in params.items():
@@ -299,6 +321,8 @@ class OpenAIServingChat(OpenAIServing):
                 "llama_cpp: dropping request params not supported by create_chat_completion: %s",
                 dropped,
             )
+        if grammar is not None:
+            kwargs["grammar"] = grammar
         return kwargs
 
     def _build_completion_kwargs(self, request: ChatCompletionRequest, prompt: str) -> dict:
@@ -312,4 +336,9 @@ class OpenAIServingChat(OpenAIServing):
         for k in ("logprobs", "top_logprobs"):
             params.pop(k, None)
 
-        return {k: v for k, v in params.items() if k in self._completion_accepted_params}
+        grammar = build_llama_grammar(params.pop("response_format", None))
+
+        kwargs = {k: v for k, v in params.items() if k in self._completion_accepted_params}
+        if grammar is not None:
+            kwargs["grammar"] = grammar
+        return kwargs

--- a/modelship/infer/llama_cpp/openai/serving_chat.py
+++ b/modelship/infer/llama_cpp/openai/serving_chat.py
@@ -301,6 +301,7 @@ class OpenAIServingChat(OpenAIServing):
         params["messages"] = messages
         if "max_tokens" not in params and "max_completion_tokens" in params:
             params["max_tokens"] = params["max_completion_tokens"]
+        params.pop("max_completion_tokens", None)
 
         # Convert OpenAI-shaped response_format → LlamaGrammar. llama-cpp-python's
         # own handler only recognizes {"type": "json_object", "schema": ...} and
@@ -330,6 +331,7 @@ class OpenAIServingChat(OpenAIServing):
         params["prompt"] = prompt
         if "max_tokens" not in params and "max_completion_tokens" in params:
             params["max_tokens"] = params["max_completion_tokens"]
+        params.pop("max_completion_tokens", None)
         # These are consumed by our renderer/parser, not by `create_completion`.
         for k in ("messages", "tools", "tool_choice", "stream", "stream_options"):
             params.pop(k, None)

--- a/modelship/infer/llama_cpp/structured.py
+++ b/modelship/infer/llama_cpp/structured.py
@@ -1,0 +1,59 @@
+"""OpenAI ``response_format`` → llama.cpp ``LlamaGrammar`` conversion.
+
+llama-cpp-python's ``create_chat_completion`` accepts a ``response_format``
+kwarg, but its built-in handler only recognizes the narrower
+``{"type": "json_object", "schema": ...}`` shape and silently returns no
+grammar for OpenAI's ``{"type": "json_schema", "json_schema": {...}}``.
+We convert the OpenAI shape into a ``LlamaGrammar`` here and pass it via
+the ``grammar`` kwarg, which both ``create_chat_completion`` and
+``create_completion`` accept.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from llama_cpp import LlamaGrammar
+
+from modelship.logging import get_logger
+
+logger = get_logger("infer.llama_cpp.structured")
+
+# Permissive JSON-object grammar: any valid JSON object. Used when the
+# caller requested ``{"type": "json_object"}`` without a schema.
+_JSON_OBJECT_SCHEMA = {"type": "object"}
+
+
+def build_llama_grammar(response_format: dict[str, Any] | None) -> LlamaGrammar | None:
+    """Convert an OpenAI-shaped ``response_format`` to a ``LlamaGrammar``.
+
+    Returns ``None`` when no constraint should apply (missing, ``text``,
+    or a malformed payload — logged as a warning).
+    """
+    if not response_format:
+        return None
+
+    fmt_type = response_format.get("type")
+    if fmt_type in (None, "text"):
+        return None
+
+    if fmt_type == "json_object":
+        return LlamaGrammar.from_json_schema(json.dumps(_JSON_OBJECT_SCHEMA), verbose=False)
+
+    if fmt_type == "json_schema":
+        spec = response_format.get("json_schema") or {}
+        schema = spec.get("schema")
+        if not isinstance(schema, dict):
+            logger.warning(
+                "response_format.json_schema is missing a 'schema' object; skipping grammar constraint",
+            )
+            return None
+        try:
+            return LlamaGrammar.from_json_schema(json.dumps(schema), verbose=False)
+        except Exception as exc:
+            logger.warning("failed to compile json_schema into LlamaGrammar: %s; skipping", exc)
+            return None
+
+    logger.warning("unsupported response_format type %r; skipping grammar constraint", fmt_type)
+    return None

--- a/modelship/infer/llama_cpp/structured.py
+++ b/modelship/infer/llama_cpp/structured.py
@@ -12,7 +12,6 @@ the ``grammar`` kwarg, which both ``create_chat_completion`` and
 from __future__ import annotations
 
 import json
-from functools import lru_cache
 from typing import Any
 
 from llama_cpp import LlamaGrammar
@@ -23,13 +22,12 @@ logger = get_logger("infer.llama_cpp.structured")
 
 # Permissive JSON-object grammar: any valid JSON object. Used when the
 # caller requested ``{"type": "json_object"}`` without a schema.
+# Built fresh per request rather than cached: ``LlamaGrammar`` wraps a
+# stateful C-side parser pointer, so sharing one instance across
+# concurrent requests (or across Llama instances in the same process)
+# would corrupt sampling state. Compilation cost for this trivial
+# schema is negligible.
 _JSON_OBJECT_SCHEMA = {"type": "object"}
-
-
-@lru_cache(maxsize=1)
-def _json_object_grammar() -> LlamaGrammar:
-    """Compile the permissive json_object grammar once per process."""
-    return LlamaGrammar.from_json_schema(json.dumps(_JSON_OBJECT_SCHEMA), verbose=False)
 
 
 def build_llama_grammar(response_format: dict[str, Any] | None) -> LlamaGrammar | None:
@@ -46,7 +44,7 @@ def build_llama_grammar(response_format: dict[str, Any] | None) -> LlamaGrammar 
         return None
 
     if fmt_type == "json_object":
-        return _json_object_grammar()
+        return LlamaGrammar.from_json_schema(json.dumps(_JSON_OBJECT_SCHEMA), verbose=False)
 
     if fmt_type == "json_schema":
         spec = response_format.get("json_schema") or {}

--- a/modelship/infer/llama_cpp/structured.py
+++ b/modelship/infer/llama_cpp/structured.py
@@ -12,6 +12,7 @@ the ``grammar`` kwarg, which both ``create_chat_completion`` and
 from __future__ import annotations
 
 import json
+from functools import lru_cache
 from typing import Any
 
 from llama_cpp import LlamaGrammar
@@ -23,6 +24,12 @@ logger = get_logger("infer.llama_cpp.structured")
 # Permissive JSON-object grammar: any valid JSON object. Used when the
 # caller requested ``{"type": "json_object"}`` without a schema.
 _JSON_OBJECT_SCHEMA = {"type": "object"}
+
+
+@lru_cache(maxsize=1)
+def _json_object_grammar() -> LlamaGrammar:
+    """Compile the permissive json_object grammar once per process."""
+    return LlamaGrammar.from_json_schema(json.dumps(_JSON_OBJECT_SCHEMA), verbose=False)
 
 
 def build_llama_grammar(response_format: dict[str, Any] | None) -> LlamaGrammar | None:
@@ -39,7 +46,7 @@ def build_llama_grammar(response_format: dict[str, Any] | None) -> LlamaGrammar 
         return None
 
     if fmt_type == "json_object":
-        return LlamaGrammar.from_json_schema(json.dumps(_JSON_OBJECT_SCHEMA), verbose=False)
+        return _json_object_grammar()
 
     if fmt_type == "json_schema":
         spec = response_format.get("json_schema") or {}

--- a/modelship/openai/protocol.py
+++ b/modelship/openai/protocol.py
@@ -13,7 +13,7 @@ from http import HTTPStatus
 from typing import Any, ClassVar, Literal
 
 from fastapi import UploadFile
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -184,6 +184,27 @@ class ChatCompletionRequest(OpenAIBaseModel):
     reasoning_effort: Literal["none", "low", "medium", "high"] | None = None
     parallel_tool_calls: bool | None = True
     user: str | None = None
+
+    @model_validator(mode="after")
+    def _validate_tools_response_format_compat(self) -> "ChatCompletionRequest":
+        # response_format=json_object/json_schema is enforced via a sampling-time
+        # grammar that excludes any token outside the schema — including the
+        # markers a model would use to emit a tool call (<tool_call>...,
+        # <|python_tag|>..., etc.). The two cannot meaningfully coexist on any
+        # loader we support: vLLM passes both through but the grammar dominates;
+        # llama-cpp-python silently drops json_schema; transformers has no
+        # native machinery to compose them. Reject upfront so callers don't
+        # discover the conflict by watching tool calls never fire in prod.
+        if not self.tools or not self.response_format:
+            return self
+        fmt_type = self.response_format.get("type")
+        if fmt_type in (None, "text"):
+            return self
+        if self.tool_choice == "none":
+            return self
+        raise ValueError(
+            f"response_format with type={fmt_type!r} cannot be combined with tools unless tool_choice='none'."
+        )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -742,6 +742,130 @@ class TestChatLlamaCpp:
         assert "Paris" in parsed_args["city"]
         assert collected["finish_reason"] == "tool_calls"
 
+    def test_response_format_json_object_constrains_unprompted_output(self, client):
+        """Prompt is natural-language; the grammar constraint produces JSON."""
+        completion = client.chat.completions.create(
+            model="chat-llama-mship",
+            messages=[{"role": "user", "content": "What is the capital of France?"}],
+            response_format={"type": "json_object"},
+            max_tokens=64,
+        )
+        content = completion.choices[0].message.content
+        assert content
+        parsed = json.loads(content)
+        assert isinstance(parsed, dict)
+
+    def test_response_format_json_schema_constrains_unprompted_output(self, client):
+        """A natural-language question + json_schema → schema-conformant output."""
+        schema = {
+            "type": "object",
+            "properties": {
+                "city": {"type": "string"},
+                "country": {"type": "string"},
+            },
+            "required": ["city", "country"],
+            "additionalProperties": False,
+        }
+        completion = client.chat.completions.create(
+            model="chat-llama-mship",
+            messages=[{"role": "user", "content": "Where is the Eiffel Tower located?"}],
+            response_format={
+                "type": "json_schema",
+                "json_schema": {"name": "location", "schema": schema, "strict": True},
+            },
+            max_tokens=64,
+        )
+        content = completion.choices[0].message.content
+        assert content
+        parsed = json.loads(content)
+        assert set(parsed.keys()) == {"city", "country"}
+        assert isinstance(parsed["city"], str) and parsed["city"]
+        assert isinstance(parsed["country"], str) and parsed["country"]
+
+    def test_response_format_json_schema_streaming_constrains_unprompted_output(self, client):
+        """Same intent on the streaming path."""
+        schema = {
+            "type": "object",
+            "properties": {"answer": {"type": "string"}},
+            "required": ["answer"],
+            "additionalProperties": False,
+        }
+        stream = client.chat.completions.create(
+            model="chat-llama-mship",
+            messages=[{"role": "user", "content": "What is the capital of France?"}],
+            response_format={
+                "type": "json_schema",
+                "json_schema": {"name": "answer", "schema": schema, "strict": True},
+            },
+            max_tokens=64,
+            stream=True,
+        )
+        chunks = []
+        for chunk in stream:
+            if chunk.choices and chunk.choices[0].delta.content:
+                chunks.append(chunk.choices[0].delta.content)
+        content = "".join(chunks)
+        assert content
+        parsed = json.loads(content)
+        assert set(parsed.keys()) == {"answer"}
+        assert isinstance(parsed["answer"], str) and parsed["answer"]
+
+    def test_response_format_coexists_with_tool_choice_none(self, client):
+        """tool_choice='none' is the safe escape valve: tools listed but inert,
+        schema enforced on content output.
+        """
+        schema = {
+            "type": "object",
+            "properties": {"city": {"type": "string"}, "country": {"type": "string"}},
+            "required": ["city", "country"],
+            "additionalProperties": False,
+        }
+        completion = client.chat.completions.create(
+            model="chat-llama-mship",
+            messages=[{"role": "user", "content": "Where is the Eiffel Tower located?"}],
+            tools=[_WEATHER_TOOL],
+            tool_choice="none",
+            response_format={
+                "type": "json_schema",
+                "json_schema": {"name": "location", "schema": schema, "strict": True},
+            },
+            max_tokens=64,
+        )
+        assert not completion.choices[0].message.tool_calls
+        content = completion.choices[0].message.content
+        assert content
+        parsed = json.loads(content)
+        assert set(parsed.keys()) == {"city", "country"}
+
+    def test_response_format_with_active_tools_rejected_by_gateway(self):
+        """Protocol-layer validator rejects tools + response_format when
+        tool_choice is anything other than 'none'. The schema grammar would
+        block tool-call markers from being emitted, so we surface the conflict
+        upfront rather than silently breaking tool calling.
+        """
+        response = httpx.post(
+            f"{OPENAI_API_BASE}/chat/completions",
+            json={
+                "model": "chat-llama-mship",
+                "messages": [{"role": "user", "content": "What is the weather in Paris?"}],
+                "tools": [_WEATHER_TOOL],
+                "tool_choice": "auto",
+                "response_format": {
+                    "type": "json_schema",
+                    "json_schema": {
+                        "name": "unused",
+                        "schema": {"type": "object", "properties": {"x": {"type": "string"}}},
+                        "strict": True,
+                    },
+                },
+            },
+            timeout=30,
+        )
+        assert response.status_code in (400, 422), (
+            f"expected client-error status, got {response.status_code}: {response.text}"
+        )
+        assert "tool_choice='none'" in response.text
+
 
 @pytest.mark.integration
 @pytest.mark.llama_cpp
@@ -912,6 +1036,35 @@ class TestChatLlamaCppReasoning:
             assert "</tool_call>" in reasoning, (
                 f"reasoning has an unmatched <tool_call> marker (open without close): {reasoning!r}"
             )
+
+    def test_response_format_with_reasoning_deployment_rejected(self):
+        """A JSON grammar would exclude the `<` token, breaking the reasoning
+        parser's `<think>...` emission. The loader rejects the combination at
+        request time rather than producing malformed output.
+        """
+        response = httpx.post(
+            f"{OPENAI_API_BASE}/chat/completions",
+            json={
+                "model": "chat-llama-reasoning",
+                "messages": [{"role": "user", "content": "What is 2+2?"}],
+                "response_format": {
+                    "type": "json_schema",
+                    "json_schema": {
+                        "name": "answer",
+                        "schema": {
+                            "type": "object",
+                            "properties": {"answer": {"type": "string"}},
+                            "required": ["answer"],
+                        },
+                        "strict": True,
+                    },
+                },
+                "max_tokens": 256,
+            },
+            timeout=60,
+        )
+        assert response.status_code == 400, f"expected 400, got {response.status_code}: {response.text}"
+        assert "reasoning" in response.text.lower()
 
 
 @pytest.mark.integration

--- a/tests/test_llama_cpp_structured.py
+++ b/tests/test_llama_cpp_structured.py
@@ -1,0 +1,143 @@
+"""Tests for the llama_cpp ``response_format`` → ``LlamaGrammar`` converter."""
+
+from llama_cpp import LlamaGrammar
+
+from modelship.infer.llama_cpp.structured import build_llama_grammar
+
+
+class TestBuildLlamaGrammar:
+    def test_none_returns_none(self):
+        assert build_llama_grammar(None) is None
+
+    def test_empty_dict_returns_none(self):
+        assert build_llama_grammar({}) is None
+
+    def test_text_type_returns_none(self):
+        assert build_llama_grammar({"type": "text"}) is None
+
+    def test_missing_type_returns_none(self):
+        assert build_llama_grammar({"foo": "bar"}) is None
+
+    def test_json_object_returns_grammar(self):
+        g = build_llama_grammar({"type": "json_object"})
+        assert isinstance(g, LlamaGrammar)
+
+    def test_json_schema_compiles_schema(self):
+        schema = {
+            "type": "object",
+            "properties": {"name": {"type": "string"}, "age": {"type": "integer"}},
+            "required": ["name", "age"],
+        }
+        g = build_llama_grammar(
+            {"type": "json_schema", "json_schema": {"name": "p", "schema": schema, "strict": True}},
+        )
+        assert isinstance(g, LlamaGrammar)
+
+    def test_json_schema_missing_schema_returns_none_with_warning(self, caplog):
+        import logging
+
+        target = logging.getLogger("modelship.infer.llama_cpp.structured")
+        target.addHandler(caplog.handler)
+        try:
+            caplog.set_level(logging.WARNING)
+            g = build_llama_grammar({"type": "json_schema", "json_schema": {"name": "p"}})
+        finally:
+            target.removeHandler(caplog.handler)
+        assert g is None
+        assert any("missing a 'schema'" in r.message for r in caplog.records)
+
+    def test_unknown_type_returns_none_with_warning(self, caplog):
+        import logging
+
+        target = logging.getLogger("modelship.infer.llama_cpp.structured")
+        target.addHandler(caplog.handler)
+        try:
+            caplog.set_level(logging.WARNING)
+            g = build_llama_grammar({"type": "xml"})
+        finally:
+            target.removeHandler(caplog.handler)
+        assert g is None
+        assert any("unsupported response_format" in r.message for r in caplog.records)
+
+    def test_invalid_schema_returns_none_with_warning(self, caplog):
+        import logging
+
+        target = logging.getLogger("modelship.infer.llama_cpp.structured")
+        target.addHandler(caplog.handler)
+        try:
+            caplog.set_level(logging.WARNING)
+            # Schema with an unresolvable $ref triggers LlamaGrammar.from_json_schema to raise.
+            bad_schema = {"$ref": "#/definitions/nope"}
+            g = build_llama_grammar(
+                {"type": "json_schema", "json_schema": {"name": "p", "schema": bad_schema}},
+            )
+        finally:
+            target.removeHandler(caplog.handler)
+        # Either compiles to something or fails gracefully — both are acceptable;
+        # this test just guarantees we never raise into the caller.
+        assert g is None or isinstance(g, LlamaGrammar)
+
+
+class TestKwargBuilders:
+    """``_build_kwargs`` and ``_build_completion_kwargs`` must replace
+    ``response_format`` with a compiled ``grammar`` so neither field reaches
+    llama-cpp-python with a shape it would silently ignore.
+    """
+
+    def _serving(self):
+        from llama_cpp import Llama
+
+        from modelship.infer.llama_cpp.openai.serving_chat import OpenAIServingChat
+
+        # Bypass __init__ — we only need the kwarg builders, which only read
+        # _accepted_params / _completion_accepted_params.
+        chat = OpenAIServingChat.__new__(OpenAIServingChat)
+        import inspect
+
+        chat._accepted_params = set(inspect.signature(Llama.create_chat_completion).parameters)
+        chat._completion_accepted_params = set(inspect.signature(Llama.create_completion).parameters)
+        return chat
+
+    def _request(self, response_format=None):
+        from modelship.openai.protocol import ChatCompletionRequest
+
+        payload = {"model": "x", "messages": [{"role": "user", "content": "hi"}]}
+        if response_format is not None:
+            payload["response_format"] = response_format
+        return ChatCompletionRequest(**payload)
+
+    def test_build_kwargs_injects_grammar(self):
+        chat = self._serving()
+        req = self._request(
+            response_format={
+                "type": "json_schema",
+                "json_schema": {
+                    "name": "p",
+                    "schema": {"type": "object", "properties": {"x": {"type": "string"}}},
+                    "strict": True,
+                },
+            }
+        )
+        kwargs = chat._build_kwargs(req, messages=[{"role": "user", "content": "hi"}])
+        assert "response_format" not in kwargs
+        assert isinstance(kwargs.get("grammar"), LlamaGrammar)
+
+    def test_build_kwargs_omits_grammar_when_no_response_format(self):
+        chat = self._serving()
+        req = self._request()
+        kwargs = chat._build_kwargs(req, messages=[{"role": "user", "content": "hi"}])
+        assert "grammar" not in kwargs
+        assert "response_format" not in kwargs
+
+    def test_build_completion_kwargs_injects_grammar(self):
+        chat = self._serving()
+        req = self._request(response_format={"type": "json_object"})
+        kwargs = chat._build_completion_kwargs(req, prompt="hi")
+        assert "response_format" not in kwargs
+        assert isinstance(kwargs.get("grammar"), LlamaGrammar)
+
+    def test_build_completion_kwargs_omits_grammar_when_no_response_format(self):
+        chat = self._serving()
+        req = self._request()
+        kwargs = chat._build_completion_kwargs(req, prompt="hi")
+        assert "grammar" not in kwargs

--- a/tests/test_llama_cpp_structured.py
+++ b/tests/test_llama_cpp_structured.py
@@ -141,3 +141,23 @@ class TestKwargBuilders:
         req = self._request()
         kwargs = chat._build_completion_kwargs(req, prompt="hi")
         assert "grammar" not in kwargs
+
+    def test_max_completion_tokens_mapped_and_dropped(self):
+        # ``max_completion_tokens`` is the modern OpenAI field. llama-cpp-python
+        # only accepts ``max_tokens``. We map the value over and must drop the
+        # original key so it doesn't end up in the "unsupported params" warning.
+        chat = self._serving()
+        from modelship.openai.protocol import ChatCompletionRequest
+
+        req = ChatCompletionRequest(
+            model="x",
+            messages=[{"role": "user", "content": "hi"}],
+            max_completion_tokens=42,
+        )
+        kwargs = chat._build_kwargs(req, messages=[{"role": "user", "content": "hi"}])
+        assert kwargs.get("max_tokens") == 42
+        assert "max_completion_tokens" not in kwargs
+
+        completion_kwargs = chat._build_completion_kwargs(req, prompt="hi")
+        assert completion_kwargs.get("max_tokens") == 42
+        assert "max_completion_tokens" not in completion_kwargs

--- a/tests/test_llama_cpp_structured.py
+++ b/tests/test_llama_cpp_structured.py
@@ -22,6 +22,13 @@ class TestBuildLlamaGrammar:
         g = build_llama_grammar({"type": "json_object"})
         assert isinstance(g, LlamaGrammar)
 
+    def test_json_object_grammar_is_cached(self):
+        # The permissive json_object grammar takes the same input on every
+        # call; it must be compiled once per process, not per request.
+        g1 = build_llama_grammar({"type": "json_object"})
+        g2 = build_llama_grammar({"type": "json_object"})
+        assert g1 is g2
+
     def test_json_schema_compiles_schema(self):
         schema = {
             "type": "object",

--- a/tests/test_llama_cpp_structured.py
+++ b/tests/test_llama_cpp_structured.py
@@ -22,12 +22,13 @@ class TestBuildLlamaGrammar:
         g = build_llama_grammar({"type": "json_object"})
         assert isinstance(g, LlamaGrammar)
 
-    def test_json_object_grammar_is_cached(self):
-        # The permissive json_object grammar takes the same input on every
-        # call; it must be compiled once per process, not per request.
+    def test_json_object_returns_fresh_instance(self):
+        # LlamaGrammar wraps a stateful C-side parser pointer; sharing an
+        # instance across concurrent requests would corrupt sampling state.
+        # Each call must compile a fresh grammar.
         g1 = build_llama_grammar({"type": "json_object"})
         g2 = build_llama_grammar({"type": "json_object"})
-        assert g1 is g2
+        assert g1 is not g2
 
     def test_json_schema_compiles_schema(self):
         schema = {

--- a/tests/test_structured_outputs.py
+++ b/tests/test_structured_outputs.py
@@ -14,6 +14,8 @@ def _base_request(**overrides) -> dict:
     return payload
 
 
+_TOOL = {"type": "function", "function": {"name": "f", "parameters": {"type": "object"}}}
+
 JSON_SCHEMA_FORMAT = {
     "type": "json_schema",
     "json_schema": {
@@ -28,12 +30,7 @@ JSON_SCHEMA_FORMAT = {
 }
 
 
-class TestResponseFormatPropagation:
-    """response_format passes through our protocol unchanged. The protocol
-    layer takes no opinion on tools/response_format coexistence — that's a
-    per-loader concern (OpenAI allows both together).
-    """
-
+class TestResponseFormatValidation:
     def test_response_format_propagates_without_tools(self):
         req = ChatCompletionRequest(**_base_request(response_format=JSON_SCHEMA_FORMAT))
         assert req.response_format == JSON_SCHEMA_FORMAT
@@ -42,21 +39,47 @@ class TestResponseFormatPropagation:
         req = ChatCompletionRequest(**_base_request(response_format={"type": "json_object"}))
         assert req.response_format == {"type": "json_object"}
 
-    def test_response_format_propagates_with_tools(self):
-        tool = {"type": "function", "function": {"name": "f", "parameters": {"type": "object"}}}
+    def test_text_format_with_tools_allowed(self):
+        # response_format={"type":"text"} is a no-op and must not block tools.
         req = ChatCompletionRequest(
-            **_base_request(response_format=JSON_SCHEMA_FORMAT, tools=[tool]),
+            **_base_request(response_format={"type": "text"}, tools=[_TOOL]),
         )
-        assert req.response_format == JSON_SCHEMA_FORMAT
-        assert req.tools == [tool]
+        assert req.response_format == {"type": "text"}
+        assert req.tools == [_TOOL]
 
-    def test_response_format_propagates_with_tool_choice_none(self):
-        tool = {"type": "function", "function": {"name": "f", "parameters": {"type": "object"}}}
+    def test_response_format_with_tools_allowed_when_tool_choice_none(self):
         req = ChatCompletionRequest(
-            **_base_request(response_format=JSON_SCHEMA_FORMAT, tools=[tool], tool_choice="none"),
+            **_base_request(
+                response_format=JSON_SCHEMA_FORMAT,
+                tools=[_TOOL],
+                tool_choice="none",
+            ),
         )
         assert req.response_format == JSON_SCHEMA_FORMAT
         assert req.tool_choice == "none"
+
+    @pytest.mark.parametrize("tool_choice", [None, "auto", "required"])
+    def test_response_format_with_tools_rejected_for_active_tool_choice(self, tool_choice):
+        payload = _base_request(response_format=JSON_SCHEMA_FORMAT, tools=[_TOOL])
+        if tool_choice is not None:
+            payload["tool_choice"] = tool_choice
+        with pytest.raises(ValueError, match="tool_choice='none'"):
+            ChatCompletionRequest(**payload)
+
+    def test_response_format_with_tools_rejected_for_named_tool(self):
+        payload = _base_request(
+            response_format=JSON_SCHEMA_FORMAT,
+            tools=[_TOOL],
+            tool_choice={"type": "function", "function": {"name": "f"}},
+        )
+        with pytest.raises(ValueError, match="tool_choice='none'"):
+            ChatCompletionRequest(**payload)
+
+    def test_json_object_with_tools_also_rejected(self):
+        with pytest.raises(ValueError, match="tool_choice='none'"):
+            ChatCompletionRequest(
+                **_base_request(response_format={"type": "json_object"}, tools=[_TOOL]),
+            )
 
     def test_no_response_format_no_op(self):
         req = ChatCompletionRequest(**_base_request())
@@ -84,15 +107,17 @@ class TestVllmRoundTrip:
         assert vllm_req.response_format is not None
         assert vllm_req.response_format.type == "json_object"
 
-    def test_response_format_and_tools_coexist(self):
-        """vLLM honors both natively — confirm our model_dump() preserves the pair."""
+    def test_response_format_with_tools_and_tool_choice_none_round_trip(self):
+        """The one combination the validator allows still survives the dump."""
         vllm = pytest.importorskip("vllm.entrypoints.openai.chat_completion.protocol")
-        tool = {"type": "function", "function": {"name": "f", "parameters": {"type": "object"}}}
         req = ChatCompletionRequest(
-            **_base_request(response_format=JSON_SCHEMA_FORMAT, tools=[tool]),
+            **_base_request(
+                response_format=JSON_SCHEMA_FORMAT,
+                tools=[_TOOL],
+                tool_choice="none",
+            ),
         )
         vllm_req = vllm.ChatCompletionRequest(**req.model_dump())
         assert vllm_req.response_format is not None
-        assert vllm_req.response_format.type == "json_schema"
         assert vllm_req.tools is not None
-        assert len(vllm_req.tools) == 1
+        assert vllm_req.tool_choice == "none"


### PR DESCRIPTION
Wire OpenAI response_format into the llama_cpp loader. llama-cpp-python's own handler only recognizes the narrower {"type": "json_object", "schema": ...} shape and silently drops the OpenAI {"type": "json_schema", ...} envelope, so we convert response_format → LlamaGrammar ourselves and pass it via the `grammar` kwarg on both the native (create_chat_completion) and parser (create_completion) paths.

Add a protocol-layer model_validator that rejects requests combining tools with a JSON response_format unless tool_choice="none". The schema grammar excludes tool-call marker tokens (<tool_call>, <|python_tag|>, etc.) at sampling time, so tools cannot fire when the grammar is active. Surface this upfront rather than letting it look like the model "chose not to call a tool." Applies uniformly across vLLM, llama_cpp, and transformers since they all consume the same ChatCompletionRequest class.

Reasoning-enabled llama_cpp deployments also reject response_format because the JSON grammar would exclude the `<` token required for the `<think>...</think>` reasoning markers — caught at the loader level since reasoning_parser is deployment config, not a request field.

Tests:
- 13 unit tests on the protocol validator + vLLM round-trip
- 13 unit tests on build_llama_grammar and the kwarg builders
- 6 integration tests on chat-llama-mship and chat-llama-reasoning (json_object, json_schema, streaming, tool_choice='none' coexistence, validator rejection at the gateway, reasoning rejection)


