### PR TITLE
feat(vllm): vision / image_url input support

### DIFF
--- a/config/examples/vllm-vision.yaml
+++ b/config/examples/vllm-vision.yaml
@@ -1,0 +1,24 @@
+# vLLM vision (VLM) example — requires an NVIDIA GPU with enough VRAM for the
+# vision encoder plus KV cache. Tested with Qwen2.5-VL-7B-Instruct on a single
+# 24GB GPU. Send chat messages with `image_url` content parts the same way you
+# would against the official OpenAI API.
+
+models:
+  - name: "qwen-vl"
+    model: "Qwen/Qwen2.5-VL-7B-Instruct"
+    usecase: "generate"
+    loader: "vllm"
+    num_gpus: 1
+    vllm_engine_kwargs:
+      # VLMs eat hundreds to thousands of tokens per image; bump the context
+      # so a single user turn with one image still has room for a response.
+      max_model_len: 16384
+      # Cap images per request: protects against accidentally OOM-ing the GPU
+      # when a client sends a 50-image batch. Adjust to your VRAM budget.
+      limit_mm_per_prompt:
+        image: 4
+      # Qwen2.5-VL accepts min/max pixel knobs that trade off latency vs detail.
+      # Defaults are high quality; lower max_pixels to speed up inference.
+      mm_processor_kwargs:
+        min_pixels: 50176   # 224 * 224
+        max_pixels: 1003520 # 1280 * 784

--- a/modelship/infer/infer_config.py
+++ b/modelship/infer/infer_config.py
@@ -65,6 +65,12 @@ class VllmEngineConfig(BaseModel):
     chat_template_content_format: ChatTemplateContentFormatOption = "auto"
     enforce_eager: bool | None = None
     max_num_batched_tokens: int | None = None
+    # Cap on multimodal items per prompt (e.g. {"image": 4}). vLLM allows a
+    # richer per-modality budget shape (dict of caps) so we mirror that.
+    limit_mm_per_prompt: dict[str, int | dict[str, int]] | None = None
+    # Per-model multimodal processor knobs (e.g. min_pixels / max_pixels for
+    # Qwen2.5-VL). Forwarded verbatim to the HF processor.
+    mm_processor_kwargs: dict[str, Any] | None = None
 
 
 class TransformersConfig(BaseModel):

--- a/modelship/infer/vllm/capabilities.py
+++ b/modelship/infer/vllm/capabilities.py
@@ -1,0 +1,20 @@
+"""Modality capability detection for a loaded vLLM engine."""
+
+from dataclasses import dataclass
+
+from vllm.config.model import ModelConfig
+
+
+@dataclass(frozen=True)
+class VllmCapabilities:
+    """Modalities the underlying vLLM model can ingest."""
+
+    supports_image: bool
+    supports_audio: bool = False  # audio chat input not wired through the vLLM serving_chat path
+
+    @classmethod
+    def detect(cls, model_config: ModelConfig) -> "VllmCapabilities":
+        # vLLM's own ModelConfig inspects the loaded HF config and registry to
+        # decide whether the architecture is multimodal — far more reliable than
+        # sniffing model names or task strings.
+        return cls(supports_image=bool(model_config.is_multimodal_model))

--- a/modelship/infer/vllm/vllm_infer.py
+++ b/modelship/infer/vllm/vllm_infer.py
@@ -1,7 +1,7 @@
 import io
 from collections.abc import AsyncGenerator
 from http import HTTPStatus
-from typing import ClassVar, cast
+from typing import Any, ClassVar, cast
 
 from fastapi import UploadFile
 from starlette.requests import Request
@@ -52,8 +52,10 @@ from vllm.v1.engine.async_llm import AsyncLLM
 from modelship.infer.base_infer import MINIMAL_WAV, BaseInfer
 from modelship.infer.infer_config import ModelshipModelConfig, ModelUsecase, RawRequestProxy, VllmEngineConfig
 from modelship.infer.preflight import discover_hardware, merge_with_user_overrides, run_preflight
+from modelship.infer.vllm.capabilities import VllmCapabilities
 from modelship.logging import get_logger
 from modelship.metrics import _ENABLED as _METRICS_ENABLED
