### PR TITLE
fix(diffusers): accept Open WebUI image[] edit uploads and log 422s

### DIFF
--- a/modelship/openai/api.py
+++ b/modelship/openai/api.py
@@ -4,6 +4,8 @@ from http import HTTPStatus
 from typing import Annotated
 
 from fastapi import FastAPI, Form, HTTPException, Request
+from fastapi.encoders import jsonable_encoder
+from fastapi.exceptions import RequestValidationError
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse, Response, StreamingResponse
 from pydantic import BaseModel, Field
@@ -84,6 +86,11 @@ def build_app():
         logger.info("API key authentication enabled (%d key(s))", len(api_keys))
     else:
         logger.warning("API key authentication disabled (MSHIP_API_KEYS not set)")
+
+    @app.exception_handler(RequestValidationError)
+    async def log_validation_error(request: Request, exc: RequestValidationError):
+        logger.warning("%s %s -> 422 validation error: %s", request.method, request.url.path, exc.errors())
+        return JSONResponse(status_code=422, content={"detail": jsonable_encoder(exc.errors())})
 
     @app.exception_handler(HTTPException)
     async def log_http_exception(request: Request, exc: HTTPException):

--- a/modelship/openai/api.py
+++ b/modelship/openai/api.py
@@ -506,6 +506,9 @@ class ModelshipAPI:
         headers = dict(raw_request.headers)
         # Read image bytes before crossing the process boundary — UploadFile is not serializable.
         # The bytes are passed separately; the request is reconstructed without the file fields.
+        # `image` is Optional on the model (to accept the `image[]` alias) but the validator
+        # guarantees it is set post-validation.
+        assert request.image is not None
         try:
             image_data = await request.image.read()
             mask_data = await request.mask.read() if request.mask is not None else None
@@ -528,6 +531,9 @@ class ModelshipAPI:
         watcher = RequestWatcher(raw_request, model=request.model, endpoint="create_image_variation")
         headers = dict(raw_request.headers)
         # Read image bytes before crossing the process boundary — UploadFile is not serializable.
+        # `image` is Optional on the model (to accept the `image[]` alias) but the validator
+        # guarantees it is set post-validation.
+        assert request.image is not None
         try:
             image_data = await request.image.read()
         finally:

--- a/modelship/openai/protocol.py
+++ b/modelship/openai/protocol.py
@@ -513,26 +513,37 @@ class ImageGenerationRequest(OpenAIBaseModel):
     )
 
 
-def _accept_bracketed_image(data: Any) -> Any:
-    """Map the `image[]` array form key onto the singular `image` field.
+# Type for the OpenAI `image[]` array field: a single upload, a list of uploads
+# (the spec allows several), or absent. Declared as an explicit aliased field on
+# the request models below rather than relying on extra-field forwarding.
+_ImageArray = UploadFile | list[UploadFile] | None
+
+
+def _coalesce_image_array(image: UploadFile | None, image_array: _ImageArray) -> UploadFile:
+    """Fold the OpenAI `image[]` array form onto the singular `image`.
 
     OpenAI's gpt-image-1 edits/variations accept the upload as an array under
     `image[]` (multiple input images), while the older DALL·E 2 form uses the
-    singular `image`. Clients such as Open WebUI send `image[]`; accept it and
-    take the first image (the diffusers img2img path uses a single image)."""
-    if isinstance(data, dict) and "image" not in data and "image[]" in data:
-        data = dict(data)
-        # Pop, not copy: extra="allow" would otherwise keep `image[]` as an
-        # extra attribute holding an UploadFile, which then rides along through
-        # model_dump() and fails to serialize across the Ray process boundary.
-        value = data.pop("image[]")
-        # A repeated form key may arrive as a list of uploads; take the first.
-        data["image"] = value[0] if isinstance(value, list) else value
-    return data
+    singular `image`. Clients such as Open WebUI send `image[]`. Prefer an
+    explicit `image`; otherwise take the first `image[]` entry (the diffusers
+    img2img path uses a single image). Raise if neither was supplied."""
+    if image is not None:
+        return image
+    if isinstance(image_array, list):
+        image_array = image_array[0] if image_array else None
+    if image_array is None:
+        raise ValueError("Field required: provide 'image' (or 'image[]')")
+    return image_array
 
 
 class ImageEditRequest(OpenAIBaseModel):
