### PR TITLE
feat: make Ray Serve concurrency caps configurable

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -93,6 +93,11 @@ The Docker image's `CMD` (`scripts/start.sh`) starts the Ray head (auto-detectin
 
 Commit messages matter: use Conventional Commits prefixes so the changelog generator picks them up.
 
+## Working with git
+
+- **The maintainer pushes; agents don't.** Create branches and commits locally, but leave `git push` to the human (this environment has no `ssh`, and the remote is SSH anyway). Hand back the branch name and let them push and open the PR.
+- **Never amend; always add a new commit.** Don't `git commit --amend` (or rebase/squash) unless explicitly asked. Follow-up work — review feedback, refactors, even bug fixes to a just-made commit — goes in its own commit stacked on top of the original, so history stays reviewable.
+
 ## Gotchas
 
 - `config/models.yaml` is gitignored; `mship_deploy.py` errors out with a pointer to `config/examples/` if missing.

--- a/docs/development.md
+++ b/docs/development.md
@@ -58,6 +58,8 @@ The following environment variables are set in the dev image with sensible defau
 | `RAY_HEAD_GPU_NUM` | *(unset)* | **Optional override:** GPUs allocated to Ray head. If unset, Ray auto-detects. |
 | `MSHIP_CACHE_DIR` | `/.cache` | Model cache directory |
 | `MSHIP_USE_EXISTING_RAY_CLUSTER` | `false` | Set to `true` to skip starting a Ray head node |
+| `MSHIP_GATEWAY_REPLICAS` | `1` | Number of API gateway replicas. Raise to spread request-proxying load across processes under high concurrency. |
+| `MSHIP_GATEWAY_MAX_ONGOING` | `1024` | Per-replica Ray Serve concurrency cap for the gateway. The gateway holds a slot for the whole lifetime of each streamed response, so a low cap throttles before the engine does. |
 
 ### Installing plugin dependencies for IntelliSense
 

--- a/docs/model-configuration.md
+++ b/docs/model-configuration.md
@@ -72,6 +72,7 @@ python mship_deploy.py --config config/tts.yaml --gateway-name "tts-api"
 | `num_gpus` | float \| int | GPU allocation. Fractional `< 1` shares one GPU (also sets vLLM `gpu_memory_utilization`); integer `≥ 1` requests that many whole GPUs (for `vllm`, this auto-sets `tensor_parallel_size = num_gpus` unless tp/pp is already specified). |
 | `num_cpus` | float | CPU units to allocate (default `0.1`) |
 | `num_replicas` | int | Number of identical Ray Serve replicas for this deployment (default `1`) |
