### PR TITLE
fix(llama_cpp): reject logprobs explicitly instead of silently dropping

### DIFF
--- a/modelship/infer/llama_cpp/openai/serving_chat.py
+++ b/modelship/infer/llama_cpp/openai/serving_chat.py
@@ -82,6 +82,18 @@ class OpenAIServingChat(OpenAIServing):
         request_id = f"{self.request_id_prefix}-{base_request_id(raw_request)}"
         logger.info("chat completion request %s: stream=%s", request_id, request.stream)
 
+        # llama.cpp can produce token logprobs, but the modelship wrapper does
+        # not yet thread them into the OpenAI `choices[].logprobs` response.
+        # Reject explicitly rather than silently dropping the request fields,
+        # which used to leave clients waiting for logprobs that never arrived.
+        if request.logprobs or request.top_logprobs:
+            msg = (
+                "logprobs / top_logprobs are not yet supported on the llama.cpp loader. "
+                "Resend the request without them."
+            )
+            logger.warning("chat request %s rejected: %s", request_id, msg)
+            return create_error_response(msg)
+
         try:
             messages = normalize_chat_messages(
                 request.messages,
@@ -333,9 +345,8 @@ class OpenAIServingChat(OpenAIServing):
             params["max_tokens"] = params["max_completion_tokens"]
         params.pop("max_completion_tokens", None)
         # These are consumed by our renderer/parser, not by `create_completion`.
+        # (logprobs/top_logprobs are rejected up front in create_chat_completion.)
         for k in ("messages", "tools", "tool_choice", "stream", "stream_options"):
-            params.pop(k, None)
-        for k in ("logprobs", "top_logprobs"):
             params.pop(k, None)
 
         grammar = build_llama_grammar(params.pop("response_format", None))

--- a/modelship/infer/llama_cpp/openai/serving_chat.py
+++ b/modelship/infer/llama_cpp/openai/serving_chat.py
@@ -345,8 +345,14 @@ class OpenAIServingChat(OpenAIServing):
             params["max_tokens"] = params["max_completion_tokens"]
         params.pop("max_completion_tokens", None)
         # These are consumed by our renderer/parser, not by `create_completion`.
-        # (logprobs/top_logprobs are rejected up front in create_chat_completion.)
         for k in ("messages", "tools", "tool_choice", "stream", "stream_options"):
+            params.pop(k, None)
+        # logprobs/top_logprobs are rejected up front in create_chat_completion when
+        # truthy, but `model_dump(exclude_none=True)` still keeps their falsy defaults
+        # (False / 0). `create_completion` accepts `logprobs` (Optional[int]), so a
+        # leftover `logprobs=False` is `not None` and triggers needless logprob work
+        # in llama-cpp-python. Drop both unconditionally.
+        for k in ("logprobs", "top_logprobs"):
             params.pop(k, None)
 
         grammar = build_llama_grammar(params.pop("response_format", None))

--- a/tests/test_llama_cpp_logprobs.py
+++ b/tests/test_llama_cpp_logprobs.py
@@ -1,0 +1,53 @@
+"""The llama.cpp loader cannot yet thread token logprobs into the OpenAI
+response, so it must reject requests that ask for them rather than silently
+dropping the fields (which left clients waiting for logprobs that never came).
+"""
+
+import pytest
+
+from modelship.infer.infer_config import RawRequestProxy
+from modelship.infer.llama_cpp.openai.serving_chat import OpenAIServingChat
+from modelship.openai.protocol import ChatCompletionRequest, ErrorResponse
+
+
+def _serving() -> OpenAIServingChat:
+    # The logprobs guard runs at the very top of create_chat_completion, before
+    # anything reads _caps / renderer / llama, so a bare instance is enough.
+    return OpenAIServingChat.__new__(OpenAIServingChat)
+
+
+def _request(**overrides) -> ChatCompletionRequest:
+    payload = {"model": "x", "messages": [{"role": "user", "content": "hi"}], **overrides}
+    return ChatCompletionRequest(**payload)
+
+
+def _raw_request() -> RawRequestProxy:
+    return RawRequestProxy(None, {})
+
+
+class TestLogprobsRejected:
+    @pytest.mark.asyncio
+    async def test_logprobs_true_returns_400(self):
+        chat = _serving()
+        result = await chat.create_chat_completion(_request(logprobs=True), _raw_request())
+        assert isinstance(result, ErrorResponse)
+        assert result._http_status == 400
+        assert "logprobs" in result.error.message
+
+    @pytest.mark.asyncio
+    async def test_top_logprobs_alone_returns_400(self):
+        # A client may set top_logprobs without logprobs=True; still unsupported.
+        chat = _serving()
+        result = await chat.create_chat_completion(_request(top_logprobs=5), _raw_request())
+        assert isinstance(result, ErrorResponse)
+        assert result._http_status == 400
+
+    @pytest.mark.asyncio
+    async def test_logprobs_false_is_not_rejected_here(self):
+        # The default (logprobs=False, top_logprobs=0) must fall through the guard
+        # so normal requests still work; it then proceeds past this point and
+        # touches _caps, which the bare instance lacks → AttributeError, not an
+        # ErrorResponse. That confirms the guard let it through.
+        chat = _serving()
+        with pytest.raises(AttributeError):
+            await chat.create_chat_completion(_request(), _raw_request())


### PR DESCRIPTION
The llama.cpp loader cannot yet thread token logprobs into the OpenAI `choices[].logprobs` response, but it used to silently strip the `logprobs`/`top_logprobs` request fields in `_build_completion_kwargs`. Clients got a normal 200 response with no logprobs and no indication their request was not honored.

Reject these fields with an explicit 400 at the top of `create_chat_completion` so both the native and renderer/parser paths fail consistently, and remove the now-dead silent strip.