-    image: UploadFile = Field(..., description="The image to edit.")
+    image: UploadFile | None = Field(default=None, description="The image to edit.")
+    # OpenAI gpt-image-1 sends the upload as the array field `image[]`; declare it
+    # explicitly (aliased) so FastAPI's form decomposition extracts it without
+    # depending on extra-field forwarding. exclude=True keeps the UploadFile out
+    # of model_dump() so it never crosses the Ray process boundary; the validator
+    # folds it into `image`.
+    image_array: _ImageArray = Field(default=None, alias="image[]", exclude=True)
     prompt: str = Field(..., description="A text description of the desired edit.")
     mask: UploadFile | None = Field(
         default=None,
@@ -550,11 +561,16 @@ class ImageEditRequest(OpenAIBaseModel):
     # applied serving-side. Documented in docs/extensions.md.
     strength: float | None = Field(default=None, ge=0.0, le=1.0)
 
-    _accept_image_array = model_validator(mode="before")(_accept_bracketed_image)
+    @model_validator(mode="after")
+    def _accept_image_array(self) -> "ImageEditRequest":
+        self.image = _coalesce_image_array(self.image, self.image_array)
+        self.image_array = None
+        return self
 
 
 class ImageVariationRequest(OpenAIBaseModel):
-    image: UploadFile = Field(..., description="The image to use as the basis for the variation(s).")
+    image: UploadFile | None = Field(default=None, description="The image to use as the basis for the variation(s).")
+    image_array: _ImageArray = Field(default=None, alias="image[]", exclude=True)
     model: str = Field(..., description="The model to use for image variations.")
     n: int = Field(default=1, ge=1, le=10, description="The number of variations to generate.")
     size: str = Field(default="512x512", description="The size of the generated images in WxH format.")
@@ -567,7 +583,11 @@ class ImageVariationRequest(OpenAIBaseModel):
     # applied serving-side. Documented in docs/extensions.md.
     strength: float | None = Field(default=None, ge=0.0, le=1.0)
 
-    _accept_image_array = model_validator(mode="before")(_accept_bracketed_image)
+    @model_validator(mode="after")
+    def _accept_image_array(self) -> "ImageVariationRequest":
+        self.image = _coalesce_image_array(self.image, self.image_array)
+        self.image_array = None
+        return self
 
 
 class ImageObject(OpenAIBaseModel):

--- a/modelship/openai/protocol.py
+++ b/modelship/openai/protocol.py
@@ -513,6 +513,24 @@ class ImageGenerationRequest(OpenAIBaseModel):
     )
 
 
+def _accept_bracketed_image(data: Any) -> Any:
+    """Map the `image[]` array form key onto the singular `image` field.
+
+    OpenAI's gpt-image-1 edits/variations accept the upload as an array under
+    `image[]` (multiple input images), while the older DALL·E 2 form uses the
+    singular `image`. Clients such as Open WebUI send `image[]`; accept it and
+    take the first image (the diffusers img2img path uses a single image)."""
+    if isinstance(data, dict) and "image" not in data and "image[]" in data:
+        data = dict(data)
+        # Pop, not copy: extra="allow" would otherwise keep `image[]` as an
+        # extra attribute holding an UploadFile, which then rides along through
+        # model_dump() and fails to serialize across the Ray process boundary.
+        value = data.pop("image[]")
+        # A repeated form key may arrive as a list of uploads; take the first.
+        data["image"] = value[0] if isinstance(value, list) else value
+    return data
+
+
 class ImageEditRequest(OpenAIBaseModel):
     image: UploadFile = Field(..., description="The image to edit.")
     prompt: str = Field(..., description="A text description of the desired edit.")