+| `max_ongoing_requests` | int | Per-replica Ray Serve concurrency cap (default: Ray Serve's own default of `100`). Streaming requests hold a slot for the whole generation, so a low cap throttles upstream of the engine; raise it for high-concurrency models. Omit to inherit the default. |
 | `vllm_engine_kwargs` | object | Passed directly to the vLLM engine (see below) |
 | `transformers_config` | object | Transformers loader options (see below) |
 | `diffusers_config` | object | Diffusers pipeline options (see below) |

--- a/modelship/deploy/actor_options.py
+++ b/modelship/deploy/actor_options.py
@@ -112,28 +112,30 @@ def build_deployment_options(config: ModelshipModelConfig, plugin_wheel: Path | 
                 config.name,
             )
         opts: dict = {"ray_actor_options": {"num_gpus": 0, "num_cpus": config.num_cpus, "runtime_env": runtime_env}}
-    elif _world_size(config) == 1:
-        # Single slot: scalar Ray allocation. Fractional num_gpus (0 < n < 1)
-        # lets Ray pack other actors onto the same physical GPU.
-        opts = {
-            "ray_actor_options": {
-                "num_gpus": config.num_gpus,
-                "num_cpus": config.num_cpus,
-                "runtime_env": runtime_env,
-            }
-        }
     else:
-        # Multi-slot: one PG bundle per slot, STRICT_PACK keeps them on the same
-        # node (NVLink). Outer actor sits in bundle 0 with 0 GPU; vLLM's ray
-        # executor reuses the PG via get_current_placement_group() and pins each
-        # worker actor to its bundle. Each bundle requests a whole GPU, so Ray
-        # spreads across distinct physical GPUs.
-        bundles = [{"GPU": 1, "CPU": config.num_cpus} for _ in range(_world_size(config))]
-        opts = {
-            "ray_actor_options": {"num_gpus": 0, "num_cpus": config.num_cpus, "runtime_env": runtime_env},
-            "placement_group_bundles": bundles,
-            "placement_group_strategy": "STRICT_PACK",
-        }
+        world_size = _world_size(config)
+        if world_size == 1:
+            # Single slot: scalar Ray allocation. Fractional num_gpus (0 < n < 1)
+            # lets Ray pack other actors onto the same physical GPU.
+            opts = {
+                "ray_actor_options": {
+                    "num_gpus": config.num_gpus,
+                    "num_cpus": config.num_cpus,
+                    "runtime_env": runtime_env,
+                }
+            }
+        else:
+            # Multi-slot: one PG bundle per slot, STRICT_PACK keeps them on the
+            # same node (NVLink). Outer actor sits in bundle 0 with 0 GPU; vLLM's
+            # ray executor reuses the PG via get_current_placement_group() and
+            # pins each worker actor to its bundle. Each bundle requests a whole
+            # GPU, so Ray spreads across distinct physical GPUs.
+            bundles = [{"GPU": 1, "CPU": config.num_cpus} for _ in range(world_size)]
+            opts = {
+                "ray_actor_options": {"num_gpus": 0, "num_cpus": config.num_cpus, "runtime_env": runtime_env},
+                "placement_group_bundles": bundles,
+                "placement_group_strategy": "STRICT_PACK",
+            }
 
     # Per-model Ray Serve concurrency cap; only override the default when set.
     # The reservation helpers read only the GPU/CPU keys, so this is inert there.

--- a/modelship/deploy/actor_options.py
+++ b/modelship/deploy/actor_options.py
@@ -88,7 +88,8 @@ def build_deployment_options(config: ModelshipModelConfig, plugin_wheel: Path | 
     Always contains ``ray_actor_options``; for multi-slot vLLM deploys also
     contains ``placement_group_bundles`` and ``placement_group_strategy`` so
     Ray Serve allocates one whole-GPU bundle per slot and vLLM's ray executor
-    inherits the PG.
+    inherits the PG. When the model config sets ``max_ongoing_requests`` it is
+    forwarded as the per-replica Ray Serve concurrency cap.
     """
     env_vars = build_cache_env_vars()
     for log_var in _LOG_PASSTHROUGH_ENV_VARS:
@@ -110,29 +111,32 @@ def build_deployment_options(config: ModelshipModelConfig, plugin_wheel: Path | 
                 config.num_gpus,
                 config.name,
             )
-        return {"ray_actor_options": {"num_gpus": 0, "num_cpus": config.num_cpus, "runtime_env": runtime_env}}
-
-    world_size = _world_size(config)
-
-    if world_size == 1:
+        opts: dict = {"ray_actor_options": {"num_gpus": 0, "num_cpus": config.num_cpus, "runtime_env": runtime_env}}
+    elif _world_size(config) == 1:
         # Single slot: scalar Ray allocation. Fractional num_gpus (0 < n < 1)
         # lets Ray pack other actors onto the same physical GPU.
-        return {
+        opts = {
             "ray_actor_options": {
                 "num_gpus": config.num_gpus,
                 "num_cpus": config.num_cpus,
                 "runtime_env": runtime_env,
             }
         }
+    else:
+        # Multi-slot: one PG bundle per slot, STRICT_PACK keeps them on the same
+        # node (NVLink). Outer actor sits in bundle 0 with 0 GPU; vLLM's ray
+        # executor reuses the PG via get_current_placement_group() and pins each
+        # worker actor to its bundle. Each bundle requests a whole GPU, so Ray
+        # spreads across distinct physical GPUs.
+        bundles = [{"GPU": 1, "CPU": config.num_cpus} for _ in range(_world_size(config))]
+        opts = {
+            "ray_actor_options": {"num_gpus": 0, "num_cpus": config.num_cpus, "runtime_env": runtime_env},
+            "placement_group_bundles": bundles,
+            "placement_group_strategy": "STRICT_PACK",
+        }
 
-    # Multi-slot: one PG bundle per slot, STRICT_PACK keeps them on the same
-    # node (NVLink). Outer actor sits in bundle 0 with 0 GPU; vLLM's ray
-    # executor reuses the PG via get_current_placement_group() and pins each
-    # worker actor to its bundle. Each bundle requests a whole GPU, so Ray
-    # spreads across distinct physical GPUs.
-    bundles = [{"GPU": 1, "CPU": config.num_cpus} for _ in range(world_size)]
-    return {
-        "ray_actor_options": {"num_gpus": 0, "num_cpus": config.num_cpus, "runtime_env": runtime_env},
-        "placement_group_bundles": bundles,
-        "placement_group_strategy": "STRICT_PACK",
-    }
+    # Per-model Ray Serve concurrency cap; only override the default when set.
+    # The reservation helpers read only the GPU/CPU keys, so this is inert there.
+    if config.max_ongoing_requests is not None:
+        opts["max_ongoing_requests"] = config.max_ongoing_requests
+    return opts

--- a/modelship/deploy/serve_utils.py
+++ b/modelship/deploy/serve_utils.py
@@ -87,10 +87,28 @@ def start_serve(serve_logging_config: LoggingConfig) -> None:
     )
 
 
+def _positive_int_env(name: str, default: int) -> int:
+    """Read an env var as an int >= 1, failing fast with a clear message.
+
+    Ray Serve rejects num_replicas / max_ongoing_requests < 1 deep in
+    deployment, so validate up front to surface the misconfiguration plainly.
+    """
+    raw = os.environ.get(name)
+    if raw is None:
+        return default
+    try:
+        value = int(raw)
+    except ValueError:
+        raise ValueError(f"{name} must be a positive integer, got {raw!r}") from None
+    if value < 1:
+        raise ValueError(f"{name} must be >= 1, got {value}")
+    return value
+
+
 def start_gateway(gateway_name: str, serve_logging_config: LoggingConfig) -> None:
     logger.info("Starting API gateway...")
-    gateway_replicas = int(os.environ.get("MSHIP_GATEWAY_REPLICAS", "1"))
-    gateway_max_ongoing = int(os.environ.get("MSHIP_GATEWAY_MAX_ONGOING", "1024"))
+    gateway_replicas = _positive_int_env("MSHIP_GATEWAY_REPLICAS", 1)
+    gateway_max_ongoing = _positive_int_env("MSHIP_GATEWAY_MAX_ONGOING", 1024)
     serve.run(
         ModelshipAPI.options(
             name=gateway_name,

--- a/modelship/deploy/serve_utils.py
+++ b/modelship/deploy/serve_utils.py
@@ -89,17 +89,24 @@ def start_serve(serve_logging_config: LoggingConfig) -> None:
 
 def start_gateway(gateway_name: str, serve_logging_config: LoggingConfig) -> None:
     logger.info("Starting API gateway...")
+    gateway_replicas = int(os.environ.get("MSHIP_GATEWAY_REPLICAS", "1"))
+    gateway_max_ongoing = int(os.environ.get("MSHIP_GATEWAY_MAX_ONGOING", "1024"))
     serve.run(
         ModelshipAPI.options(
             name=gateway_name,
-            num_replicas=1,
+            num_replicas=gateway_replicas,
+            max_ongoing_requests=gateway_max_ongoing,
             ray_actor_options={"num_cpus": 0},
             logging_config=serve_logging_config,
         ).bind(),
         name=gateway_name,
         route_prefix="/",
     )
-    logger.info("Gateway up — /health and /readyz now serving.")
+    logger.info(
+        "Gateway up — /health and /readyz now serving. (replicas=%d, max_ongoing=%d)",
+        gateway_replicas,
+        gateway_max_ongoing,
+    )
 
 
 def seed_expected_models(gateway_handle, yml_conf: ModelshipConfig) -> None:

--- a/modelship/infer/infer_config.py
+++ b/modelship/infer/infer_config.py
@@ -109,6 +109,8 @@ class ModelshipModelConfig(BaseModel):
     num_gpus: float = 0
     num_cpus: float = 0.1
     num_replicas: int = 1
+    # Ray Serve's per-replica concurrency cap.
+    max_ongoing_requests: int | None = None
     vllm_engine_kwargs: VllmEngineConfig = Field(default_factory=VllmEngineConfig)
     transformers_config: TransformersConfig | None = None
     diffusers_config: DiffusersConfig | None = None

--- a/tests/test_mship_deploy.py
+++ b/tests/test_mship_deploy.py
@@ -181,6 +181,44 @@ class TestBuildDeploymentOptions:
         assert opts["ray_actor_options"]["num_gpus"] == 0.3
         assert "placement_group_bundles" not in opts
 
+    def test_max_ongoing_requests_omitted_by_default(self):
+        config = ModelshipModelConfig(
+            name="test-model",
+            model="some-model",
+            usecase=ModelUsecase.generate,
+            loader=ModelLoader.vllm,
+            num_gpus=1,
+        )
+        opts = build_deployment_options(config)
+        assert "max_ongoing_requests" not in opts
+
+    def test_max_ongoing_requests_forwarded_when_set(self):
+        config = ModelshipModelConfig(
+            name="test-model",
+            model="some-model",
+            usecase=ModelUsecase.generate,
+            loader=ModelLoader.vllm,
+            num_gpus=1,
+            max_ongoing_requests=256,
+        )
+        opts = build_deployment_options(config)
+        assert opts["max_ongoing_requests"] == 256
+
+    def test_max_ongoing_requests_forwarded_for_multi_slot(self):
+        # Multi-slot (PG) deploys carry the cap alongside placement_group_bundles.
+        config = ModelshipModelConfig(
+            name="test-model",
+            model="some-model",
+            usecase=ModelUsecase.generate,
+            loader=ModelLoader.vllm,
+            num_gpus=2,
+            vllm_engine_kwargs=VllmEngineConfig(tensor_parallel_size=2),
+            max_ongoing_requests=64,
+        )
+        opts = build_deployment_options(config)
+        assert opts["max_ongoing_requests"] == 64
+        assert len(opts["placement_group_bundles"]) == 2
+
 
 class TestReservationTotals:
     def test_single_slot_uses_actor_options(self):
@@ -239,6 +277,37 @@ class TestRemoveApps:
             mship_deploy.remove_apps(gateway, ["a-1234567890", "b-1234567890"])
         # Both deletes attempted even though the first raised.
         assert mock_delete.call_count == 2
+
+
+class TestStartGateway:
+    def _run(self, env):
+        from modelship.deploy import serve_utils
+
+        bound = MagicMock()
+        options = MagicMock()
+        options.return_value.bind.return_value = bound
+        logging_config = MagicMock()
+        with (
+            patch.dict(os.environ, env, clear=False),
+            patch.object(serve_utils.ModelshipAPI, "options", options),
+            patch.object(serve_utils.serve, "run") as mock_run,
+        ):
+            serve_utils.start_gateway("gw", logging_config)
+        return options, mock_run
+
+    def test_defaults(self):
+        # Ensure no leftover env from the ambient process leaks the assertion.
+        options, mock_run = self._run({"MSHIP_GATEWAY_REPLICAS": "1", "MSHIP_GATEWAY_MAX_ONGOING": "1024"})
+        _, kwargs = options.call_args
+        assert kwargs["num_replicas"] == 1
+        assert kwargs["max_ongoing_requests"] == 1024
+        mock_run.assert_called_once()
+
+    def test_env_overrides(self):
+        options, _ = self._run({"MSHIP_GATEWAY_REPLICAS": "3", "MSHIP_GATEWAY_MAX_ONGOING": "256"})
+        _, kwargs = options.call_args
+        assert kwargs["num_replicas"] == 3
+        assert kwargs["max_ongoing_requests"] == 256
 
 
 class TestResolvePluginWheel:

--- a/tests/test_mship_deploy.py
+++ b/tests/test_mship_deploy.py
@@ -309,6 +309,19 @@ class TestStartGateway:
         assert kwargs["num_replicas"] == 3
         assert kwargs["max_ongoing_requests"] == 256
 
+    @pytest.mark.parametrize(
+        "name, value",
+        [
+            ("MSHIP_GATEWAY_REPLICAS", "0"),
+            ("MSHIP_GATEWAY_REPLICAS", "-2"),
+            ("MSHIP_GATEWAY_MAX_ONGOING", "0"),
+            ("MSHIP_GATEWAY_MAX_ONGOING", "notanint"),
+        ],
+    )
+    def test_rejects_invalid_env(self, name, value):
+        with pytest.raises(ValueError, match=name):
+            self._run({name: value})
+
 
 class TestResolvePluginWheel:
     def test_resolves_latest_wheel(self, tmp_path):


### PR DESCRIPTION
Ray Serve defaults each deployment to max_ongoing_requests=100 per replica. For streaming LLM requests every client holds a slot for the whole generation, so the cap throttles requests upstream of the engine (inflated TTFT) long before the engine itself saturates.

Add three knobs to lift the throttle:

- max_ongoing_requests (per-model config field) — forwarded to the model deployment's Ray Serve options via build_deployment_options. None inherits the default, so existing configs are unaffected.
- MSHIP_GATEWAY_MAX_ONGOING (env, default 1024) — per-replica cap for the API gateway, which sits in the path for the lifetime of each streamed response.
- MSHIP_GATEWAY_REPLICAS (env, default 1) — number of gateway replicas, to spread proxying load across processes under high concurrency.

Gateway replica scaling is keyed under the same application name, so the existing gateway-exclusion filter in reconcile (existing_apps - {gateway_name}) remains correct.


