### PR TITLE
feat(diffusers): /v1/images/edits and /v1/images/variations

### DIFF
--- a/modelship/infer/base_infer.py
+++ b/modelship/infer/base_infer.py
@@ -10,8 +10,10 @@ from modelship.openai.protocol import (
     EmbeddingRequest,
     ErrorInfo,
     ErrorResponse,
+    ImageEditRequest,
     ImageGenerationRequest,
     ImageGenerationResponse,
+    ImageVariationRequest,
     RawSpeechResponse,
     SpeechRequest,
     TranscriptionRequest,
@@ -109,5 +111,19 @@ class BaseInfer(ABC):
 
     async def create_image_generation(
         self, request: ImageGenerationRequest, raw_request: RawRequestProxy
+    ) -> ErrorResponse | ImageGenerationResponse:
+        return _NOT_SUPPORTED
+
+    async def create_image_edit(
+        self,
+        image_data: bytes,
+        mask_data: bytes | None,
+        request: ImageEditRequest,
+        raw_request: RawRequestProxy,
+    ) -> ErrorResponse | ImageGenerationResponse:
+        return _NOT_SUPPORTED
+
+    async def create_image_variation(
+        self, image_data: bytes, request: ImageVariationRequest, raw_request: RawRequestProxy
     ) -> ErrorResponse | ImageGenerationResponse:
         return _NOT_SUPPORTED

--- a/modelship/infer/diffusers/diffusers_infer.py
+++ b/modelship/infer/diffusers/diffusers_infer.py
@@ -47,8 +47,9 @@ class DiffusersInfer(BaseInfer):
 
     def __del__(self):
         try:
-            if pipeline := getattr(self, "_pipeline", None):
-                del pipeline
+            for attr in ("serving_image", "_img2img", "_inpaint", "_pipeline"):
+                if getattr(self, attr, None) is not None:
+                    delattr(self, attr)
             if torch.cuda.is_available():
                 torch.cuda.empty_cache()
         except Exception:

--- a/modelship/infer/diffusers/diffusers_infer.py
+++ b/modelship/infer/diffusers/diffusers_infer.py
@@ -6,11 +6,25 @@ from modelship.infer.infer_config import DiffusersConfig, ModelshipModelConfig, 
 from modelship.logging import get_logger
 from modelship.openai.protocol import (
     ErrorResponse,
+    ImageEditRequest,
     ImageGenerationRequest,
     ImageGenerationResponse,
+    ImageVariationRequest,
 )
 
 logger = get_logger("infer.diffusers")
+
+
+def _dummy_png(width: int, height: int) -> bytes:
+    """A solid-grey PNG used to exercise the edit/variation paths during warmup."""
+    import io
+
+    from PIL import Image
+
+    buf = io.BytesIO()
+    Image.new("RGB", (width, height), (127, 127, 127)).save(buf, format="PNG")
+    return buf.getvalue()
+
 
 _TORCH_DTYPES = {
     "float16": torch.float16,
@@ -43,7 +57,11 @@ class DiffusersInfer(BaseInfer):
             RESOURCE_CLEANUP_ERRORS_TOTAL.inc(tags={"model": self.model_config.name, "component": "diffusers_pipeline"})
 
     async def start(self):
-        from diffusers.pipelines.auto_pipeline import AutoPipelineForText2Image
+        from diffusers.pipelines.auto_pipeline import (
+            AutoPipelineForImage2Image,
+            AutoPipelineForInpainting,
+            AutoPipelineForText2Image,
+        )
 
         config = self.model_config.diffusers_config or DiffusersConfig()
         dtype = _TORCH_DTYPES.get(config.torch_dtype, torch.float16)
@@ -69,8 +87,16 @@ class DiffusersInfer(BaseInfer):
         if tokenizer is not None:
             self._set_max_context_length(getattr(tokenizer, "model_max_length", None))
 
+        self._img2img = AutoPipelineForImage2Image.from_pipe(self._pipeline)
+        self._inpaint = AutoPipelineForInpainting.from_pipe(self._pipeline)
+
         self.serving_image: OpenAIServingImage | None = (
-            OpenAIServingImage(pipeline=self._pipeline, config=config)
+            OpenAIServingImage(
+                pipeline=self._pipeline,
+                config=config,
+                img2img_pipeline=self._img2img,
+                inpaint_pipeline=self._inpaint,
+            )
             if self.model_config.usecase is ModelUsecase.image
             else None
         )
@@ -79,13 +105,24 @@ class DiffusersInfer(BaseInfer):
         if self.serving_image is None:
             return
         logger.info("Warming up diffusers model: %s", self.model_config.name)
-        request = ImageGenerationRequest(
+        proxy = RawRequestProxy(None, {})
+        gen_request = ImageGenerationRequest(
             model=self.model_config.name,
             prompt="warmup",
             n=1,
             size="64x64",
         )
-        await self.create_image_generation(request, RawRequestProxy(None, {}))
+        await self.create_image_generation(gen_request, proxy)
+
+        dummy_png = _dummy_png(64, 64)
+        edit_request = ImageEditRequest.model_construct(
+            model=self.model_config.name, prompt="warmup", n=1, size="64x64", strength=None
+        )
+        await self.create_image_edit(dummy_png, None, edit_request, proxy)
+        variation_request = ImageVariationRequest.model_construct(
+            model=self.model_config.name, n=1, size="64x64", strength=None
+        )
+        await self.create_image_variation(dummy_png, variation_request, proxy)
         logger.info("Warmup image generation done for %s", self.model_config.name)
 
     async def create_image_generation(
@@ -94,3 +131,21 @@ class DiffusersInfer(BaseInfer):
         if self.serving_image is None:
             return await super().create_image_generation(request, raw_request)
         return await self.serving_image.create_image_generation(request, raw_request)
+
+    async def create_image_edit(
+        self,
+        image_data: bytes,
+        mask_data: bytes | None,
+        request: ImageEditRequest,
+        raw_request: RawRequestProxy,
+    ) -> ErrorResponse | ImageGenerationResponse:
+        if self.serving_image is None:
+            return await super().create_image_edit(image_data, mask_data, request, raw_request)
+        return await self.serving_image.create_image_edit(image_data, mask_data, request, raw_request)
+
+    async def create_image_variation(
+        self, image_data: bytes, request: ImageVariationRequest, raw_request: RawRequestProxy
+    ) -> ErrorResponse | ImageGenerationResponse:
+        if self.serving_image is None:
+            return await super().create_image_variation(image_data, request, raw_request)
+        return await self.serving_image.create_image_variation(image_data, request, raw_request)

--- a/modelship/infer/diffusers/diffusers_infer.py
+++ b/modelship/infer/diffusers/diffusers_infer.py
@@ -88,8 +88,22 @@ class DiffusersInfer(BaseInfer):
         if tokenizer is not None:
             self._set_max_context_length(getattr(tokenizer, "model_max_length", None))
 
-        self._img2img = AutoPipelineForImage2Image.from_pipe(self._pipeline)
-        self._inpaint = AutoPipelineForInpainting.from_pipe(self._pipeline)
+        # img2img / inpaint back /v1/images/edits and /v1/images/variations.
+        # from_pipe can fail for models AutoPipeline can't map; degrade
+        # gracefully (those endpoints return a clear error) rather than crash
+        # the whole deployment, which still serves text2img generation.
+        try:
+            self._img2img = AutoPipelineForImage2Image.from_pipe(self._pipeline)
+        except Exception as e:
+            self._img2img = None
+            logger.warning(
+                "img2img pipeline unavailable for %s (edits/variations disabled): %s", self.model_config.name, e
+            )
+        try:
+            self._inpaint = AutoPipelineForInpainting.from_pipe(self._pipeline)
+        except Exception as e:
+            self._inpaint = None
+            logger.warning("inpaint pipeline unavailable for %s (masked edits disabled): %s", self.model_config.name, e)
 
         self.serving_image: OpenAIServingImage | None = (
             OpenAIServingImage(

--- a/modelship/infer/diffusers/diffusers_infer.py
+++ b/modelship/infer/diffusers/diffusers_infer.py
@@ -43,15 +43,20 @@ class DiffusersInfer(BaseInfer):
             torch.cuda.set_per_process_memory_fraction(mem_frac)
 
     def shutdown(self) -> None:
-        pass
+        # The img2img / inpaint pipelines and the serving wrapper all hold
+        # references to the text2img pipeline's shared components (VAE / UNet /
+        # text-encoder). Every holder must be dropped before empty_cache() can
+        # actually reclaim the GPU memory. Idempotent — the getattr guards make
+        # repeat calls (e.g. graceful shutdown then __del__) safe.
+        for attr in ("serving_image", "_img2img", "_inpaint", "_pipeline"):
+            if getattr(self, attr, None) is not None:
+                delattr(self, attr)
+        if torch.cuda.is_available():
+            torch.cuda.empty_cache()
 
     def __del__(self):
         try:
-            for attr in ("serving_image", "_img2img", "_inpaint", "_pipeline"):
-                if getattr(self, attr, None) is not None:
-                    delattr(self, attr)
-            if torch.cuda.is_available():
-                torch.cuda.empty_cache()
+            self.shutdown()
         except Exception:
             from modelship.metrics import RESOURCE_CLEANUP_ERRORS_TOTAL
 

--- a/modelship/infer/diffusers/openai/serving_image.py
+++ b/modelship/infer/diffusers/openai/serving_image.py
@@ -265,12 +265,15 @@ def _alpha_mask(img: Image.Image, width: int, height: int) -> Image.Image | None
     if "A" not in img.mode and "transparency" not in img.info:
         return None
     alpha = img.convert("RGBA").getchannel("A")
-    lo = alpha.getextrema()[0]  # single-band L image -> numeric (min, max)
-    if not isinstance(lo, int | float) or lo >= 255:
-        return None  # fully opaque — nothing marked for editing
-    # Transparent (alpha 0) -> white (repaint); opaque -> black (keep).
+    extrema = alpha.getextrema()  # single-band "L" -> (min, max)
+    if not extrema or not isinstance(extrema[0], int | float) or extrema[0] >= 255:
+        return None  # empty band or fully opaque — nothing marked for editing
+    # Transparent (alpha 0) -> white (repaint); opaque -> black (keep). Threshold
+    # at the source resolution, then resize: the interpolation softens the
+    # binary edge into a gradient, which blends better in inpainting than a hard,
+    # aliased boundary.
     lut = [255 if a < 128 else 0 for a in range(256)]
-    return alpha.resize((width, height)).point(lut)
+    return alpha.point(lut).resize((width, height))
 
 
 def _parse_size(size: str) -> tuple[int, int]:

--- a/modelship/infer/diffusers/openai/serving_image.py
+++ b/modelship/infer/diffusers/openai/serving_image.py
@@ -111,7 +111,7 @@ class OpenAIServingImage:
             # transparency is used as the mask (transparent areas mark the
             # region to edit). With neither, this is a plain img2img edit.
             if mask_data is not None:
-                mask = _load_image(mask_data, width, height)
+                mask = _load_image(mask_data, width, height, mode="L")
             else:
                 mask = _alpha_mask(image_data, width, height)
         except ValueError as e:
@@ -209,9 +209,9 @@ def _build_response(images: list, revised_prompt: str | None) -> ImageGeneration
     return ImageGenerationResponse(created=int(time.time()), data=data)
 
 
-def _load_image(data: bytes, width: int, height: int) -> Image.Image:
+def _load_image(data: bytes, width: int, height: int, mode: str = "RGB") -> Image.Image:
     try:
-        img = Image.open(io.BytesIO(data)).convert("RGB")
+        img = Image.open(io.BytesIO(data)).convert(mode)
     except Exception as e:
         raise ValueError(f"Could not decode input image: {e}") from e
     return img.resize((width, height))

--- a/modelship/infer/diffusers/openai/serving_image.py
+++ b/modelship/infer/diffusers/openai/serving_image.py
@@ -46,6 +46,12 @@ class OpenAIServingImage:
         self.config = config
         self.img2img_pipeline = img2img_pipeline
         self.inpaint_pipeline = inpaint_pipeline
+        # Diffusers pipelines are not thread-safe and the three pipelines share
+        # the same UNet/VAE/text-encoder, so concurrent forward passes (across
+        # executor threads within a replica) would race. Serialize all GPU
+        # inference through this lock; it gates only the executor hop, so the
+        # event loop stays free while a pass runs.
+        self._gpu_lock = asyncio.Lock()
 
     async def create_image_generation(
         self, request: ImageGenerationRequest, raw_request: RawRequestProxy
@@ -87,7 +93,8 @@ class OpenAIServingImage:
         # Inference and PNG/base64 encoding are both CPU-bound; run the whole
         # chain in the executor so the event loop stays responsive.
         loop = asyncio.get_event_loop()
-        response = await loop.run_in_executor(None, _run)
+        async with self._gpu_lock:
+            response = await loop.run_in_executor(None, _run)
         logger.log(TRACE, "image response %s: num_images=%d", request_id, len(response.data))
         return response
 
@@ -162,7 +169,8 @@ class OpenAIServingImage:
             return _build_response(images, revised_prompt=request.prompt)
 
         loop = asyncio.get_event_loop()
-        response = await loop.run_in_executor(None, _run)
+        async with self._gpu_lock:
+            response = await loop.run_in_executor(None, _run)
         if isinstance(response, ImageGenerationResponse):
             logger.log(TRACE, "image edit response %s: num_images=%d", request_id, len(response.data))
         return response
@@ -202,7 +210,8 @@ class OpenAIServingImage:
             return _build_response(images, revised_prompt=None)
 
         loop = asyncio.get_event_loop()
-        response = await loop.run_in_executor(None, _run)
+        async with self._gpu_lock:
+            response = await loop.run_in_executor(None, _run)
         if isinstance(response, ImageGenerationResponse):
             logger.log(TRACE, "image variation response %s: num_images=%d", request_id, len(response.data))
         return response

--- a/modelship/infer/diffusers/openai/serving_image.py
+++ b/modelship/infer/diffusers/openai/serving_image.py
@@ -72,22 +72,21 @@ class OpenAIServingImage:
         steps = self.config.num_inference_steps
         guidance = self.config.guidance_scale
 
-        loop = asyncio.get_event_loop()
-        images = await loop.run_in_executor(
-            None,
-            lambda: (
-                self.pipeline(  # type: ignore[reportCallIssue]
-                    prompt=request.prompt,
-                    num_images_per_prompt=request.n,
-                    width=width,
-                    height=height,
-                    num_inference_steps=steps,
-                    guidance_scale=guidance,
-                ).images
-            ),
-        )
+        def _run() -> ImageGenerationResponse:
+            images = self.pipeline(  # type: ignore[reportCallIssue]
+                prompt=request.prompt,
+                num_images_per_prompt=request.n,
+                width=width,
+                height=height,
+                num_inference_steps=steps,
+                guidance_scale=guidance,
+            ).images
+            return _build_response(images, revised_prompt=request.prompt)
 
-        response = _build_response(images, revised_prompt=request.prompt)
+        # Inference and PNG/base64 encoding are both CPU-bound; run the whole
+        # chain in the executor so the event loop stays responsive.
+        loop = asyncio.get_event_loop()
+        response = await loop.run_in_executor(None, _run)
         logger.log(TRACE, "image response %s: num_images=%d", request_id, len(response.data))
         return response
 
@@ -138,23 +137,20 @@ class OpenAIServingImage:
             pipeline = self.img2img_pipeline
             kwargs = {}
 
-        loop = asyncio.get_event_loop()
-        images = await loop.run_in_executor(
-            None,
-            lambda: (
-                pipeline(  # type: ignore[reportCallIssue]
-                    prompt=request.prompt,
-                    image=image,
-                    num_images_per_prompt=request.n,
-                    num_inference_steps=steps,
-                    guidance_scale=guidance,
-                    strength=strength,
-                    **kwargs,
-                ).images
-            ),
-        )
+        def _run() -> ImageGenerationResponse:
+            images = pipeline(  # type: ignore[reportCallIssue]
+                prompt=request.prompt,
+                image=image,
+                num_images_per_prompt=request.n,
+                num_inference_steps=steps,
+                guidance_scale=guidance,
+                strength=strength,
+                **kwargs,
+            ).images
+            return _build_response(images, revised_prompt=request.prompt)
 
-        response = _build_response(images, revised_prompt=request.prompt)
+        loop = asyncio.get_event_loop()
+        response = await loop.run_in_executor(None, _run)
         logger.log(TRACE, "image edit response %s: num_images=%d", request_id, len(response.data))
         return response
 
@@ -181,22 +177,19 @@ class OpenAIServingImage:
         guidance = self.config.guidance_scale
         strength = request.strength if request.strength is not None else _DEFAULT_VARIATION_STRENGTH
 
-        loop = asyncio.get_event_loop()
-        images = await loop.run_in_executor(
-            None,
-            lambda: (
-                self.img2img_pipeline(  # type: ignore[reportCallIssue]
-                    prompt="",
-                    image=image,
-                    num_images_per_prompt=request.n,
-                    num_inference_steps=steps,
-                    guidance_scale=guidance,
-                    strength=strength,
-                ).images
-            ),
-        )
+        def _run() -> ImageGenerationResponse:
+            images = self.img2img_pipeline(  # type: ignore[reportCallIssue]
+                prompt="",
+                image=image,
+                num_images_per_prompt=request.n,
+                num_inference_steps=steps,
+                guidance_scale=guidance,
+                strength=strength,
+            ).images
+            return _build_response(images, revised_prompt=None)
 
-        response = _build_response(images, revised_prompt=None)
+        loop = asyncio.get_event_loop()
+        response = await loop.run_in_executor(None, _run)
         logger.log(TRACE, "image variation response %s: num_images=%d", request_id, len(response.data))
         return response
 

--- a/modelship/infer/diffusers/openai/serving_image.py
+++ b/modelship/infer/diffusers/openai/serving_image.py
@@ -105,48 +105,51 @@ class OpenAIServingImage:
         except ValueError as e:
             return create_error_response(str(e))
 
-        try:
-            # Decode the input once; derive both the RGB image and (if needed)
-            # the alpha mask from it.
-            src = _decode_image(image_data)
-            image = src.convert("RGB").resize((width, height))
-            # Determine the inpaint mask. An explicit `mask` upload wins;
-            # otherwise, per the OpenAI edits spec, the input image's own
-            # transparency is used as the mask (transparent areas mark the
-            # region to edit). With neither, this is a plain img2img edit.
-            if mask_data is not None:
-                mask = _load_image(mask_data, width, height, mode="L")
-            else:
-                mask = _alpha_mask(src, width, height)
-        except ValueError as e:
-            return create_error_response(str(e))
-
-        inpaint = mask is not None
-        logger.info(
-            "image edit request %s: prompt=%r, n=%d, size=%s, inpaint=%s",
-            request_id,
-            request.prompt,
-            request.n,
-            request.size,
-            inpaint,
-        )
-
         steps = self.config.num_inference_steps
         guidance = self.config.guidance_scale
         strength = request.strength if request.strength is not None else _DEFAULT_EDIT_STRENGTH
 
-        if inpaint:
-            if self.inpaint_pipeline is None:
-                return create_error_response("model does not support image editing")
-            pipeline = self.inpaint_pipeline
-            kwargs = {"mask_image": mask}
-        else:
-            if self.img2img_pipeline is None:
-                return create_error_response("model does not support image editing")
-            pipeline = self.img2img_pipeline
-            kwargs = {}
+        # All image decode / resize / mask work is CPU-bound; run it in the
+        # executor alongside inference and encoding so the event loop is never
+        # blocked. _run returns the final response (or an error response).
+        def _run() -> ImageGenerationResponse | ErrorResponse:
+            try:
+                # Decode the input once; derive both the RGB image and (if
+                # needed) the alpha mask from it.
+                src = _decode_image(image_data)
+                image = src.convert("RGB").resize((width, height))
+                # Determine the inpaint mask. An explicit `mask` upload wins;
+                # otherwise, per the OpenAI edits spec, the input image's own
+                # transparency is used as the mask (transparent areas mark the
+                # region to edit). With neither, this is a plain img2img edit.
+                if mask_data is not None:
+                    mask = _load_mask(mask_data, width, height)
+                else:
+                    mask = _alpha_mask(src, width, height)
+            except ValueError as e:
+                return create_error_response(str(e))
 
-        def _run() -> ImageGenerationResponse:
+            inpaint = mask is not None
+            logger.info(
+                "image edit request %s: prompt=%r, n=%d, size=%s, inpaint=%s",
+                request_id,
+                request.prompt,
+                request.n,
+                request.size,
+                inpaint,
+            )
+
+            if inpaint:
+                if self.inpaint_pipeline is None:
+                    return create_error_response("model does not support image editing")
+                pipeline = self.inpaint_pipeline
+                kwargs = {"mask_image": mask}
+            else:
+                if self.img2img_pipeline is None:
+                    return create_error_response("model does not support image editing")
+                pipeline = self.img2img_pipeline
+                kwargs = {}
+
             images = pipeline(  # type: ignore[reportCallIssue]
                 prompt=request.prompt,
                 image=image,
@@ -160,7 +163,8 @@ class OpenAIServingImage:
 
         loop = asyncio.get_event_loop()
         response = await loop.run_in_executor(None, _run)
-        logger.log(TRACE, "image edit response %s: num_images=%d", request_id, len(response.data))
+        if isinstance(response, ImageGenerationResponse):
+            logger.log(TRACE, "image edit response %s: num_images=%d", request_id, len(response.data))
         return response
 
     async def create_image_variation(
@@ -177,16 +181,16 @@ class OpenAIServingImage:
         except ValueError as e:
             return create_error_response(str(e))
 
-        try:
-            image = _load_image(image_data, width, height)
-        except ValueError as e:
-            return create_error_response(str(e))
-
         steps = self.config.num_inference_steps
         guidance = self.config.guidance_scale
         strength = request.strength if request.strength is not None else _DEFAULT_VARIATION_STRENGTH
 
-        def _run() -> ImageGenerationResponse:
+        # Decode / resize / encode are CPU-bound; keep them off the event loop.
+        def _run() -> ImageGenerationResponse | ErrorResponse:
+            try:
+                image = _load_image(image_data, width, height)
+            except ValueError as e:
+                return create_error_response(str(e))
             images = self.img2img_pipeline(  # type: ignore[reportCallIssue]
                 prompt="",
                 image=image,
@@ -199,7 +203,8 @@ class OpenAIServingImage:
 
         loop = asyncio.get_event_loop()
         response = await loop.run_in_executor(None, _run)
-        logger.log(TRACE, "image variation response %s: num_images=%d", request_id, len(response.data))
+        if isinstance(response, ImageGenerationResponse):
+            logger.log(TRACE, "image variation response %s: num_images=%d", request_id, len(response.data))
         return response
 
 
@@ -222,6 +227,18 @@ def _decode_image(data: bytes) -> Image.Image:
 
 def _load_image(data: bytes, width: int, height: int, mode: str = "RGB") -> Image.Image:
     return _decode_image(data).convert(mode).resize((width, height))
+
+
+def _load_mask(data: bytes, width: int, height: int) -> Image.Image:
+    """Load an uploaded edit mask into a diffusers mask (white = edit region).
+    Per the OpenAI spec a mask encodes the edit region in its alpha channel
+    (transparent = edit), so prefer that; fall back to luminance for an
+    opaque / grayscale mask (white = edit)."""
+    img = _decode_image(data)
+    mask = _alpha_mask(img, width, height)
+    if mask is not None:
+        return mask
+    return img.convert("L").resize((width, height))
 
 
 def _alpha_mask(img: Image.Image, width: int, height: int) -> Image.Image | None:

--- a/modelship/infer/diffusers/openai/serving_image.py
+++ b/modelship/infer/diffusers/openai/serving_image.py
@@ -220,7 +220,12 @@ def _build_response(images: list, revised_prompt: str | None) -> ImageGeneration
 
 def _decode_image(data: bytes) -> Image.Image:
     try:
-        return Image.open(io.BytesIO(data))
+        img = Image.open(io.BytesIO(data))
+        # Image.open is lazy (headers only); force decoding now so truncated /
+        # corrupt pixel data raises here and is wrapped, rather than later
+        # during convert()/resize() where it would escape as an OSError.
+        img.load()
+        return img
     except Exception as e:
         raise ValueError(f"Could not decode input image: {e}") from e
 

--- a/modelship/infer/diffusers/openai/serving_image.py
+++ b/modelship/infer/diffusers/openai/serving_image.py
@@ -3,28 +3,48 @@ import base64
 import io
 import time
 
-from diffusers.pipelines.auto_pipeline import AutoPipelineForText2Image
+from diffusers.pipelines.auto_pipeline import (
+    AutoPipelineForImage2Image,
+    AutoPipelineForInpainting,
+    AutoPipelineForText2Image,
+)
+from PIL import Image
 
 from modelship.infer.infer_config import DiffusersConfig, RawRequestProxy
 from modelship.logging import TRACE, get_logger
 from modelship.openai.protocol import (
     ErrorResponse,
+    ImageEditRequest,
     ImageGenerationRequest,
     ImageGenerationResponse,
     ImageObject,
+    ImageVariationRequest,
     create_error_response,
 )
 from modelship.utils import base_request_id
 
 logger = get_logger("infer.diffusers.image")
 
+# Default img2img strength when the request omits it. Edits stay closer to the
+# source (lower strength); variations diverge more (higher strength).
+_DEFAULT_EDIT_STRENGTH = 0.8
+_DEFAULT_VARIATION_STRENGTH = 0.7
+
 
 class OpenAIServingImage:
     request_id_prefix = "img"
 
-    def __init__(self, pipeline: AutoPipelineForText2Image, config: DiffusersConfig):
+    def __init__(
+        self,
+        pipeline: AutoPipelineForText2Image,
+        config: DiffusersConfig,
+        img2img_pipeline: AutoPipelineForImage2Image | None = None,
+        inpaint_pipeline: AutoPipelineForInpainting | None = None,
+    ):
         self.pipeline = pipeline
         self.config = config
+        self.img2img_pipeline = img2img_pipeline
+        self.inpaint_pipeline = inpaint_pipeline
 
     async def create_image_generation(
         self, request: ImageGenerationRequest, raw_request: RawRequestProxy
@@ -67,16 +87,136 @@ class OpenAIServingImage:
             ),
         )
 
-        data = []
-        for img in images:
-            buf = io.BytesIO()
-            img.save(buf, format="PNG")
-            b64 = base64.b64encode(buf.getvalue()).decode("utf-8")
-            data.append(ImageObject(b64_json=b64, revised_prompt=request.prompt))
-
-        response = ImageGenerationResponse(created=int(time.time()), data=data)
-        logger.log(TRACE, "image response %s: num_images=%d", request_id, len(data))
+        response = _build_response(images, revised_prompt=request.prompt)
+        logger.log(TRACE, "image response %s: num_images=%d", request_id, len(response.data))
         return response
+
+    async def create_image_edit(
+        self,
+        image_data: bytes,
+        mask_data: bytes | None,
+        request: ImageEditRequest,
+        raw_request: RawRequestProxy,
+    ) -> ImageGenerationResponse | ErrorResponse:
+        request_id = f"{self.request_id_prefix}-{base_request_id(raw_request)}"
+        inpaint = mask_data is not None
+        logger.info(
+            "image edit request %s: prompt=%r, n=%d, size=%s, mask=%s",
+            request_id,
+            request.prompt,
+            request.n,
+            request.size,
+            inpaint,
+        )
+
+        try:
+            width, height = _parse_size(request.size)
+        except ValueError as e:
+            return create_error_response(str(e))
+
+        try:
+            image = _load_image(image_data, width, height)
+        except ValueError as e:
+            return create_error_response(str(e))
+
+        steps = self.config.num_inference_steps
+        guidance = self.config.guidance_scale
+        strength = request.strength if request.strength is not None else _DEFAULT_EDIT_STRENGTH
+
+        if inpaint:
+            if self.inpaint_pipeline is None:
+                return create_error_response("model does not support image editing")
+            try:
+                mask = _load_image(mask_data, width, height)  # type: ignore[arg-type]
+            except ValueError as e:
+                return create_error_response(str(e))
+            pipeline = self.inpaint_pipeline
+            kwargs = {"mask_image": mask}
+        else:
+            if self.img2img_pipeline is None:
+                return create_error_response("model does not support image editing")
+            pipeline = self.img2img_pipeline
+            kwargs = {}
+
+        loop = asyncio.get_event_loop()
+        images = await loop.run_in_executor(
+            None,
+            lambda: (
+                pipeline(  # type: ignore[reportCallIssue]
+                    prompt=request.prompt,
+                    image=image,
+                    num_images_per_prompt=request.n,
+                    num_inference_steps=steps,
+                    guidance_scale=guidance,
+                    strength=strength,
+                    **kwargs,
+                ).images
+            ),
+        )
+
+        response = _build_response(images, revised_prompt=request.prompt)
+        logger.log(TRACE, "image edit response %s: num_images=%d", request_id, len(response.data))
+        return response
+
+    async def create_image_variation(
+        self, image_data: bytes, request: ImageVariationRequest, raw_request: RawRequestProxy
+    ) -> ImageGenerationResponse | ErrorResponse:
+        request_id = f"{self.request_id_prefix}-{base_request_id(raw_request)}"
+        logger.info("image variation request %s: n=%d, size=%s", request_id, request.n, request.size)
+
+        if self.img2img_pipeline is None:
+            return create_error_response("model does not support image variations")
+
+        try:
+            width, height = _parse_size(request.size)
+        except ValueError as e:
+            return create_error_response(str(e))
+
+        try:
+            image = _load_image(image_data, width, height)
+        except ValueError as e:
+            return create_error_response(str(e))
+
+        steps = self.config.num_inference_steps
+        guidance = self.config.guidance_scale
+        strength = request.strength if request.strength is not None else _DEFAULT_VARIATION_STRENGTH
+
+        loop = asyncio.get_event_loop()
+        images = await loop.run_in_executor(
+            None,
+            lambda: (
+                self.img2img_pipeline(  # type: ignore[reportCallIssue]
+                    prompt="",
+                    image=image,
+                    num_images_per_prompt=request.n,
+                    num_inference_steps=steps,
+                    guidance_scale=guidance,
+                    strength=strength,
+                ).images
+            ),
+        )
+
+        response = _build_response(images, revised_prompt=None)
+        logger.log(TRACE, "image variation response %s: num_images=%d", request_id, len(response.data))
+        return response
+
+
+def _build_response(images: list, revised_prompt: str | None) -> ImageGenerationResponse:
+    data = []
+    for img in images:
+        buf = io.BytesIO()
+        img.save(buf, format="PNG")
+        b64 = base64.b64encode(buf.getvalue()).decode("utf-8")
+        data.append(ImageObject(b64_json=b64, revised_prompt=revised_prompt))
+    return ImageGenerationResponse(created=int(time.time()), data=data)
+
+
+def _load_image(data: bytes, width: int, height: int) -> Image.Image:
+    try:
+        img = Image.open(io.BytesIO(data)).convert("RGB")
+    except Exception as e:
+        raise ValueError(f"Could not decode input image: {e}") from e
+    return img.resize((width, height))
 
 
 def _parse_size(size: str) -> tuple[int, int]:

--- a/modelship/infer/diffusers/openai/serving_image.py
+++ b/modelship/infer/diffusers/openai/serving_image.py
@@ -98,15 +98,6 @@ class OpenAIServingImage:
         raw_request: RawRequestProxy,
     ) -> ImageGenerationResponse | ErrorResponse:
         request_id = f"{self.request_id_prefix}-{base_request_id(raw_request)}"
-        inpaint = mask_data is not None
-        logger.info(
-            "image edit request %s: prompt=%r, n=%d, size=%s, mask=%s",
-            request_id,
-            request.prompt,
-            request.n,
-            request.size,
-            inpaint,
-        )
 
         try:
             width, height = _parse_size(request.size)
@@ -115,8 +106,26 @@ class OpenAIServingImage:
 
         try:
             image = _load_image(image_data, width, height)
+            # Determine the inpaint mask. An explicit `mask` upload wins;
+            # otherwise, per the OpenAI edits spec, the input image's own
+            # transparency is used as the mask (transparent areas mark the
+            # region to edit). With neither, this is a plain img2img edit.
+            if mask_data is not None:
+                mask = _load_image(mask_data, width, height)
+            else:
+                mask = _alpha_mask(image_data, width, height)
         except ValueError as e:
             return create_error_response(str(e))
+
+        inpaint = mask is not None
+        logger.info(
+            "image edit request %s: prompt=%r, n=%d, size=%s, inpaint=%s",
+            request_id,
+            request.prompt,
+            request.n,
+            request.size,
+            inpaint,
+        )
 
         steps = self.config.num_inference_steps
         guidance = self.config.guidance_scale
@@ -125,10 +134,6 @@ class OpenAIServingImage:
         if inpaint:
             if self.inpaint_pipeline is None:
                 return create_error_response("model does not support image editing")
-            try:
-                mask = _load_image(mask_data, width, height)  # type: ignore[arg-type]
-            except ValueError as e:
-                return create_error_response(str(e))
             pipeline = self.inpaint_pipeline
             kwargs = {"mask_image": mask}
         else:
@@ -210,6 +215,27 @@ def _load_image(data: bytes, width: int, height: int) -> Image.Image:
     except Exception as e:
         raise ValueError(f"Could not decode input image: {e}") from e
     return img.resize((width, height))
+
+
+def _alpha_mask(data: bytes, width: int, height: int) -> Image.Image | None:
+    """Derive an inpaint mask from the input image's alpha channel, per the
+    OpenAI edits spec: when no separate mask is supplied, transparent areas of
+    the image mark the region to edit. Returns a diffusers mask (white = edit,
+    black = keep) sized to (width, height), or None when the image has no alpha
+    channel or is fully opaque (so the caller falls back to img2img)."""
+    try:
+        img = Image.open(io.BytesIO(data))
+    except Exception as e:
+        raise ValueError(f"Could not decode input image: {e}") from e
+    if "A" not in img.mode and "transparency" not in img.info:
+        return None
+    alpha = img.convert("RGBA").getchannel("A")
+    lo = alpha.getextrema()[0]  # single-band L image -> numeric (min, max)
+    if not isinstance(lo, int | float) or lo >= 255:
+        return None  # fully opaque — nothing marked for editing
+    # Transparent (alpha 0) -> white (repaint); opaque -> black (keep).
+    lut = [255 if a < 128 else 0 for a in range(256)]
+    return alpha.resize((width, height)).point(lut)
 
 
 def _parse_size(size: str) -> tuple[int, int]:

--- a/modelship/infer/diffusers/openai/serving_image.py
+++ b/modelship/infer/diffusers/openai/serving_image.py
@@ -106,7 +106,10 @@ class OpenAIServingImage:
             return create_error_response(str(e))
 
         try:
-            image = _load_image(image_data, width, height)
+            # Decode the input once; derive both the RGB image and (if needed)
+            # the alpha mask from it.
+            src = _decode_image(image_data)
+            image = src.convert("RGB").resize((width, height))
             # Determine the inpaint mask. An explicit `mask` upload wins;
             # otherwise, per the OpenAI edits spec, the input image's own
             # transparency is used as the mask (transparent areas mark the
@@ -114,7 +117,7 @@ class OpenAIServingImage:
             if mask_data is not None:
                 mask = _load_image(mask_data, width, height, mode="L")
             else:
-                mask = _alpha_mask(image_data, width, height)
+                mask = _alpha_mask(src, width, height)
         except ValueError as e:
             return create_error_response(str(e))
 
@@ -210,24 +213,24 @@ def _build_response(images: list, revised_prompt: str | None) -> ImageGeneration
     return ImageGenerationResponse(created=int(time.time()), data=data)
 
 
+def _decode_image(data: bytes) -> Image.Image:
+    try:
+        return Image.open(io.BytesIO(data))
+    except Exception as e:
+        raise ValueError(f"Could not decode input image: {e}") from e
+
+
 def _load_image(data: bytes, width: int, height: int, mode: str = "RGB") -> Image.Image:
-    try:
-        img = Image.open(io.BytesIO(data)).convert(mode)
-    except Exception as e:
-        raise ValueError(f"Could not decode input image: {e}") from e
-    return img.resize((width, height))
+    return _decode_image(data).convert(mode).resize((width, height))
 
 
-def _alpha_mask(data: bytes, width: int, height: int) -> Image.Image | None:
-    """Derive an inpaint mask from the input image's alpha channel, per the
-    OpenAI edits spec: when no separate mask is supplied, transparent areas of
-    the image mark the region to edit. Returns a diffusers mask (white = edit,
-    black = keep) sized to (width, height), or None when the image has no alpha
-    channel or is fully opaque (so the caller falls back to img2img)."""
-    try:
-        img = Image.open(io.BytesIO(data))
-    except Exception as e:
-        raise ValueError(f"Could not decode input image: {e}") from e
+def _alpha_mask(img: Image.Image, width: int, height: int) -> Image.Image | None:
+    """Derive an inpaint mask from an already-decoded image's alpha channel,
+    per the OpenAI edits spec: when no separate mask is supplied, transparent
+    areas of the image mark the region to edit. Returns a diffusers mask
+    (white = edit, black = keep) sized to (width, height), or None when the
+    image has no alpha channel or is fully opaque (so the caller falls back to
+    img2img)."""
     if "A" not in img.mode and "transparency" not in img.info:
         return None
     alpha = img.convert("RGBA").getchannel("A")

--- a/modelship/infer/diffusers/openai/serving_image.py
+++ b/modelship/infer/diffusers/openai/serving_image.py
@@ -26,9 +26,10 @@ from modelship.utils import base_request_id
 logger = get_logger("infer.diffusers.image")
 
 # Default img2img strength when the request omits it. Edits stay closer to the
-# source (lower strength); variations diverge more (higher strength).
-_DEFAULT_EDIT_STRENGTH = 0.8
-_DEFAULT_VARIATION_STRENGTH = 0.7
+# source (lower strength) since the prompt guides the change; variations have
+# no prompt, so they need a higher strength to diverge from the input.
+_DEFAULT_EDIT_STRENGTH = 0.7
+_DEFAULT_VARIATION_STRENGTH = 0.8
 
 
 class OpenAIServingImage:

--- a/modelship/infer/infer_config.py
+++ b/modelship/infer/infer_config.py
@@ -129,12 +129,23 @@ class ModelshipModelConfig(BaseModel):
     # default.
     _resolved_skip_special_tokens: bool | None = PrivateAttr(default=None)
 
+    @model_validator(mode="before")
+    @classmethod
+    def default_diffusers_usecase(cls, data):
+        # Diffusers is image-only, so `usecase` is implicit — let configs omit
+        # it. (An explicit non-image usecase is still rejected below.)
+        if isinstance(data, dict) and data.get("loader") == ModelLoader.diffusers and data.get("usecase") is None:
+            data = {**data, "usecase": ModelUsecase.image}
+        return data
+
     @model_validator(mode="after")
     def check_custom_requires_plugin(self):
         if self.loader == ModelLoader.custom and self.plugin is None:
             raise ValueError("loader='custom' requires plugin to be set")
         if self.loader != ModelLoader.custom and not self.model:
             raise ValueError(f"`model:` is required for loader={self.loader!r}")
+        if self.loader == ModelLoader.diffusers and self.usecase is not ModelUsecase.image:
+            raise ValueError(f"loader='diffusers' only supports usecase='image', got {self.usecase!r}")
         return self
 
     @model_validator(mode="after")

--- a/modelship/infer/model_deployment.py
+++ b/modelship/infer/model_deployment.py
@@ -25,7 +25,9 @@ from modelship.metrics import (
 from modelship.openai.protocol import (
     ChatCompletionRequest,
     EmbeddingRequest,
+    ImageEditRequest,
     ImageGenerationRequest,
+    ImageVariationRequest,
     SpeechRequest,
     TranscriptionRequest,
     TranslationRequest,
@@ -317,6 +319,45 @@ class ModelDeployment:
         proxy = RawRequestProxy(disconnect_event, request_headers, request_id)
         start = time.monotonic()
         result = await self.infer.create_image_generation(request, proxy)
+        IMAGE_GENERATION_DURATION_SECONDS.observe(time.monotonic() - start, tags={"model": self.config.name})
+        if isinstance(result, AsyncGenerator):
+            async for chunk in result:
+                yield chunk
+        else:
+            yield result
+
+    async def edit_image(
+        self,
+        image_data: bytes,
+        mask_data: bytes | None,
+        request: ImageEditRequest,
+        request_headers: dict[str, str],
+        disconnect_event: Any,
+        request_id: str | None = None,
+    ):
+        self._set_request_id(request_id)
+        proxy = RawRequestProxy(disconnect_event, request_headers, request_id)
+        start = time.monotonic()
+        result = await self.infer.create_image_edit(image_data, mask_data, request, proxy)
+        IMAGE_GENERATION_DURATION_SECONDS.observe(time.monotonic() - start, tags={"model": self.config.name})
+        if isinstance(result, AsyncGenerator):
+            async for chunk in result:
+                yield chunk
+        else:
+            yield result
+
+    async def vary_image(
+        self,
+        image_data: bytes,
+        request: ImageVariationRequest,
+        request_headers: dict[str, str],
+        disconnect_event: Any,
+        request_id: str | None = None,
+    ):
+        self._set_request_id(request_id)
+        proxy = RawRequestProxy(disconnect_event, request_headers, request_id)
+        start = time.monotonic()
+        result = await self.infer.create_image_variation(image_data, request, proxy)
         IMAGE_GENERATION_DURATION_SECONDS.observe(time.monotonic() - start, tags={"model": self.config.name})
         if isinstance(result, AsyncGenerator):
             async for chunk in result:

--- a/modelship/openai/api.py
+++ b/modelship/openai/api.py
@@ -426,7 +426,10 @@ class ModelshipAPI:
         logger.info("transcription model=%s", model)
         # Read audio bytes before crossing process boundary — UploadFile is not serializable.
         # The bytes are passed separately; the request is reconstructed without the file field.
-        audio_data = await request.file.read()
+        try:
+            audio_data = await request.file.read()
+        finally:
+            await request.file.close()
         request_no_file = TranscriptionRequest.model_construct(**request.model_dump(exclude={"file"}))
         response_gen = handle.transcribe.options(stream=True).remote(
             audio_data, request_no_file, headers, watcher.event, req_id
@@ -444,7 +447,10 @@ class ModelshipAPI:
         logger.info("translation model=%s", model)
         # Read audio bytes before crossing process boundary — UploadFile is not serializable.
         # The bytes are passed separately; the request is reconstructed without the file field.
-        audio_data = await request.file.read()
+        try:
+            audio_data = await request.file.read()
+        finally:
+            await request.file.close()
         request_no_file = TranslationRequest.model_construct(**request.model_dump(exclude={"file"}))
         response_gen = handle.translate.options(stream=True).remote(
             audio_data, request_no_file, headers, watcher.event, req_id

--- a/modelship/openai/api.py
+++ b/modelship/openai/api.py
@@ -493,8 +493,13 @@ class ModelshipAPI:
         headers = dict(raw_request.headers)
         # Read image bytes before crossing the process boundary — UploadFile is not serializable.
         # The bytes are passed separately; the request is reconstructed without the file fields.
-        image_data = await request.image.read()
-        mask_data = await request.mask.read() if request.mask is not None else None
+        try:
+            image_data = await request.image.read()
+            mask_data = await request.mask.read() if request.mask is not None else None
+        finally:
+            await request.image.close()
+            if request.mask is not None:
+                await request.mask.close()
         request_no_file = ImageEditRequest.model_construct(**request.model_dump(exclude={"image", "mask"}))
         response_gen = handle.edit_image.options(stream=True).remote(
             image_data, mask_data, request_no_file, headers, watcher.event, req_id
@@ -510,7 +515,10 @@ class ModelshipAPI:
         watcher = RequestWatcher(raw_request, model=request.model, endpoint="create_image_variation")
         headers = dict(raw_request.headers)
         # Read image bytes before crossing the process boundary — UploadFile is not serializable.
-        image_data = await request.image.read()
+        try:
+            image_data = await request.image.read()
+        finally:
+            await request.image.close()
         request_no_file = ImageVariationRequest.model_construct(**request.model_dump(exclude={"image"}))
         response_gen = handle.vary_image.options(stream=True).remote(
             image_data, request_no_file, headers, watcher.event, req_id

--- a/modelship/openai/api.py
+++ b/modelship/openai/api.py
@@ -30,8 +30,10 @@ from modelship.openai.protocol import (
     EmbeddingRequest,
     EmbeddingResponse,
     ErrorResponse,
+    ImageEditRequest,
     ImageGenerationRequest,
     ImageGenerationResponse,
+    ImageVariationRequest,
     RawSpeechResponse,
     SpeechRequest,
     TranscriptionRequest,
@@ -473,3 +475,44 @@ class ModelshipAPI:
         headers = dict(raw_request.headers)
         response_gen = handle.imagine.options(stream=True).remote(request, headers, watcher.event, req_id)
         return await self._handle_response(response_gen, watcher, request.model, "create_image")
+
+    @app.post("/v1/images/edits")
+    async def create_image_edit(self, request: Annotated[ImageEditRequest, Form()], raw_request: Request):
+        req_id = random_uuid()
+        self._set_request_id(req_id)
+        logger.info(
+            "image_edit model=%s prompt=%r n=%d size=%s mask=%s",
+            request.model,
+            request.prompt,
+            request.n,
+            request.size,
+            request.mask is not None,
+        )
+        handle = self._get_handle(request.model)
+        watcher = RequestWatcher(raw_request, model=request.model, endpoint="create_image_edit")
+        headers = dict(raw_request.headers)
+        # Read image bytes before crossing the process boundary — UploadFile is not serializable.
+        # The bytes are passed separately; the request is reconstructed without the file fields.
+        image_data = await request.image.read()
+        mask_data = await request.mask.read() if request.mask is not None else None
+        request_no_file = ImageEditRequest.model_construct(**request.model_dump(exclude={"image", "mask"}))
+        response_gen = handle.edit_image.options(stream=True).remote(
+            image_data, mask_data, request_no_file, headers, watcher.event, req_id
+        )
+        return await self._handle_response(response_gen, watcher, request.model, "create_image_edit")
+
+    @app.post("/v1/images/variations")
+    async def create_image_variation(self, request: Annotated[ImageVariationRequest, Form()], raw_request: Request):
+        req_id = random_uuid()
+        self._set_request_id(req_id)
+        logger.info("image_variation model=%s n=%d size=%s", request.model, request.n, request.size)
+        handle = self._get_handle(request.model)
+        watcher = RequestWatcher(raw_request, model=request.model, endpoint="create_image_variation")
+        headers = dict(raw_request.headers)
+        # Read image bytes before crossing the process boundary — UploadFile is not serializable.
+        image_data = await request.image.read()
+        request_no_file = ImageVariationRequest.model_construct(**request.model_dump(exclude={"image"}))
+        response_gen = handle.vary_image.options(stream=True).remote(
+            image_data, request_no_file, headers, watcher.event, req_id
+        )
+        return await self._handle_response(response_gen, watcher, request.model, "create_image_variation")

--- a/modelship/openai/protocol.py
+++ b/modelship/openai/protocol.py
@@ -513,6 +513,41 @@ class ImageGenerationRequest(OpenAIBaseModel):
     )
 
 
+class ImageEditRequest(OpenAIBaseModel):
+    image: UploadFile = Field(..., description="The image to edit.")
+    prompt: str = Field(..., description="A text description of the desired edit.")
+    mask: UploadFile | None = Field(
+        default=None,
+        description="An optional mask; fully transparent areas indicate where the image should be edited (inpainting).",
+    )
+    model: str = Field(..., description="The model to use for image editing.")
+    n: int = Field(default=1, ge=1, le=10, description="The number of edited images to generate.")
+    size: str = Field(default="512x512", description="The size of the generated images in WxH format.")
+    response_format: Literal["b64_json"] = Field(
+        default="b64_json",
+        description="The format in which the generated images are returned.",
+    )
+    # modelship extension (not in OpenAI spec) — controls how far the output may
+    # diverge from the input image (0.0 keeps it, 1.0 ignores it). Defaults are
+    # applied serving-side. Documented in docs/extensions.md.
+    strength: float | None = Field(default=None, ge=0.0, le=1.0)
+
+
+class ImageVariationRequest(OpenAIBaseModel):
+    image: UploadFile = Field(..., description="The image to use as the basis for the variation(s).")
+    model: str = Field(..., description="The model to use for image variations.")
+    n: int = Field(default=1, ge=1, le=10, description="The number of variations to generate.")
+    size: str = Field(default="512x512", description="The size of the generated images in WxH format.")
+    response_format: Literal["b64_json"] = Field(
+        default="b64_json",
+        description="The format in which the generated images are returned.",
+    )
+    # modelship extension (not in OpenAI spec) — controls how far each variation
+    # diverges from the input image (0.0 keeps it, 1.0 ignores it). Defaults are
+    # applied serving-side. Documented in docs/extensions.md.
+    strength: float | None = Field(default=None, ge=0.0, le=1.0)
+
+
 class ImageObject(OpenAIBaseModel):
     b64_json: str = Field(..., description="The base64-encoded JSON of the generated image.")
     revised_prompt: str | None = Field(default=None, description="The prompt that was used to generate the image.")
@@ -549,9 +584,11 @@ __all__ = [
     "ErrorInfo",
     "ErrorResponse",
     "FunctionCall",
+    "ImageEditRequest",
     "ImageGenerationRequest",
     "ImageGenerationResponse",
     "ImageObject",
+    "ImageVariationRequest",
     "OpenAIBaseModel",
     "PromptTokenUsageInfo",
     "RawChatCompletion",

--- a/modelship/plugins/base_plugin.py
+++ b/modelship/plugins/base_plugin.py
@@ -118,6 +118,30 @@ class BasePlugin(ABC):
         """Returns a list of PNG-encoded image bytes."""
         return _NOT_SUPPORTED
 
+    async def create_image_edit(
+        self,
+        image_data: bytes,
+        mask_data: bytes | None = None,
+        prompt: str | None = None,
+        n: int = 1,
+        size: str | None = None,
+        strength: float | None = None,
+        request_id: str | None = None,
+    ) -> list[bytes] | ErrorResponse:
+        """Returns a list of PNG-encoded image bytes."""
+        return _NOT_SUPPORTED
+
+    async def create_image_variation(
+        self,
+        image_data: bytes,
+        n: int = 1,
+        size: str | None = None,
+        strength: float | None = None,
+        request_id: str | None = None,
+    ) -> list[bytes] | ErrorResponse:
+        """Returns a list of PNG-encoded image bytes."""
+        return _NOT_SUPPORTED
+
 
 class PluginProto(Protocol):
     ModelPlugin: type[BasePlugin]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -154,6 +154,7 @@ markers = [
     "integration: tests that require a running Ray cluster and external models",
     "llama_cpp: integration tests that exercise the llama_cpp loader",
     "vllm: integration tests that exercise the vllm loader",
+    "diffusers: integration tests that exercise the diffusers loader",
 ]
 
 [tool.pyright]

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,6 +1,6 @@
 """Tests for ModelshipAPI model discovery and routing."""
 
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -194,6 +194,77 @@ class TestGetHandle:
 
         with pytest.raises(HTTPException):
             api._get_handle(None)
+
+
+class TestImageEditRoutes:
+    @pytest.mark.asyncio
+    async def test_edit_reads_upload_before_ray_boundary(self, api):
+        import io
+
+        from fastapi import UploadFile
+
+        from modelship.openai.protocol import ImageEditRequest
+
+        handle = MagicMock()
+        remote = handle.edit_image.options.return_value.remote
+        api.models = {"sdxl": {"sdxl-a1b2c": handle}}
+        api._round_robin = {"sdxl": 0}
+
+        request = ImageEditRequest(
+            image=UploadFile(file=io.BytesIO(b"IMAGE_BYTES"), filename="i.png"),
+            mask=UploadFile(file=io.BytesIO(b"MASK_BYTES"), filename="m.png"),
+            prompt="add a hat",
+            model="sdxl",
+        )
+        raw_request = MagicMock()
+        raw_request.headers = {}
+
+        with (
+            patch("modelship.openai.api.RequestWatcher"),
+            patch.object(api, "_handle_response", new=AsyncMock(return_value="OK")) as handle_response,
+        ):
+            result = await api.create_image_edit(request, raw_request)
+
+        assert result == "OK"
+        # The upload bytes must be read in the gateway, not handed to the actor as UploadFile.
+        args, _ = remote.call_args
+        image_data, mask_data, request_no_file = args[0], args[1], args[2]
+        assert image_data == b"IMAGE_BYTES"
+        assert mask_data == b"MASK_BYTES"
+        # The UploadFile must not cross the boundary; bytes are passed separately.
+        dumped = request_no_file.model_dump()
+        assert "image" not in dumped
+        assert dumped.get("mask") is None
+        handle_response.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_variation_reads_upload_and_omits_mask(self, api):
+        import io
+
+        from fastapi import UploadFile
+
+        from modelship.openai.protocol import ImageVariationRequest
+
+        handle = MagicMock()
+        remote = handle.vary_image.options.return_value.remote
+        api.models = {"sdxl": {"sdxl-a1b2c": handle}}
+        api._round_robin = {"sdxl": 0}
+
+        request = ImageVariationRequest(
+            image=UploadFile(file=io.BytesIO(b"IMAGE_BYTES"), filename="i.png"),
+            model="sdxl",
+        )
+        raw_request = MagicMock()
+        raw_request.headers = {}
+
+        with (
+            patch("modelship.openai.api.RequestWatcher"),
+            patch.object(api, "_handle_response", new=AsyncMock(return_value="OK")),
+        ):
+            await api.create_image_variation(request, raw_request)
+
+        args, _ = remote.call_args
+        assert args[0] == b"IMAGE_BYTES"
 
 
 class TestHandleResponse:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -107,6 +107,32 @@ class TestModelshipModelConfig:
                 usecase=ModelUsecase.generate,
             )
 
+    def test_diffusers_usecase_defaults_to_image(self):
+        config = ModelshipModelConfig(
+            name="test-image",
+            model="stabilityai/sdxl-turbo",
+            loader=ModelLoader.diffusers,
+        )
+        assert config.usecase is ModelUsecase.image
+
+    def test_diffusers_explicit_image_usecase_ok(self):
+        config = ModelshipModelConfig(
+            name="test-image",
+            model="stabilityai/sdxl-turbo",
+            usecase=ModelUsecase.image,
+            loader=ModelLoader.diffusers,
+        )
+        assert config.usecase is ModelUsecase.image
+
+    def test_diffusers_rejects_non_image_usecase(self):
+        with pytest.raises(ValidationError, match="loader='diffusers' only supports usecase='image'"):
+            ModelshipModelConfig(
+                name="test-image",
+                model="stabilityai/sdxl-turbo",
+                usecase=ModelUsecase.generate,
+                loader=ModelLoader.diffusers,
+            )
+
     def test_gpu_allocation_fraction(self):
         config = ModelshipModelConfig(
             name="test-llm",
@@ -224,7 +250,9 @@ class TestModelshipModelConfig:
 
     def test_all_loaders_valid(self):
         for loader in ModelLoader:
-            kwargs = {"name": "test", "model": "some-model", "usecase": ModelUsecase.generate}
+            # diffusers is image-only; every other loader supports generate.
+            usecase = ModelUsecase.image if loader == ModelLoader.diffusers else ModelUsecase.generate
+            kwargs = {"name": "test", "model": "some-model", "usecase": usecase}
             if loader == ModelLoader.custom:
                 kwargs["plugin"] = "test-plugin"
             config = ModelshipModelConfig(loader=loader, **kwargs)

--- a/tests/test_diffusers_image.py
+++ b/tests/test_diffusers_image.py
@@ -41,6 +41,19 @@ def _png_bytes(w: int = 16, h: int = 16) -> bytes:
     return buf.getvalue()
 
 
+def _rgba_png(w: int = 16, h: int = 16, *, transparent: bool) -> bytes:
+    """An RGBA PNG. With ``transparent=True`` a central square has alpha 0
+    (the OpenAI 'edit here' region); otherwise the image is fully opaque."""
+    img = Image.new("RGBA", (w, h), (200, 100, 50, 255))
+    if transparent:
+        for x in range(w // 4, w * 3 // 4):
+            for y in range(h // 4, h * 3 // 4):
+                img.putpixel((x, y), (0, 0, 0, 0))
+    buf = io.BytesIO()
+    img.save(buf, format="PNG")
+    return buf.getvalue()
+
+
 def _serving(img2img=None, inpaint=None) -> OpenAIServingImage:
     return OpenAIServingImage(
         pipeline=_StubPipeline(),  # type: ignore[arg-type]
@@ -95,6 +108,33 @@ class TestImageEdit:
         call = inpaint.calls[0]
         assert call["strength"] == 0.5
         assert "mask_image" in call
+
+    async def test_edit_transparent_image_no_mask_uses_inpaint(self):
+        # RGBA input with transparency + no separate mask -> alpha is the mask.
+        img2img = _StubPipeline()
+        inpaint = _StubPipeline()
+        serving = _serving(img2img=img2img, inpaint=inpaint)
+        request = ImageEditRequest.model_construct(model="m", prompt="fill", n=1, size="16x16", strength=None)
+
+        result = await serving.create_image_edit(_rgba_png(transparent=True), None, request, _proxy())
+
+        assert isinstance(result, ImageGenerationResponse)
+        assert len(inpaint.calls) == 1
+        assert len(img2img.calls) == 0
+        assert "mask_image" in inpaint.calls[0]
+
+    async def test_edit_opaque_rgba_no_mask_uses_img2img(self):
+        # RGBA input with no transparent pixels falls back to plain img2img.
+        img2img = _StubPipeline()
+        inpaint = _StubPipeline()
+        serving = _serving(img2img=img2img, inpaint=inpaint)
+        request = ImageEditRequest.model_construct(model="m", prompt="x", n=1, size="16x16", strength=None)
+
+        result = await serving.create_image_edit(_rgba_png(transparent=False), None, request, _proxy())
+
+        assert isinstance(result, ImageGenerationResponse)
+        assert len(img2img.calls) == 1
+        assert len(inpaint.calls) == 0
 
     async def test_edit_missing_img2img_pipeline_errors(self):
         serving = _serving(img2img=None)

--- a/tests/test_diffusers_image.py
+++ b/tests/test_diffusers_image.py
@@ -1,0 +1,176 @@
+import base64
+import io
+
+import pytest
+from pydantic import ValidationError
+
+pytest.importorskip("diffusers")
+
+from PIL import Image
+
+from modelship.infer.diffusers.openai.serving_image import (
+    _DEFAULT_EDIT_STRENGTH,
+    _DEFAULT_VARIATION_STRENGTH,
+    OpenAIServingImage,
+)
+from modelship.infer.infer_config import DiffusersConfig, RawRequestProxy
+from modelship.openai.protocol import (
+    ErrorResponse,
+    ImageEditRequest,
+    ImageGenerationResponse,
+    ImageVariationRequest,
+)
+
+
+class _StubPipeline:
+    """Records the kwargs it was called with and returns `n` solid PIL images."""
+
+    def __init__(self):
+        self.calls: list[dict] = []
+
+    def __call__(self, **kwargs):
+        self.calls.append(kwargs)
+        n = kwargs.get("num_images_per_prompt", 1)
+        images = [Image.new("RGB", (8, 8), (10, 20, 30)) for _ in range(n)]
+        return type("Result", (), {"images": images})()
+
+
+def _png_bytes(w: int = 16, h: int = 16) -> bytes:
+    buf = io.BytesIO()
+    Image.new("RGB", (w, h), (200, 100, 50)).save(buf, format="PNG")
+    return buf.getvalue()
+
+
+def _serving(img2img=None, inpaint=None) -> OpenAIServingImage:
+    return OpenAIServingImage(
+        pipeline=_StubPipeline(),  # type: ignore[arg-type]
+        config=DiffusersConfig(num_inference_steps=5, guidance_scale=3.0),
+        img2img_pipeline=img2img,
+        inpaint_pipeline=inpaint,
+    )
+
+
+def _proxy() -> RawRequestProxy:
+    return RawRequestProxy(None, {})
+
+
+def _assert_valid_b64_image(obj) -> None:
+    raw = base64.b64decode(obj.b64_json)
+    Image.open(io.BytesIO(raw)).verify()
+
+
+@pytest.mark.asyncio
+class TestImageEdit:
+    async def test_edit_without_mask_uses_img2img(self):
+        img2img = _StubPipeline()
+        serving = _serving(img2img=img2img)
+        request = ImageEditRequest.model_construct(model="m", prompt="add a hat", n=2, size="32x32", strength=None)
+
+        result = await serving.create_image_edit(_png_bytes(), None, request, _proxy())
+
+        assert isinstance(result, ImageGenerationResponse)
+        assert len(result.data) == 2
+        for obj in result.data:
+            assert obj.revised_prompt == "add a hat"
+            _assert_valid_b64_image(obj)
+        assert len(img2img.calls) == 1
+        call = img2img.calls[0]
+        assert call["prompt"] == "add a hat"
+        assert call["strength"] == _DEFAULT_EDIT_STRENGTH
+        assert call["num_inference_steps"] == 5
+        assert call["guidance_scale"] == 3.0
+        assert "mask_image" not in call
+
+    async def test_edit_with_mask_uses_inpaint(self):
+        img2img = _StubPipeline()
+        inpaint = _StubPipeline()
+        serving = _serving(img2img=img2img, inpaint=inpaint)
+        request = ImageEditRequest.model_construct(model="m", prompt="erase", n=1, size="16x16", strength=0.5)
+
+        result = await serving.create_image_edit(_png_bytes(), _png_bytes(), request, _proxy())
+
+        assert isinstance(result, ImageGenerationResponse)
+        assert len(inpaint.calls) == 1
+        assert len(img2img.calls) == 0
+        call = inpaint.calls[0]
+        assert call["strength"] == 0.5
+        assert "mask_image" in call
+
+    async def test_edit_missing_img2img_pipeline_errors(self):
+        serving = _serving(img2img=None)
+        request = ImageEditRequest.model_construct(model="m", prompt="x", n=1, size="16x16", strength=None)
+        result = await serving.create_image_edit(_png_bytes(), None, request, _proxy())
+        assert isinstance(result, ErrorResponse)
+
+    async def test_edit_missing_inpaint_pipeline_errors(self):
+        serving = _serving(img2img=_StubPipeline(), inpaint=None)
+        request = ImageEditRequest.model_construct(model="m", prompt="x", n=1, size="16x16", strength=None)
+        result = await serving.create_image_edit(_png_bytes(), _png_bytes(), request, _proxy())
+        assert isinstance(result, ErrorResponse)
+
+    async def test_edit_bad_image_bytes_errors(self):
+        serving = _serving(img2img=_StubPipeline())
+        request = ImageEditRequest.model_construct(model="m", prompt="x", n=1, size="16x16", strength=None)
+        result = await serving.create_image_edit(b"not an image", None, request, _proxy())
+        assert isinstance(result, ErrorResponse)
+
+    async def test_edit_invalid_size_errors(self):
+        serving = _serving(img2img=_StubPipeline())
+        request = ImageEditRequest.model_construct(model="m", prompt="x", n=1, size="nonsense", strength=None)
+        result = await serving.create_image_edit(_png_bytes(), None, request, _proxy())
+        assert isinstance(result, ErrorResponse)
+
+
+@pytest.mark.asyncio
+class TestImageVariation:
+    async def test_variation_uses_img2img_with_empty_prompt(self):
+        img2img = _StubPipeline()
+        serving = _serving(img2img=img2img)
+        request = ImageVariationRequest.model_construct(model="m", n=3, size="16x16", strength=None)
+
+        result = await serving.create_image_variation(_png_bytes(), request, _proxy())
+
+        assert isinstance(result, ImageGenerationResponse)
+        assert len(result.data) == 3
+        for obj in result.data:
+            assert obj.revised_prompt is None
+            _assert_valid_b64_image(obj)
+        call = img2img.calls[0]
+        assert call["prompt"] == ""
+        assert call["strength"] == _DEFAULT_VARIATION_STRENGTH
+
+    async def test_variation_respects_request_strength(self):
+        img2img = _StubPipeline()
+        serving = _serving(img2img=img2img)
+        request = ImageVariationRequest.model_construct(model="m", n=1, size="16x16", strength=0.9)
+        await serving.create_image_variation(_png_bytes(), request, _proxy())
+        assert img2img.calls[0]["strength"] == 0.9
+
+    async def test_variation_missing_img2img_pipeline_errors(self):
+        serving = _serving(img2img=None)
+        request = ImageVariationRequest.model_construct(model="m", n=1, size="16x16", strength=None)
+        result = await serving.create_image_variation(_png_bytes(), request, _proxy())
+        assert isinstance(result, ErrorResponse)
+
+
+class TestProtocolResponseFormat:
+    @staticmethod
+    def _upload():
+        from fastapi import UploadFile
+
+        return UploadFile(file=io.BytesIO(b"x"), filename="x.png")
+
+    def test_edit_rejects_non_b64_response_format(self):
+        with pytest.raises(ValidationError) as exc:
+            ImageEditRequest(image=self._upload(), prompt="p", model="m", response_format="url")  # type: ignore[arg-type]
+        assert any(e["loc"] == ("response_format",) for e in exc.value.errors())
+
+    def test_variation_rejects_non_b64_response_format(self):
+        with pytest.raises(ValidationError) as exc:
+            ImageVariationRequest(image=self._upload(), model="m", response_format="url")  # type: ignore[arg-type]
+        assert any(e["loc"] == ("response_format",) for e in exc.value.errors())
+
+    def test_strength_bounds_enforced(self):
+        with pytest.raises(ValidationError) as exc:
+            ImageEditRequest(image=self._upload(), prompt="p", model="m", strength=2.0)
+        assert any(e["loc"] == ("strength",) for e in exc.value.errors())

--- a/tests/test_diffusers_image.py
+++ b/tests/test_diffusers_image.py
@@ -1,5 +1,8 @@
+import asyncio
 import base64
 import io
+import threading
+import time
 
 import pytest
 from pydantic import ValidationError
@@ -33,6 +36,25 @@ class _StubPipeline:
         n = kwargs.get("num_images_per_prompt", 1)
         images = [Image.new("RGB", (8, 8), (10, 20, 30)) for _ in range(n)]
         return type("Result", (), {"images": images})()
+
+
+class _ConcurrencyProbe:
+    """Stub pipeline that records the peak number of overlapping calls."""
+
+    def __init__(self):
+        self.active = 0
+        self.max_active = 0
+        self._lock = threading.Lock()
+
+    def __call__(self, **kwargs):
+        with self._lock:
+            self.active += 1
+            self.max_active = max(self.max_active, self.active)
+        time.sleep(0.05)  # widen the window so unserialized calls would overlap
+        with self._lock:
+            self.active -= 1
+        n = kwargs.get("num_images_per_prompt", 1)
+        return type("Result", (), {"images": [Image.new("RGB", (8, 8)) for _ in range(n)]})()
 
 
 def _png_bytes(w: int = 16, h: int = 16) -> bytes:
@@ -215,6 +237,18 @@ class TestImageVariation:
         request = ImageVariationRequest.model_construct(model="m", n=1, size="16x16", strength=None)
         result = await serving.create_image_variation(_png_bytes(), request, _proxy())
         assert isinstance(result, ErrorResponse)
+
+    async def test_concurrent_inference_is_serialized(self):
+        # The GPU lock must serialize pipeline forward passes — two concurrent
+        # requests should never overlap inside the (non-thread-safe) pipeline.
+        probe = _ConcurrencyProbe()
+        serving = _serving(img2img=probe)
+        request = ImageVariationRequest.model_construct(model="m", n=1, size="16x16", strength=None)
+        await asyncio.gather(
+            serving.create_image_variation(_png_bytes(), request, _proxy()),
+            serving.create_image_variation(_png_bytes(), request, _proxy()),
+        )
+        assert probe.max_active == 1
 
 
 class TestProtocolResponseFormat:

--- a/tests/test_diffusers_image.py
+++ b/tests/test_diffusers_image.py
@@ -173,6 +173,19 @@ class TestImageEdit:
         assert mask.getpixel((8, 8)) == 255  # transparent center -> edit
         assert mask.getpixel((0, 0)) == 0  # opaque corner -> keep
 
+    async def test_edit_mask_has_soft_edges_when_resized(self):
+        # Thresholding before the resize lets interpolation soften the binary
+        # edge into a gradient when the mask is scaled to a different size.
+        inpaint = _StubPipeline()
+        serving = _serving(img2img=_StubPipeline(), inpaint=inpaint)
+        request = ImageEditRequest.model_construct(model="m", prompt="x", n=1, size="64x64", strength=None)
+
+        await serving.create_image_edit(_rgba_png(16, 16, transparent=True), None, request, _proxy())
+
+        mask = inpaint.calls[0]["mask_image"]
+        assert mask.size == (64, 64)
+        assert any(0 < v < 255 for v in mask.getdata())  # anti-aliased boundary
+
     async def test_edit_missing_img2img_pipeline_errors(self):
         serving = _serving(img2img=None)
         request = ImageEditRequest.model_construct(model="m", prompt="x", n=1, size="16x16", strength=None)

--- a/tests/test_diffusers_image.py
+++ b/tests/test_diffusers_image.py
@@ -136,6 +136,21 @@ class TestImageEdit:
         assert len(img2img.calls) == 1
         assert len(inpaint.calls) == 0
 
+    async def test_edit_rgba_mask_uses_alpha_channel(self):
+        # OpenAI masks encode the edit region in the alpha channel (transparent
+        # = edit), not luminance. The derived diffusers mask must be white
+        # (repaint) where the upload was transparent and black where opaque.
+        inpaint = _StubPipeline()
+        serving = _serving(img2img=_StubPipeline(), inpaint=inpaint)
+        request = ImageEditRequest.model_construct(model="m", prompt="fill", n=1, size="16x16", strength=None)
+
+        result = await serving.create_image_edit(_png_bytes(), _rgba_png(transparent=True), request, _proxy())
+
+        assert isinstance(result, ImageGenerationResponse)
+        mask = inpaint.calls[0]["mask_image"]
+        assert mask.getpixel((8, 8)) == 255  # transparent center -> edit
+        assert mask.getpixel((0, 0)) == 0  # opaque corner -> keep
+
     async def test_edit_missing_img2img_pipeline_errors(self):
         serving = _serving(img2img=None)
         request = ImageEditRequest.model_construct(model="m", prompt="x", n=1, size="16x16", strength=None)

--- a/tests/test_diffusers_image.py
+++ b/tests/test_diffusers_image.py
@@ -169,6 +169,15 @@ class TestImageEdit:
         result = await serving.create_image_edit(b"not an image", None, request, _proxy())
         assert isinstance(result, ErrorResponse)
 
+    async def test_edit_truncated_image_errors(self):
+        # Headers parse but pixel data is cut off — must surface as an error,
+        # not an uncaught OSError from a later convert()/resize().
+        full = _png_bytes(64, 64)
+        serving = _serving(img2img=_StubPipeline())
+        request = ImageEditRequest.model_construct(model="m", prompt="x", n=1, size="64x64", strength=None)
+        result = await serving.create_image_edit(full[: len(full) // 2], None, request, _proxy())
+        assert isinstance(result, ErrorResponse)
+
     async def test_edit_invalid_size_errors(self):
         serving = _serving(img2img=_StubPipeline())
         request = ImageEditRequest.model_construct(model="m", prompt="x", n=1, size="nonsense", strength=None)

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1,3 +1,5 @@
+import base64
+import io
 import json
 import subprocess
 import time
@@ -206,6 +208,14 @@ MODEL_CONFIGS: dict[str, dict] = {
         "plugin": "kokoroonnx",
         "num_cpus": 1,
         "plugin_config": {"onnx_provider": "CPUExecutionProvider"},
+    },
+    "image-model": {
+        "name": "image-model",
+        "model": "stabilityai/sdxl-turbo",
+        "usecase": "image",
+        "loader": "diffusers",
+        "num_gpus": 1,
+        "diffusers_config": {"num_inference_steps": 2, "guidance_scale": 0.0},
     },
 }
 
@@ -1457,6 +1467,103 @@ class TestAudio:
         with open(audio_file, "rb") as f:
             transcription = client.audio.transcriptions.create(model="stt-model", file=f)
         assert "test" in transcription.text.lower()
+
+
+@pytest.mark.integration
+@pytest.mark.diffusers
+class TestImage:
+    """End-to-end image generation, editing and variations through the
+    diffusers loader. One sdxl-turbo deployment backs all three endpoints
+    (text2img + img2img + inpaint, weight-shared via from_pipe). The generated
+    image is reused as the input for the edit and variation calls."""
+
+    SIZE = "512x512"
+
+    @pytest.fixture(autouse=True, scope="class")
+    def _deploy(self, model_deployer):
+        model_deployer.deploy("image-model")
+
+    @staticmethod
+    def _decode(b64: str) -> bytes:
+        return base64.b64decode(b64)
+
+    @staticmethod
+    def _assert_png(data: bytes, *, expect_size: tuple[int, int] | None = None) -> None:
+        from PIL import Image
+
+        img = Image.open(io.BytesIO(data))
+        img.verify()
+        assert img.format == "PNG"
+        if expect_size is not None:
+            assert img.size == expect_size
+
+    def test_image_generation(self, client):
+        response = client.images.generate(
+            model="image-model", prompt="a red apple on a table", size=self.SIZE, response_format="b64_json"
+        )
+        assert response.data[0].b64_json
+        self._assert_png(self._decode(response.data[0].b64_json), expect_size=(512, 512))
+
+    def test_image_edit(self, client, tmp_path):
+        source = client.images.generate(
+            model="image-model", prompt="a plain blue sky", size=self.SIZE, response_format="b64_json"
+        )
+        image_path = tmp_path / "source.png"
+        image_path.write_bytes(self._decode(source.data[0].b64_json))
+
+        with open(image_path, "rb") as f:
+            edited = client.images.edit(
+                model="image-model",
+                image=f,
+                prompt="a blue sky with a bright sun",
+                size=self.SIZE,
+                response_format="b64_json",
+            )
+        assert edited.data[0].b64_json
+        self._assert_png(self._decode(edited.data[0].b64_json), expect_size=(512, 512))
+
+    def test_image_edit_with_mask(self, client, tmp_path):
+        from PIL import Image
+
+        source = client.images.generate(
+            model="image-model", prompt="a grassy field", size=self.SIZE, response_format="b64_json"
+        )
+        image_path = tmp_path / "source.png"
+        image_path.write_bytes(self._decode(source.data[0].b64_json))
+
+        # White rectangle marks the region to repaint; the rest is preserved.
+        mask = Image.new("RGB", (512, 512), (0, 0, 0))
+        for x in range(128, 384):
+            for y in range(128, 384):
+                mask.putpixel((x, y), (255, 255, 255))
+        mask_path = tmp_path / "mask.png"
+        mask.save(mask_path, format="PNG")
+
+        with open(image_path, "rb") as img_f, open(mask_path, "rb") as mask_f:
+            edited = client.images.edit(
+                model="image-model",
+                image=img_f,
+                mask=mask_f,
+                prompt="a grassy field with a small red flower",
+                size=self.SIZE,
+                response_format="b64_json",
+            )
+        assert edited.data[0].b64_json
+        self._assert_png(self._decode(edited.data[0].b64_json), expect_size=(512, 512))
+
+    def test_image_variation(self, client, tmp_path):
+        source = client.images.generate(
+            model="image-model", prompt="a yellow lemon", size=self.SIZE, response_format="b64_json"
+        )
+        image_path = tmp_path / "source.png"
+        image_path.write_bytes(self._decode(source.data[0].b64_json))
+
+        with open(image_path, "rb") as f:
+            variation = client.images.create_variation(
+                model="image-model", image=f, size=self.SIZE, response_format="b64_json"
+            )
+        assert variation.data[0].b64_json
+        self._assert_png(self._decode(variation.data[0].b64_json), expect_size=(512, 512))
 
 
 @pytest.mark.integration

--- a/tests/test_parser_resolution.py
+++ b/tests/test_parser_resolution.py
@@ -84,7 +84,7 @@ class TestResolveReasoningParsers:
         assert cfg._resolved_reasoning_parser is None
 
     def test_skips_non_applicable_loader(self):
-        cfg = _make_cfg(loader=ModelLoader.diffusers)
+        cfg = _make_cfg(loader=ModelLoader.diffusers, usecase=ModelUsecase.image)
         cfg._resolved_chat_template = "<think>x</think>"
         resolve_all_reasoning_parsers(ModelshipConfig(models=[cfg]))
         assert cfg._resolved_reasoning_parser is None


### PR DESCRIPTION
Add OpenAI-compatible image editing and variation endpoints on the Diffusers loader. img2img and inpaint pipelines are built from the text2img pipeline via from_pipe, so they share weights at ~zero extra VRAM. Edits dispatch to inpaint when a mask is supplied, otherwise img2img; variations run img2img with an empty prompt.

Request shapes mirror the OpenAI spec; the only extension is a per-request `strength` (img2img divergence), kept as a deliberate deviation. num_inference_steps/guidance_scale stay per-deployment in DiffusersConfig. b64_json output only, single input image.

Adds unit tests (serving layer + gateway upload handling) and a GPU-gated integration suite (TestImage) behind a new `diffusers` marker.