@@ -532,6 +550,8 @@ class ImageEditRequest(OpenAIBaseModel):
     # applied serving-side. Documented in docs/extensions.md.
     strength: float | None = Field(default=None, ge=0.0, le=1.0)
 
+    _accept_image_array = model_validator(mode="before")(_accept_bracketed_image)
+
 
 class ImageVariationRequest(OpenAIBaseModel):
     image: UploadFile = Field(..., description="The image to use as the basis for the variation(s).")
@@ -546,6 +566,8 @@ class ImageVariationRequest(OpenAIBaseModel):
     # diverges from the input image (0.0 keeps it, 1.0 ignores it). Defaults are
     # applied serving-side. Documented in docs/extensions.md.
     strength: float | None = Field(default=None, ge=0.0, le=1.0)
+
+    _accept_image_array = model_validator(mode="before")(_accept_bracketed_image)
 
 
 class ImageObject(OpenAIBaseModel):

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -266,6 +266,33 @@ class TestImageEditRoutes:
         args, _ = remote.call_args
         assert args[0] == b"IMAGE_BYTES"
 
+    def test_edit_accepts_bracketed_image_array_field(self):
+        # Open WebUI (and OpenAI's gpt-image-1 form) send the upload as `image[]`.
+        import io
+
+        from fastapi import UploadFile
+
+        from modelship.openai.protocol import ImageEditRequest
+
+        upload = UploadFile(file=io.BytesIO(b"IMAGE_BYTES"), filename="goat.png")
+        request = ImageEditRequest.model_validate({"image[]": upload, "prompt": "add a sombrero", "model": "sdxl"})
+        assert request.image is upload
+        # `image[]` must not linger as an extra (it would carry an UploadFile
+        # through model_dump and fail to serialize across the Ray boundary).
+        assert "image[]" not in request.model_dump(exclude={"image"})
+
+    def test_variation_accepts_bracketed_image_array_field(self):
+        import io
+
+        from fastapi import UploadFile
+
+        from modelship.openai.protocol import ImageVariationRequest
+
+        upload = UploadFile(file=io.BytesIO(b"IMAGE_BYTES"), filename="goat.png")
+        request = ImageVariationRequest.model_validate({"image[]": upload, "model": "sdxl"})
+        assert request.image is upload
+        assert "image[]" not in request.model_dump(exclude={"image"})
+
 
 class TestHandleResponse:
     @pytest.mark.asyncio

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -231,10 +231,13 @@ class TestImageEditRoutes:
         image_data, mask_data, request_no_file = args[0], args[1], args[2]
         assert image_data == b"IMAGE_BYTES"
         assert mask_data == b"MASK_BYTES"
-        # The UploadFile must not cross the boundary; bytes are passed separately.
+        # No UploadFile may cross the boundary; the image/mask fields are dropped
+        # to None and the bytes are passed separately. (image[] is exclude=True,
+        # so it never appears in the dump regardless.)
         dumped = request_no_file.model_dump()
-        assert "image" not in dumped
+        assert dumped.get("image") is None
         assert dumped.get("mask") is None
+        assert "image[]" not in dumped and "image_array" not in dumped
         handle_response.assert_awaited_once()
 
     @pytest.mark.asyncio
@@ -266,32 +269,82 @@ class TestImageEditRoutes:
         args, _ = remote.call_args
         assert args[0] == b"IMAGE_BYTES"
 