+from modelship.openai.chat_utils import UnsupportedContentError, normalize_chat_messages
 from modelship.openai.protocol import (
     ChatCompletionRequest,
     ChatCompletionResponse,
@@ -129,6 +131,14 @@ class VllmInfer(BaseInfer):
         world_size = self.vllm_engine_kwargs.tensor_parallel_size * self.vllm_engine_kwargs.pipeline_parallel_size
         distributed_executor_backend = "ray" if world_size > 1 else None
 
+        # Multimodal knobs: only forward when the user set them so we inherit
+        # vLLM's own defaults (empty dict / None) otherwise.
+        mm_kwargs: dict[str, Any] = {}
+        if self.vllm_engine_kwargs.limit_mm_per_prompt is not None:
+            mm_kwargs["limit_mm_per_prompt"] = self.vllm_engine_kwargs.limit_mm_per_prompt
+        if self.vllm_engine_kwargs.mm_processor_kwargs is not None:
+            mm_kwargs["mm_processor_kwargs"] = self.vllm_engine_kwargs.mm_processor_kwargs
+
         engine_args = AsyncEngineArgs(
             model=self.vllm_engine_kwargs.model,
             tensor_parallel_size=self.vllm_engine_kwargs.tensor_parallel_size,
@@ -149,6 +159,7 @@ class VllmInfer(BaseInfer):
             kv_cache_dtype=self.vllm_engine_kwargs.kv_cache_dtype or "auto",  # type: ignore[arg-type]
             enforce_eager=self.vllm_engine_kwargs.enforce_eager or False,
             max_num_batched_tokens=self.vllm_engine_kwargs.max_num_batched_tokens,
+            **mm_kwargs,
         )
 
         usage_context = UsageContext.OPENAI_API_SERVER
@@ -186,6 +197,9 @@ class VllmInfer(BaseInfer):
         self._set_max_context_length(self.vllm_config.model_config.max_model_len)
         self.supported_tasks = await self.engine.get_supported_tasks()
         logger.info("Supported_tasks: %s", self.supported_tasks)
+
+        self._caps = VllmCapabilities.detect(self.vllm_config.model_config)
+        logger.info("vllm capabilities for '%s': %s", self.model_config.name, self._caps)
 
         self.serving_chat = await self.init_serving_chat()
         self.serving_embedding = await self.init_serving_embeding()
@@ -338,6 +352,14 @@ class VllmInfer(BaseInfer):
     ) -> ErrorResponse | ChatCompletionResponse | AsyncGenerator[str, None]:
         if self.serving_chat is None:
             return await super().create_chat_completion(request, raw_request)
+        try:
+            request.messages = normalize_chat_messages(
+                request.messages,
+                supports_image=self._caps.supports_image,
+                supports_audio=self._caps.supports_audio,
+            )
+        except UnsupportedContentError as exc:
+            return create_error_response(exc)
         vllm_request = VllmChatCompletionRequest(**request.model_dump())
         try:
             result = await self.serving_chat.create_chat_completion(vllm_request, cast("Request", raw_request))

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -46,6 +46,19 @@ MODEL_CONFIGS: dict[str, dict] = {
             "reasoning_parser": "deepseek_r1",
         },
     },
