### PR TITLE
refactor(openai): tighten protocol shapes to OpenAI spec

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,6 +34,17 @@ Agents: when running tests on your own initiative (sanity-checking a change, ver
 
 Pre-commit only runs ruff; it does **not** run pyright or tests, so don't rely on the hook to catch type errors.
 
+## OpenAI protocol fidelity
+
+`modelship/openai/protocol.py` is the request/response surface clients see. When adding or changing models there:
+
+- **Follow the official OpenAI API specification strictly.** Field names, types, defaults, optionality, and shape of nested objects must match what `platform.openai.com/docs` documents for the corresponding route.
+- Do not invent fields to expose loader-specific knobs (Diffusers `strength`, vLLM `stop_reason`, etc.). Carry loader-specific defaults via the per-model `*_config` in `infer_config.py` instead.
+- Missing optional OpenAI fields are fine when a feature is genuinely unsupported. Adding fields that aren't in OpenAI's spec is not — it locks clients into a modelship-specific dialect and breaks the drop-in-replacement guarantee.
+- When OpenAI's spec evolves (new fields, new response_format values, new routes), update the protocol shapes before wiring the backend.
+
+When in doubt, check OpenAI's reference for the exact route. Existing deviations are documented and tracked separately; do not add new ones.
+
 ## Lint / format / typecheck rules
 
 - Line length **120** (not 88). Ruff handles formatting; `E501` is disabled because the formatter owns line length.

--- a/modelship/infer/base_infer.py
+++ b/modelship/infer/base_infer.py
@@ -25,8 +25,9 @@ from modelship.openai.protocol import (
 logger = get_logger("infer")
 
 _NOT_SUPPORTED = ErrorResponse(
-    error=ErrorInfo(message="model does not support this action", type="invalid_request_error", code=404)
+    error=ErrorInfo(message="model does not support this action", type="invalid_request_error")
 )
+_NOT_SUPPORTED._http_status = 404
 
 # 44-byte WAV header + 2 bytes of silence (one 16-bit sample at 16 kHz mono)
 _MINIMAL_WAV_HEADER = struct.pack(

--- a/modelship/infer/diffusers/diffusers_infer.py
+++ b/modelship/infer/diffusers/diffusers_infer.py
@@ -84,8 +84,6 @@ class DiffusersInfer(BaseInfer):
             prompt="warmup",
             n=1,
             size="64x64",
-            num_inference_steps=1,
-            guidance_scale=0.0,
         )
         await self.create_image_generation(request, RawRequestProxy(None, {}))
         logger.info("Warmup image generation done for %s", self.model_config.name)

--- a/modelship/infer/diffusers/openai/serving_image.py
+++ b/modelship/infer/diffusers/openai/serving_image.py
@@ -40,8 +40,8 @@ class OpenAIServingImage:
             request.prompt,
             request.n,
             request.size,
-            request.num_inference_steps,
-            request.guidance_scale,
+            self.config.num_inference_steps,
+            self.config.guidance_scale,
         )
 
         try:
@@ -49,8 +49,8 @@ class OpenAIServingImage:
         except ValueError as e:
             return create_error_response(str(e))
 
-        steps = request.num_inference_steps or self.config.num_inference_steps
-        guidance = request.guidance_scale or self.config.guidance_scale
+        steps = self.config.num_inference_steps
+        guidance = self.config.guidance_scale
 
         loop = asyncio.get_event_loop()
         images = await loop.run_in_executor(

--- a/modelship/openai/api.py
+++ b/modelship/openai/api.py
@@ -112,7 +112,7 @@ class OpenaiModelList(BaseModel):
 
 
 def _error_response(result: ErrorResponse) -> JSONResponse:
-    return JSONResponse(content=result.model_dump(mode="json"), status_code=result.error.code if result.error else 500)
+    return JSONResponse(content=result.model_dump(mode="json"), status_code=result._http_status)
 
 
 def _validation_error_from_cause(cause: BaseException) -> ErrorResponse:

--- a/modelship/openai/protocol.py
+++ b/modelship/openai/protocol.py
@@ -13,7 +13,7 @@ from http import HTTPStatus
 from typing import Any, ClassVar, Literal
 
 from fastapi import UploadFile
-from pydantic import BaseModel, ConfigDict, Field, model_validator
+from pydantic import BaseModel, ConfigDict, Field, PrivateAttr, model_validator
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -44,43 +44,53 @@ class ErrorInfo(OpenAIBaseModel):
     message: str
     type: str
     param: str | None = None
-    code: int
+    # OpenAI error code identifier (e.g. "context_length_exceeded"). None when we
+    # haven't mapped the underlying failure to a specific OpenAI-known code.
+    code: str | None = None
 
 
 class ErrorResponse(OpenAIBaseModel):
     error: ErrorInfo
 
+    # HTTP status code carried for the gateway to set on the JSONResponse. Lives
+    # outside `error` because OpenAI's spec has no HTTP status field on the
+    # error object — the spec exposes status purely via the HTTP layer.
+    _http_status: int = PrivateAttr(default=500)
+
 
 def create_error_response(
     message: str | Exception,
-    err_type: str = "BadRequestError",
+    err_type: str = "invalid_request_error",
     status_code: HTTPStatus = HTTPStatus.BAD_REQUEST,
     param: str | None = None,
+    code: str | None = None,
 ) -> ErrorResponse:
     if isinstance(message, Exception):
         exc = message
         if isinstance(exc, ValueError | TypeError | OverflowError):
-            err_type = "BadRequestError"
+            err_type = "invalid_request_error"
             status_code = HTTPStatus.BAD_REQUEST
             param = None
         elif isinstance(exc, NotImplementedError):
-            err_type = "NotImplementedError"
+            err_type = "api_error"
             status_code = HTTPStatus.NOT_IMPLEMENTED
             param = None
         else:
-            err_type = "InternalServerError"
+            err_type = "api_error"
             status_code = HTTPStatus.INTERNAL_SERVER_ERROR
             param = None
         message = str(exc)
 
-    return ErrorResponse(
+    resp = ErrorResponse(
         error=ErrorInfo(
             message=message,
             type=err_type,
-            code=status_code.value,
+            code=code,
             param=param,
         )
     )
+    resp._http_status = status_code.value
+    return resp
 
 
 # ---------------------------------------------------------------------------
@@ -273,7 +283,7 @@ class ChatCompletionStreamResponse(OpenAIBaseModel):
 
 class EmbeddingCompletionRequest(OpenAIBaseModel):
     input: list[int] | list[list[int]] | str | list[str]
-    model: str | None = None
+    model: str = Field(..., description="ID of the model to use.")
     encoding_format: Literal["float", "base64"] = "float"
     dimensions: int | None = None
     user: str | None = None
@@ -311,13 +321,15 @@ class TranscriptionUsageAudio(OpenAIBaseModel):
 
 class TranscriptionRequest(OpenAIBaseModel):
     file: UploadFile
-    model: str | None = None
+    model: str = Field(..., description="ID of the model to use.")
     language: str | None = None
     prompt: str = Field(default="")
     response_format: AudioResponseFormat = Field(default="json")
     timestamp_granularities: list[Literal["word", "segment"]] = Field(alias="timestamp_granularities[]", default=[])
     stream: bool | None = False
     temperature: float = Field(default=0.0)
+    # modelship extension (not in OpenAI spec) — used for deterministic sampling
+    # in evals/regression tests. Documented in docs/extensions.md.
     seed: int | None = None
 
 
@@ -326,10 +338,32 @@ class TranscriptionResponse(OpenAIBaseModel):
     usage: TranscriptionUsageAudio
 
 
-class TranscriptionResponseVerbose(OpenAIBaseModel):
-    duration: str
-    language: str
+class TranscriptionWord(OpenAIBaseModel):
+    word: str
+    start: float = Field(..., description="start time in seconds")
+    end: float = Field(..., description="end time in seconds")
+
+
+class TranscriptionSegment(OpenAIBaseModel):
+    id: int
+    seek: int = 0
+    start: float = Field(..., description="start time in seconds")
+    end: float = Field(..., description="end time in seconds")
     text: str
+    tokens: list[int] = Field(default_factory=list)
+    temperature: float = 0.0
+    avg_logprob: float = 0.0
+    compression_ratio: float = 0.0
+    no_speech_prob: float = 0.0
+
+
+class TranscriptionResponseVerbose(OpenAIBaseModel):
+    language: str
+    duration: float = Field(..., description="The duration of the input audio in seconds.")
+    text: str
+    words: list[TranscriptionWord] = Field(default_factory=list)
+    segments: list[TranscriptionSegment] = Field(default_factory=list)
+    usage: TranscriptionUsageAudio | None = None
 
 
 # ---------------------------------------------------------------------------
@@ -339,11 +373,13 @@ class TranscriptionResponseVerbose(OpenAIBaseModel):
 
 class TranslationRequest(OpenAIBaseModel):
     file: UploadFile
-    model: str | None = None
+    model: str = Field(..., description="ID of the model to use.")
     prompt: str = Field(default="")
     response_format: AudioResponseFormat = Field(default="json")
-    stream: bool | None = False
     temperature: float = Field(default=0.0)
+    # modelship extensions (not in OpenAI spec). Documented in
+    # docs/extensions.md.
+    stream: bool | None = False
     seed: int | None = None
     language: str | None = None
     to_language: str | None = None
@@ -354,9 +390,11 @@ class TranslationResponse(OpenAIBaseModel):
 
 
 class TranslationResponseVerbose(OpenAIBaseModel):
-    duration: str
-    language: str
+    language: str = Field(..., description="The language of the output translation (always `english`).")
+    duration: float = Field(..., description="The duration of the input audio in seconds.")
     text: str
+    segments: list[TranscriptionSegment] = Field(default_factory=list)
+    usage: TranscriptionUsageAudio | None = None
 
 
 # ---------------------------------------------------------------------------
@@ -463,8 +501,6 @@ class ImageGenerationRequest(OpenAIBaseModel):
         default="b64_json",
         description="The format in which the generated images are returned.",
     )
-    num_inference_steps: int | None = Field(default=None, description="Override default inference steps.")
-    guidance_scale: float | None = Field(default=None, description="Override default guidance scale.")
 
 
 class ImageObject(OpenAIBaseModel):
@@ -522,7 +558,9 @@ __all__ = [
     "TranscriptionRequest",
     "TranscriptionResponse",
     "TranscriptionResponseVerbose",
+    "TranscriptionSegment",
     "TranscriptionUsageAudio",
+    "TranscriptionWord",
     "TranslationRequest",
     "TranslationResponse",
     "TranslationResponseVerbose",

--- a/modelship/openai/protocol.py
+++ b/modelship/openai/protocol.py
@@ -358,6 +358,12 @@ class TranscriptionSegment(OpenAIBaseModel):
 
 
 class TranscriptionResponseVerbose(OpenAIBaseModel):
+    # `task` is missing from the openai-openapi schema definition but is
+    # explicitly emitted by the OpenAI API (see the spec's own example payload)
+    # and expected by strict client deserializers that don't tolerate unknown
+    # field absence. Pinned to "transcribe" — Whisper's only valid value for
+    # this route.
+    task: Literal["transcribe"] = "transcribe"
     language: str
     duration: float = Field(..., description="The duration of the input audio in seconds.")
     text: str
@@ -390,6 +396,10 @@ class TranslationResponse(OpenAIBaseModel):
 
 
 class TranslationResponseVerbose(OpenAIBaseModel):
+    # Same `task` story as TranscriptionResponseVerbose — emitted by the OpenAI
+    # API but missing from the openapi.yaml schema definition. Pinned to
+    # "translate".
+    task: Literal["translate"] = "translate"
     language: str = Field(..., description="The language of the output translation (always `english`).")
     duration: float = Field(..., description="The duration of the input audio in seconds.")
     text: str

--- a/modelship/plugins/base_plugin.py
+++ b/modelship/plugins/base_plugin.py
@@ -27,8 +27,9 @@ if TYPE_CHECKING:
     from modelship.infer.preflight import HardwareProfile
 
 _NOT_SUPPORTED = ErrorResponse(
-    error=ErrorInfo(message="plugin does not support this action", type="invalid_request_error", code=404)
+    error=ErrorInfo(message="plugin does not support this action", type="invalid_request_error")
 )
+_NOT_SUPPORTED._http_status = 404
 
 
 class BasePlugin(ABC):
@@ -112,8 +113,6 @@ class BasePlugin(ABC):
         prompt: str,
         n: int = 1,
         size: str | None = None,
-        num_inference_steps: int | None = None,
-        guidance_scale: float | None = None,
         request_id: str | None = None,
     ) -> list[bytes] | ErrorResponse:
         """Returns a list of PNG-encoded image bytes."""

--- a/tests/test_protocol.py
+++ b/tests/test_protocol.py
@@ -1,0 +1,148 @@
+"""Strict-OpenAI shape tests for modelship/openai/protocol.py.
+
+Covers the deviations fixed in the protocol cleanup: ErrorInfo.code retype,
+verbose response shapes, required `model` fields, and ImageGenerationRequest
+losing its Diffusers-only knobs.
+"""
+
+from http import HTTPStatus
+
+import pytest
+from pydantic import ValidationError
+
+from modelship.openai.protocol import (
+    EmbeddingCompletionRequest,
+    ErrorInfo,
+    ErrorResponse,
+    ImageGenerationRequest,
+    TranscriptionRequest,
+    TranscriptionResponseVerbose,
+    TranscriptionSegment,
+    TranscriptionUsageAudio,
+    TranscriptionWord,
+    TranslationRequest,
+    TranslationResponseVerbose,
+    create_error_response,
+)
+
+
+def test_error_info_code_accepts_string_or_none():
+    e = ErrorInfo(message="boom", type="invalid_request_error")
+    assert e.code is None
+
+    e2 = ErrorInfo(message="boom", type="invalid_request_error", code="context_length_exceeded")
+    assert e2.code == "context_length_exceeded"
+
+
+def test_error_info_rejects_int_code():
+    with pytest.raises(ValidationError):
+        ErrorInfo(message="boom", type="invalid_request_error", code=400)  # type: ignore[arg-type]
+
+
+def test_error_response_http_status_default_is_500():
+    resp = ErrorResponse(error=ErrorInfo(message="boom", type="api_error"))
+    assert resp._http_status == 500
+
+
+def test_error_response_http_status_is_not_serialized():
+    resp = ErrorResponse(error=ErrorInfo(message="boom", type="api_error"))
+    resp._http_status = 418
+    dumped = resp.model_dump()
+    assert "_http_status" not in dumped
+    assert "http_status" not in dumped
+    # The OpenAI-spec body is the `error` object only.
+    assert set(dumped.keys()) == {"error"}
+
+
+def test_create_error_response_sets_http_status_from_status_code():
+    resp = create_error_response(
+        message="overflow",
+        err_type="invalid_request_error",
+        status_code=HTTPStatus.BAD_REQUEST,
+    )
+    assert resp._http_status == 400
+    assert resp.error.type == "invalid_request_error"
+    assert resp.error.code is None
+
+
+def test_create_error_response_maps_value_error_to_400():
+    resp = create_error_response(ValueError("bad input"))
+    assert resp._http_status == 400
+    assert resp.error.type == "invalid_request_error"
+
+
+def test_create_error_response_maps_not_implemented_to_501():
+    resp = create_error_response(NotImplementedError("nope"))
+    assert resp._http_status == 501
+    assert resp.error.type == "api_error"
+
+
+def test_create_error_response_maps_other_exception_to_500():
+    resp = create_error_response(RuntimeError("boom"))
+    assert resp._http_status == 500
+    assert resp.error.type == "api_error"
+
+
+def test_transcription_verbose_duration_is_float():
+    v = TranscriptionResponseVerbose(language="en", duration=8.47, text="hi")
+    assert v.duration == 8.47
+    assert isinstance(v.duration, float)
+
+
+def test_transcription_verbose_has_optional_words_segments_usage():
+    v = TranscriptionResponseVerbose(
+        language="en",
+        duration=10.0,
+        text="hello world",
+        words=[TranscriptionWord(word="hello", start=0.0, end=0.5)],
+        segments=[TranscriptionSegment(id=0, start=0.0, end=1.0, text="hello world")],
+        usage=TranscriptionUsageAudio(seconds=10),
+    )
+    assert len(v.words) == 1
+    assert len(v.segments) == 1
+    assert v.usage is not None and v.usage.seconds == 10
+
+
+def test_translation_verbose_duration_is_float():
+    v = TranslationResponseVerbose(language="english", duration=4.2, text="hi")
+    assert v.duration == 4.2
+
+
+def test_translation_verbose_has_segments_no_words():
+    v = TranslationResponseVerbose(
+        language="english",
+        duration=10.0,
+        text="hello",
+        segments=[TranscriptionSegment(id=0, start=0.0, end=1.0, text="hello")],
+    )
+    assert len(v.segments) == 1
+    # No `words` field on translation per OpenAI spec.
+    assert not hasattr(v, "words") or "words" not in TranslationResponseVerbose.model_fields
+
+
+def test_transcription_request_model_is_required():
+    with pytest.raises(ValidationError):
+        TranscriptionRequest()  # type: ignore[call-arg]
+
+
+def test_translation_request_model_is_required():
+    with pytest.raises(ValidationError):
+        TranslationRequest()  # type: ignore[call-arg]
+
+
+def test_embedding_request_model_is_required():
+    with pytest.raises(ValidationError):
+        EmbeddingCompletionRequest(input="hello")  # type: ignore[call-arg]
+
+
+def test_image_generation_request_drops_diffusers_knobs():
+    # num_inference_steps and guidance_scale must not be declared model fields;
+    # extra="allow" still lets them through as extras but they are no longer
+    # part of the canonical shape and serving_image no longer reads them.
+    assert "num_inference_steps" not in ImageGenerationRequest.model_fields
+    assert "guidance_scale" not in ImageGenerationRequest.model_fields
+
+    req = ImageGenerationRequest(model="sd-turbo", prompt="a cat")
+    dumped = req.model_dump()
+    assert "num_inference_steps" not in dumped
+    assert "guidance_scale" not in dumped

--- a/tests/test_protocol.py
+++ b/tests/test_protocol.py
@@ -103,6 +103,21 @@ def test_transcription_verbose_has_optional_words_segments_usage():
     assert v.usage is not None and v.usage.seconds == 10
 
 
+def test_transcription_verbose_has_task_field_pinned_to_transcribe():
+    # OpenAI emits `"task": "transcribe"` on this response shape (see spec's
+    # own example payload). Wire-fidelity for clients that don't tolerate
+    # unknown field absence.
+    v = TranscriptionResponseVerbose(language="en", duration=10.0, text="hi")
+    assert v.task == "transcribe"
+    assert "task" in v.model_dump()
+
+
+def test_translation_verbose_has_task_field_pinned_to_translate():
+    v = TranslationResponseVerbose(language="english", duration=10.0, text="hi")
+    assert v.task == "translate"
+    assert "task" in v.model_dump()
+
+
 def test_translation_verbose_duration_is_float():
     v = TranslationResponseVerbose(language="english", duration=4.2, text="hi")
     assert v.duration == 4.2

--- a/tests/test_vllm_vision.py
+++ b/tests/test_vllm_vision.py
@@ -108,7 +108,7 @@ async def test_image_part_rejected_on_text_only_model_with_400():
     result = await infer.create_chat_completion(request, raw_request=MagicMock())
 
     assert isinstance(result, ErrorResponse)
-    assert result.error.code == 400
+    assert result._http_status == 400
     assert "image" in result.error.message.lower()
     # The reject must happen before we hand off to vLLM.
     infer.serving_chat.create_chat_completion.assert_not_awaited()


### PR DESCRIPTION
Source-checked against openai/openai-openapi master openapi.yaml. Fixes type/shape mismatches that broke strict OpenAI client deserializers and drops Diffusers-only knobs from ImageGenerationRequest (defaults now come from DiffusersConfig).

- ErrorInfo.code: int (HTTP status) -> str | None (OpenAI error code id)
- ErrorResponse._http_status PrivateAttr carries HTTP status out of band
- create_error_response: default err_type values switched to spec strings (invalid_request_error / api_error)
- TranscriptionResponseVerbose / TranslationResponseVerbose: duration str -> float; add optional words[]/segments[]/usage per spec
- new TranscriptionWord, TranscriptionSegment types
- TranscriptionRequest/TranslationRequest/EmbeddingCompletionRequest: model is now required (matches spec)
- ImageGenerationRequest: drop num_inference_steps, guidance_scale; Diffusers serving + warmup read from DiffusersConfig instead
- BasePlugin.create_image_generation: drop matching kwargs
- AGENTS.md: add "OpenAI protocol fidelity" section codifying the rule
- 16 new shape tests in tests/test_protocol.py

Translation language/to_language/stream/seed, transcription seed, vLLM ChatMessage.reasoning, *.stop_reason, EmbeddingResponse.id/created are documented modelship extensions kept deliberately. /v1/responses planned as the spec-correct home for reasoning.