+
+class TestImageFormDecomposition:
+    """Exercise the request models through FastAPI's real multipart/form-data
+    decomposition (not a direct model_validate), since that is what Open WebUI
+    hits and where the `image[]` array field must be picked up."""
+
+    @staticmethod
+    def _client():
+        import io
+        from typing import Annotated
+
+        from fastapi import FastAPI, Form, Request
+        from fastapi.testclient import TestClient
+
+        from modelship.openai.protocol import ImageEditRequest, ImageVariationRequest
+
+        app = FastAPI()
+
+        @app.post("/v1/images/edits")
+        async def edit(request: Annotated[ImageEditRequest, Form()], raw: Request):
+            return {
+                "image": request.image.filename if request.image else None,
+                # The UploadFile must never survive into model_dump (it would
+                # fail to serialize across the Ray process boundary).
+                "image_keys_in_dump": [k for k in request.model_dump(exclude={"image", "mask"}) if "image" in k],
+            }
+
+        @app.post("/v1/images/variations")
+        async def variation(request: Annotated[ImageVariationRequest, Form()], raw: Request):
+            return {
+                "image": request.image.filename if request.image else None,
+                "image_keys_in_dump": [k for k in request.model_dump(exclude={"image"}) if "image" in k],
+            }
+
+        return TestClient(app), io
+
     def test_edit_accepts_bracketed_image_array_field(self):
         # Open WebUI (and OpenAI's gpt-image-1 form) send the upload as `image[]`.
-        import io
+        client, io = self._client()
+        resp = client.post(
+            "/v1/images/edits",
+            data={"prompt": "add a sombrero", "model": "sdxl"},
+            files={"image[]": ("goat.png", io.BytesIO(b"IMAGE_BYTES"), "image/png")},
+        )
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        assert body["image"] == "goat.png"
+        assert body["image_keys_in_dump"] == []
 
-        from fastapi import UploadFile
+    def test_edit_accepts_singular_image_field(self):
+        # The legacy DALL·E 2 singular `image` form must keep working.
+        client, io = self._client()
+        resp = client.post(
+            "/v1/images/edits",
+            data={"prompt": "add a sombrero", "model": "sdxl"},
+            files={"image": ("goat.png", io.BytesIO(b"IMAGE_BYTES"), "image/png")},
+        )
+        assert resp.status_code == 200, resp.text
+        assert resp.json()["image"] == "goat.png"
 
-        from modelship.openai.protocol import ImageEditRequest
-
-        upload = UploadFile(file=io.BytesIO(b"IMAGE_BYTES"), filename="goat.png")
-        request = ImageEditRequest.model_validate({"image[]": upload, "prompt": "add a sombrero", "model": "sdxl"})
-        assert request.image is upload
-        # `image[]` must not linger as an extra (it would carry an UploadFile
-        # through model_dump and fail to serialize across the Ray boundary).
-        assert "image[]" not in request.model_dump(exclude={"image"})
+    def test_edit_missing_image_is_422(self):
+        client, _ = self._client()
+        resp = client.post("/v1/images/edits", data={"prompt": "add a sombrero", "model": "sdxl"})
+        assert resp.status_code == 422
 
     def test_variation_accepts_bracketed_image_array_field(self):
-        import io
-
-        from fastapi import UploadFile
-
-        from modelship.openai.protocol import ImageVariationRequest
-
-        upload = UploadFile(file=io.BytesIO(b"IMAGE_BYTES"), filename="goat.png")
-        request = ImageVariationRequest.model_validate({"image[]": upload, "model": "sdxl"})
-        assert request.image is upload
-        assert "image[]" not in request.model_dump(exclude={"image"})
+        client, io = self._client()
+        resp = client.post(
+            "/v1/images/variations",
+            data={"model": "sdxl"},
+            files={"image[]": ("goat.png", io.BytesIO(b"IMAGE_BYTES"), "image/png")},
+        )
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        assert body["image"] == "goat.png"
+        assert body["image_keys_in_dump"] == []
 
 
 class TestHandleResponse:


### PR DESCRIPTION
Open WebUI sends image edit/variation uploads under the form key `image[]` (OpenAI's gpt-image-1 array form), but ImageEditRequest / ImageVariationRequest only declared the singular `image`, so the request failed validation with a 422 — and FastAPI's built-in validation handler returns that 422 without logging, leaving no trace in the logs.

- Add a RequestValidationError handler that logs the failing field(s) before returning the 422, closing the silent-failure gap.
- Map the `image[]` array form key onto `image` in both image request models (popping it so the stray UploadFile can't ride through model_dump and break Ray serialization).
- Add tests covering the image[] mapping for edits and variations.