+    "chat-vlm": {
+        "name": "chat-vlm",
+        "model": "Qwen/Qwen2.5-VL-3B-Instruct",
+        "usecase": "generate",
+        "loader": "vllm",
+        "num_gpus": 1,
+        "vllm_engine_kwargs": {
+            "max_model_len": 8192,
+            "enforce_eager": True,
+            "limit_mm_per_prompt": {"image": 2},
+            "mm_processor_kwargs": {"min_pixels": 50176, "max_pixels": 200704},
+        },
+    },
     "chat-limited": {
         "name": "chat-limited",
         "model": "lmstudio-community/Qwen2.5-0.5B-Instruct-GGUF:*Q4_K_M.gguf",
@@ -610,6 +623,69 @@ class TestChatReasoning:
         # Reasoning markers must not leak into either stream.
         assert "<think>" not in "".join(reasoning_parts)
         assert "<think>" not in "".join(content_parts)
+
+
+# 1x1 red pixel PNG
+_RED_PIXEL_DATA_URI = (
+    "data:image/png;base64,"
+    "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8/5+hHgAHggJ/PchI7wAAAABJRU5ErkJggg=="
+)
+
+
+@pytest.mark.integration
+@pytest.mark.vllm
+class TestChatVlm:
+    """End-to-end vision: a real Qwen2.5-VL-3B deployment receiving an
+    ``image_url`` content part through the modelship gateway."""
+
+    @pytest.fixture(autouse=True, scope="class")
+    def _deploy(self, model_deployer):
+        model_deployer.deploy("chat-vlm")
+
+    def test_chat_with_image_url_returns_response(self, client):
+        completion = client.chat.completions.create(
+            model="chat-vlm",
+            messages=[
+                {
+                    "role": "user",
+                    "content": [
+                        {"type": "text", "text": "What color is this image? Answer in one word."},
+                        {"type": "image_url", "image_url": {"url": _RED_PIXEL_DATA_URI}},
+                    ],
+                }
+            ],
+            max_tokens=16,
+        )
+        assert completion.choices[0].message.content
+        assert completion.choices[0].finish_reason in {"stop", "length"}
+        assert completion.model == "chat-vlm"
+
+    def test_text_only_request_still_works_on_vlm(self, client):
+        completion = client.chat.completions.create(
+            model="chat-vlm",
+            messages=[{"role": "user", "content": "Say hi."}],
+            max_tokens=8,
+        )
+        assert completion.choices[0].message.content
+
+    def test_image_url_streaming(self, client):
+        """Streaming + image input through the gateway end-to-end."""
+        stream = client.chat.completions.create(
+            model="chat-vlm",
+            messages=[
+                {
+                    "role": "user",
+                    "content": [
+                        {"type": "text", "text": "Describe the image briefly."},
+                        {"type": "image_url", "image_url": {"url": _RED_PIXEL_DATA_URI}},
+                    ],
+                }
+            ],
+            max_tokens=16,
+            stream=True,
+        )
+        chunks = [c.choices[0].delta.content for c in stream if c.choices[0].delta.content]
+        assert len(chunks) > 0
 
 
 @pytest.mark.integration

--- a/tests/test_vllm_capabilities.py
+++ b/tests/test_vllm_capabilities.py
@@ -1,0 +1,17 @@
+from types import SimpleNamespace
+
+from modelship.infer.vllm.capabilities import VllmCapabilities
+
+
+def test_multimodal_model_supports_image():
+    mc = SimpleNamespace(is_multimodal_model=True)
+    caps = VllmCapabilities.detect(mc)  # type: ignore[arg-type]
+    assert caps.supports_image is True
+    assert caps.supports_audio is False
+
+
+def test_text_only_model_is_text_only():
+    mc = SimpleNamespace(is_multimodal_model=False)
+    caps = VllmCapabilities.detect(mc)  # type: ignore[arg-type]
+    assert caps.supports_image is False
+    assert caps.supports_audio is False

--- a/tests/test_vllm_vision.py
+++ b/tests/test_vllm_vision.py
@@ -1,0 +1,129 @@
+"""Tests for vLLM chat-completion handling of vision (image_url) message parts.
+
+The boundary we can verify without a real GPU/model is the protocol hop:
+modelship ``ChatCompletionRequest`` -> ``model_dump()`` -> ``VllmChatCompletionRequest``
+(vLLM's own pydantic model). If image parts survive that, vLLM's downstream
+multimodal preprocessing runs against the same shape it does in upstream
+deployments. Wrapper-level concerns (normalize_chat_messages gating) are
+tested via :class:`VllmInfer.create_chat_completion` with serving_chat stubbed
+out — the goal there is the 400-rejection path, not the inference call.
+"""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from vllm.entrypoints.openai.chat_completion.protocol import ChatCompletionRequest as VllmChatCompletionRequest
+
+from modelship.infer.vllm.capabilities import VllmCapabilities
+from modelship.infer.vllm.vllm_infer import VllmInfer
+from modelship.openai.protocol import ChatCompletionRequest, ErrorResponse
+
+# ---------------------------------------------------------------------------
+# Protocol hop — exercise the real vLLM ChatCompletionRequest validator
+# ---------------------------------------------------------------------------
+
+
+def test_image_url_part_survives_protocol_hop_into_vllm_request():
+    """An OpenAI-style image_url part on our request must round-trip into
+    ``VllmChatCompletionRequest`` unchanged — that's the shape vLLM's
+    multimodal preprocessing reads."""
+    request = ChatCompletionRequest(
+        model="qwen-vl",
+        messages=[
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "describe"},
+                    {"type": "image_url", "image_url": {"url": "https://example.com/cat.png"}},
+                ],
+            }
+        ],
+    )
+
+    vllm_request = VllmChatCompletionRequest(**request.model_dump())
+
+    parts = vllm_request.messages[0]["content"]
+    assert isinstance(parts, list)
+    image_parts = [p for p in parts if p.get("type") == "image_url"]
+    assert len(image_parts) == 1
+    assert image_parts[0]["image_url"]["url"] == "https://example.com/cat.png"
+    text_parts = [p for p in parts if p.get("type") == "text"]
+    assert len(text_parts) == 1
+    assert text_parts[0]["text"] == "describe"
+
+
+def test_data_uri_image_survives_protocol_hop():
+    """Base64 data URIs are the common alternative to remote URLs; vLLM must
+    accept them on the same code path."""
+    data_uri = "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII="
+    request = ChatCompletionRequest(
+        model="qwen-vl",
+        messages=[
+            {
+                "role": "user",
+                "content": [{"type": "image_url", "image_url": {"url": data_uri}}],
+            }
+        ],
+    )
+
+    vllm_request = VllmChatCompletionRequest(**request.model_dump())
+
+    parts = vllm_request.messages[0]["content"]
+    assert parts[0]["image_url"]["url"] == data_uri
+
+
+# ---------------------------------------------------------------------------
+# Wrapper gating — exercise VllmInfer.create_chat_completion's 400 path
+# ---------------------------------------------------------------------------
+
+
+def _make_infer(*, supports_image: bool) -> VllmInfer:
+    """Build a VllmInfer with __init__/start bypassed; only the fields the
+    chat-completion path reads are populated."""
+    infer = VllmInfer.__new__(VllmInfer)
+    infer._caps = VllmCapabilities(supports_image=supports_image)  # type: ignore[attr-defined]
+    infer.serving_chat = MagicMock()
+    infer.serving_chat.create_chat_completion = AsyncMock(return_value=MagicMock())
+    return infer
+
+
+@pytest.mark.asyncio
+async def test_image_part_rejected_on_text_only_model_with_400():
+    """A text-only model receiving image_url returns a 400 BadRequest with
+    our error envelope — same shape transformers and llama.cpp produce."""
+    infer = _make_infer(supports_image=False)
+    request = ChatCompletionRequest(
+        model="llm",
+        messages=[
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "describe"},
+                    {"type": "image_url", "image_url": {"url": "https://example.com/cat.png"}},
+                ],
+            }
+        ],
+    )
+
+    result = await infer.create_chat_completion(request, raw_request=MagicMock())
+
+    assert isinstance(result, ErrorResponse)
+    assert result.error.code == 400
+    assert "image" in result.error.message.lower()
+    # The reject must happen before we hand off to vLLM.
+    infer.serving_chat.create_chat_completion.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_text_only_request_reaches_serving_chat_on_vlm():
+    """Sanity check: a plain text request on a VLM is not blocked by the
+    gating layer."""
+    infer = _make_infer(supports_image=True)
+    request = ChatCompletionRequest(
+        model="qwen-vl",
+        messages=[{"role": "user", "content": "hello"}],
+    )
+
+    await infer.create_chat_completion(request, raw_request=MagicMock())
+
+    infer.serving_chat.create_chat_completion.assert_awaited_once()


### PR DESCRIPTION
Closes the top OpenAI-compat gap on the production loader. vLLM's upstream OpenAIServingChat already handles multimodal natively; this PR wires the modelship wrapper so image_url parts flow through and non-VLM models reject with the same 400 shape as transformers/llama.cpp.

- VllmCapabilities.detect() via ModelConfig.is_multimodal_model
- normalize_chat_messages pre-check in create_chat_completion
- VllmEngineConfig: limit_mm_per_prompt + mm_processor_kwargs, forwarded to AsyncEngineArgs only when set (inherit vLLM defaults otherwise)
- Example config for Qwen2.5-VL-7B-Instruct
- Unit tests: protocol-hop preserved through VllmChatCompletionRequest (URL + data: URI), 400 on text-only model, capability detection
- Integration test class TestChatVlm against Qwen2.5-VL-3B-Instruct


