### PR TITLE
feat(responses): stateless /v1/responses endpoint (Phase A)

### DIFF
--- a/modelship/openai/api.py
+++ b/modelship/openai/api.py
@@ -8,7 +8,7 @@ from fastapi.encoders import jsonable_encoder
 from fastapi.exceptions import RequestValidationError
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse, Response, StreamingResponse
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, ValidationError
 from ray import serve
 from ray.exceptions import RayTaskError
 from ray.serve.handle import DeploymentHandle
@@ -449,6 +449,11 @@ class ModelshipAPI:
             chat_request = responses_request_to_chat(request)
         except UnsupportedResponsesFeatureError as e:
             return _error_response(create_error_response(e))
+        except ValidationError as e:
+            # Translating into ChatCompletionRequest can surface invalid params
+            # (e.g. a bad reasoning.effort value) as a pydantic ValidationError,
+            # which is not a ValueError — return a 400 rather than a generic 500.
+            return _error_response(_validation_error_from_cause(e))
 
         handle = self._get_handle(request.model)
         watcher = RequestWatcher(raw_request, model=model, endpoint="create_response")

--- a/modelship/openai/api.py
+++ b/modelship/openai/api.py
@@ -37,12 +37,19 @@ from modelship.openai.protocol import (
     ImageGenerationResponse,
     ImageVariationRequest,
     RawSpeechResponse,
+    ResponseObject,
+    ResponsesRequest,
     SpeechRequest,
     TranscriptionRequest,
     TranscriptionResponse,
     TranslationRequest,
     TranslationResponse,
     create_error_response,
+)
+from modelship.openai.protocol.responses import (
+    UnsupportedResponsesFeatureError,
+    chat_response_to_responses,
+    responses_request_to_chat,
 )
 from modelship.utils import random_uuid
 
@@ -134,6 +141,20 @@ def _validation_error_from_cause(cause: BaseException) -> ErrorResponse:
         status_code=HTTPStatus.BAD_REQUEST,
         param=getattr(cause, "parameter", None),
     )
+
+
+async def _responses_from_chat(response_gen, request: ResponsesRequest):
+    """Adapt a chat-completion response generator into Responses output.
+
+    Lets ``/v1/responses`` reuse ``_handle_response`` unchanged: chat
+    response objects are translated to ``ResponseObject`` while errors and
+    Ray exceptions pass through to the same handling as every other endpoint.
+    """
+    async for item in response_gen:
+        if isinstance(item, ChatCompletionResponse):
+            yield chat_response_to_responses(item, request)
+        else:
+            yield item
 
 
 @serve.deployment
@@ -301,6 +322,7 @@ class ModelshipAPI:
             if isinstance(
                 first,
                 ChatCompletionResponse
+                | ResponseObject
                 | EmbeddingResponse
                 | TranscriptionResponse
                 | TranslationResponse
@@ -407,6 +429,39 @@ class ModelshipAPI:
         logger.debug("chat_completion full request: %s", request.model_dump_json())
         response_gen = handle.generate.options(stream=True).remote(request, headers, watcher.event, req_id)
         return await self._handle_response(response_gen, watcher, model, "create_chat_completion")
+
+    @app.post("/v1/responses")
+    async def create_response(self, request: ResponsesRequest, raw_request: Request):
+        req_id = random_uuid()
+        self._set_request_id(req_id)
+        model = request.model or ""
+        if request.stream:
+            # Phase A is non-streaming only; the Responses streaming event
+            # protocol is a separate (A2) deliverable. Reject rather than
+            # silently downgrade to a single non-streamed body.
+            return _error_response(
+                create_error_response(
+                    "streaming is not yet supported on /v1/responses; set stream=false.",
+                    status_code=HTTPStatus.BAD_REQUEST,
+                )
+            )
+        try:
+            chat_request = responses_request_to_chat(request)
+        except UnsupportedResponsesFeatureError as e:
+            return _error_response(create_error_response(e))
+
+        handle = self._get_handle(request.model)
+        watcher = RequestWatcher(raw_request, model=model, endpoint="create_response")
+        headers = dict(raw_request.headers)
+        logger.info(
+            "responses model=%s input_items=%s max_output_tokens=%s",
+            model,
+            1 if isinstance(request.input, str) else len(request.input),
+            request.max_output_tokens,
+        )
+        response_gen = handle.generate.options(stream=True).remote(chat_request, headers, watcher.event, req_id)
+        adapted = _responses_from_chat(response_gen, request)
+        return await self._handle_response(adapted, watcher, model, "create_response")
 
     @app.post("/v1/embeddings")
     async def create_embeddings(self, request: EmbeddingRequest, raw_request: Request):

--- a/modelship/openai/protocol/__init__.py
+++ b/modelship/openai/protocol/__init__.py
@@ -86,7 +86,7 @@ from modelship.openai.protocol.responses import (
     ResponsesRequest,
     ResponseUsage,
 )
-from modelship.openai.protocol.usage import PromptTokenUsageInfo, UsageInfo
+from modelship.openai.protocol.usage import CompletionTokenUsageInfo, PromptTokenUsageInfo, UsageInfo
 
 __all__ = [
     "AudioResponseFormat",
@@ -100,6 +100,7 @@ __all__ = [
     "ChatCompletionResponseStreamChoice",
     "ChatCompletionStreamResponse",
     "ChatMessage",
+    "CompletionTokenUsageInfo",
     "DeltaFunctionCall",
     "DeltaMessage",
     "DeltaToolCall",

--- a/modelship/openai/protocol/__init__.py
+++ b/modelship/openai/protocol/__init__.py
@@ -71,6 +71,21 @@ from modelship.openai.protocol.raw import (
     RawTranscription,
     RawTranslation,
 )
+from modelship.openai.protocol.responses import (
+    ResponseFunctionToolCall,
+    ResponseInputItem,
+    ResponseInputTokensDetails,
+    ResponseObject,
+    ResponseOutputItem,
+    ResponseOutputMessage,
+    ResponseOutputText,
+    ResponseOutputTokensDetails,
+    ResponseReasoningItem,
+    ResponseReasoningSummary,
+    ResponseReasoningText,
+    ResponsesRequest,
+    ResponseUsage,
+)
 from modelship.openai.protocol.usage import PromptTokenUsageInfo, UsageInfo
 
 __all__ = [
@@ -109,6 +124,19 @@ __all__ = [
     "RawToolCall",
     "RawTranscription",
     "RawTranslation",
+    "ResponseFunctionToolCall",
+    "ResponseInputItem",
+    "ResponseInputTokensDetails",
+    "ResponseObject",
+    "ResponseOutputItem",
+    "ResponseOutputMessage",
+    "ResponseOutputText",
+    "ResponseOutputTokensDetails",
+    "ResponseReasoningItem",
+    "ResponseReasoningSummary",
+    "ResponseReasoningText",
+    "ResponseUsage",
+    "ResponsesRequest",
     "SpeechRequest",
     "SpeechResponse",
     "StreamOptions",

--- a/modelship/openai/protocol/responses/__init__.py
+++ b/modelship/openai/protocol/responses/__init__.py
@@ -1,0 +1,54 @@
+"""Responses API (``/v1/responses``) schemas and the stateless chat adapter.
+
+Phase A implements ``/v1/responses`` as a stateless adapter over the existing
+chat-completion pipeline rather than a new inference path: the request is
+translated to a :class:`ChatCompletionRequest`, run through the unchanged
+``handle.generate`` deployment method, and the chat result is translated back
+into a Responses :class:`ResponseObject`.
+
+Thin re-exporter over the leaf submodules (mirrors the parent ``protocol``
+package): :mod:`.schemas` holds the pydantic models, :mod:`.adapter` the
+translation logic. The two submodules import cleanly in either order —
+``adapter`` pulls in ``schemas`` itself, and neither reaches back into the
+top-level ``protocol`` package — so no import cycle exists here.
+"""
+
+from modelship.openai.protocol.responses.adapter import (
+    UnsupportedResponsesFeatureError,
+    chat_response_to_responses,
+    responses_request_to_chat,
+)
+from modelship.openai.protocol.responses.schemas import (
+    ResponseFunctionToolCall,
+    ResponseInputItem,
+    ResponseInputTokensDetails,
+    ResponseObject,
+    ResponseOutputItem,
+    ResponseOutputMessage,
+    ResponseOutputText,
+    ResponseOutputTokensDetails,
+    ResponseReasoningItem,
+    ResponseReasoningSummary,
+    ResponseReasoningText,
+    ResponsesRequest,
+    ResponseUsage,
+)
+
+__all__ = [
+    "ResponseFunctionToolCall",
+    "ResponseInputItem",
+    "ResponseInputTokensDetails",
+    "ResponseObject",
+    "ResponseOutputItem",
+    "ResponseOutputMessage",
+    "ResponseOutputText",
+    "ResponseOutputTokensDetails",
+    "ResponseReasoningItem",
+    "ResponseReasoningSummary",
+    "ResponseReasoningText",
+    "ResponseUsage",
+    "ResponsesRequest",
+    "UnsupportedResponsesFeatureError",
+    "chat_response_to_responses",
+    "responses_request_to_chat",
+]

--- a/modelship/openai/protocol/responses/adapter.py
+++ b/modelship/openai/protocol/responses/adapter.py
@@ -39,6 +39,7 @@ from modelship.openai.protocol.responses.schemas import (
     ResponsesRequest,
     ResponseUsage,
 )
+from modelship.openai.protocol.usage import UsageInfo
 
 
 class UnsupportedResponsesFeatureError(ValueError):
@@ -198,6 +199,10 @@ def _response_format_from_text(text: dict[str, Any] | None) -> dict[str, Any] | 
     fmt = text.get("format")
     if not fmt:
         return None
+    if not isinstance(fmt, dict):
+        raise UnsupportedResponsesFeatureError(
+            f"text.format must be an object with a 'type' field, got {type(fmt).__name__}."
+        )
     ftype = fmt.get("type")
     if ftype == "json_schema":
         # Responses flattens name/schema/strict; chat nests them under json_schema.
@@ -235,19 +240,11 @@ def chat_response_to_responses(chat: ChatCompletionResponse, request: ResponsesR
 
     status, incomplete = _status_for(choice.finish_reason)
 
-    usage = ResponseUsage(
-        input_tokens=chat.usage.prompt_tokens,
-        output_tokens=chat.usage.completion_tokens or 0,
-        total_tokens=chat.usage.total_tokens,
-        input_tokens_details=ResponseInputTokensDetails(cached_tokens=0),
-        output_tokens_details=ResponseOutputTokensDetails(reasoning_tokens=0),
-    )
-
     return ResponseObject(
         model=chat.model,
         status=status,
         output=output,
-        usage=usage,
+        usage=_usage_from_chat(chat.usage),
         incomplete_details=incomplete,
         # Echo the request settings OpenAI returns on the response object.
         instructions=request.instructions,
@@ -264,9 +261,38 @@ def chat_response_to_responses(chat: ChatCompletionResponse, request: ResponsesR
     )
 
 
+def _usage_from_chat(usage: UsageInfo) -> ResponseUsage:
+    """Remap chat usage to Responses usage, preserving token details.
+
+    ``cached_tokens`` / ``reasoning_tokens`` are surfaced by vLLM (prefix
+    caching / reasoning models) under the OpenAI-standard ``prompt_tokens_details``
+    / ``completion_tokens_details``. Responses uses the same sub-field names, so
+    this is a direct field-to-field copy; loaders that report no details
+    (llama_cpp/transformers) leave them at the zero default.
+    """
+    prompt_details = usage.prompt_tokens_details
+    completion_details = usage.completion_tokens_details
+    return ResponseUsage(
+        input_tokens=usage.prompt_tokens,
+        output_tokens=usage.completion_tokens or 0,
+        total_tokens=usage.total_tokens,
+        input_tokens_details=ResponseInputTokensDetails(
+            cached_tokens=(prompt_details.cached_tokens or 0) if prompt_details else 0
+        ),
+        output_tokens_details=ResponseOutputTokensDetails(
+            reasoning_tokens=(completion_details.reasoning_tokens or 0) if completion_details else 0
+        ),
+    )
+
+
 def _status_for(
     finish_reason: str | None,
 ) -> tuple[Literal["completed", "incomplete"], dict[str, Any] | None]:
+    # chat finish_reason -> Responses status + incomplete_details.reason.
+    # The Responses spec's incomplete_details.reason enum is
+    # {max_output_tokens, content_filter}.
     if finish_reason == "length":
         return "incomplete", {"reason": "max_output_tokens"}
+    if finish_reason == "content_filter":
+        return "incomplete", {"reason": "content_filter"}
     return "completed", None

--- a/modelship/openai/protocol/responses/adapter.py
+++ b/modelship/openai/protocol/responses/adapter.py
@@ -117,17 +117,25 @@ def _messages_from_input(input_: str | list[dict[str, Any]], instructions: str |
     for item in input_:
         itype = item.get("type")
         if itype == "function_call":
-            # A prior assistant tool call being replayed as context.
+            # A prior assistant tool call being replayed as context. call_id and
+            # name identify the call; without them the loader's chat-template /
+            # tool-call handling fails downstream, so reject up front with a 400.
+            call_id = item.get("call_id") or item.get("id")
+            name = item.get("name")
+            if not call_id or not name:
+                raise UnsupportedResponsesFeatureError(
+                    "function_call input items require both 'call_id' (or 'id') and 'name'."
+                )
             messages.append(
                 {
                     "role": "assistant",
                     "content": None,
                     "tool_calls": [
                         {
-                            "id": item.get("call_id") or item.get("id"),
+                            "id": call_id,
                             "type": "function",
                             "function": {
-                                "name": item.get("name"),
+                                "name": name,
                                 "arguments": item.get("arguments", ""),
                             },
                         }
@@ -135,10 +143,15 @@ def _messages_from_input(input_: str | list[dict[str, Any]], instructions: str |
                 }
             )
         elif itype == "function_call_output":
+            # call_id ties the result back to its call; a missing one can't be
+            # associated, so reject rather than emit a tool message with no id.
+            call_id = item.get("call_id")
+            if not call_id:
+                raise UnsupportedResponsesFeatureError("function_call_output input items require 'call_id'.")
             messages.append(
                 {
                     "role": "tool",
-                    "tool_call_id": item.get("call_id"),
+                    "tool_call_id": call_id,
                     "content": _text_of(item.get("output")),
                 }
             )

--- a/modelship/openai/protocol/responses/adapter.py
+++ b/modelship/openai/protocol/responses/adapter.py
@@ -1,0 +1,272 @@
+"""Stateless translation between the Responses API and chat completions.
+
+Two directions:
+
+- :func:`responses_request_to_chat` — ``ResponsesRequest`` → ``ChatCompletionRequest``.
+  Translates the structurally different bits (``input``/``instructions`` →
+  ``messages``, flattened tools → nested, ``text.format`` → ``response_format``,
+  ``max_output_tokens`` → ``max_completion_tokens``) and rejects features Phase A
+  cannot honor (``previous_response_id``, ``background``, hosted built-in tools)
+  with an explicit error rather than dropping them silently.
+- :func:`chat_response_to_responses` — ``ChatCompletionResponse`` → ``ResponseObject``.
+  Maps the parsed message into Responses ``output[]`` items (reasoning / message /
+  function_call) and remaps token usage.
+
+Phase A is text + reasoning + (client-driven) tool calling, non-streaming.
+``store`` is accepted but never persisted — the response echoes ``store=False``.
+Image/audio input parts are reduced to their text for now (vision over
+``/v1/responses`` is out of Phase A scope).
+
+Imports come from the sibling ``schemas`` submodule and the ``chat`` submodule,
+never from the top-level ``modelship.openai.protocol`` package — that package
+imports this one, so reaching back into it would create an import cycle.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Literal
+
+from modelship.openai.protocol.chat import ChatCompletionRequest, ChatCompletionResponse
+from modelship.openai.protocol.responses.schemas import (
+    ResponseFunctionToolCall,
+    ResponseInputTokensDetails,
+    ResponseObject,
+    ResponseOutputMessage,
+    ResponseOutputText,
+    ResponseOutputTokensDetails,
+    ResponseReasoningItem,
+    ResponseReasoningSummary,
+    ResponsesRequest,
+    ResponseUsage,
+)
+
+
+class UnsupportedResponsesFeatureError(ValueError):
+    """A Responses request used a feature Phase A does not implement.
+
+    Subclasses ``ValueError`` so ``create_error_response`` maps it to an
+    OpenAI-style 400 ``invalid_request_error``.
+    """
+
+
+# ---------------------------------------------------------------------------
+# Request: Responses → chat
+# ---------------------------------------------------------------------------
+
+
+def responses_request_to_chat(request: ResponsesRequest) -> ChatCompletionRequest:
+    """Translate a ``ResponsesRequest`` into a non-streaming ``ChatCompletionRequest``.
+
+    Raises :class:`UnsupportedResponsesFeatureError` for stateful/background/hosted-tool
+    features that the stateless Phase A adapter cannot fulfill.
+    """
+    if request.previous_response_id is not None:
+        raise UnsupportedResponsesFeatureError(
+            "previous_response_id is not supported: /v1/responses does not yet persist conversation "
+            "state. Send the full conversation in `input` instead."
+        )
+    if request.background:
+        raise UnsupportedResponsesFeatureError("background mode is not supported on /v1/responses.")
+
+    messages = _messages_from_input(request.input, request.instructions)
+
+    kwargs: dict[str, Any] = {
+        "model": request.model,
+        "messages": messages,
+        "stream": False,
+    }
+    if request.max_output_tokens is not None:
+        kwargs["max_completion_tokens"] = request.max_output_tokens
+    if request.temperature is not None:
+        kwargs["temperature"] = request.temperature
+    if request.top_p is not None:
+        kwargs["top_p"] = request.top_p
+    if request.parallel_tool_calls is not None:
+        kwargs["parallel_tool_calls"] = request.parallel_tool_calls
+    if request.user is not None:
+        kwargs["user"] = request.user
+
+    tools = _tools_to_chat(request.tools)
+    if tools is not None:
+        kwargs["tools"] = tools
+    tool_choice = _tool_choice_to_chat(request.tool_choice)
+    if tool_choice is not None:
+        kwargs["tool_choice"] = tool_choice
+
+    response_format = _response_format_from_text(request.text)
+    if response_format is not None:
+        kwargs["response_format"] = response_format
+
+    effort = (request.reasoning or {}).get("effort")
+    if effort is not None:
+        kwargs["reasoning_effort"] = effort
+
+    return ChatCompletionRequest(**kwargs)
+
+
+def _messages_from_input(input_: str | list[dict[str, Any]], instructions: str | None) -> list[dict[str, Any]]:
+    messages: list[dict[str, Any]] = []
+    if instructions:
+        messages.append({"role": "system", "content": instructions})
+
+    if isinstance(input_, str):
+        messages.append({"role": "user", "content": input_})
+        return messages
+
+    for item in input_:
+        itype = item.get("type")
+        if itype == "function_call":
+            # A prior assistant tool call being replayed as context.
+            messages.append(
+                {
+                    "role": "assistant",
+                    "content": None,
+                    "tool_calls": [
+                        {
+                            "id": item.get("call_id") or item.get("id"),
+                            "type": "function",
+                            "function": {
+                                "name": item.get("name"),
+                                "arguments": item.get("arguments", ""),
+                            },
+                        }
+                    ],
+                }
+            )
+        elif itype == "function_call_output":
+            messages.append(
+                {
+                    "role": "tool",
+                    "tool_call_id": item.get("call_id"),
+                    "content": _text_of(item.get("output")),
+                }
+            )
+        elif itype == "reasoning":
+            # Don't replay raw chain-of-thought back into the prompt.
+            continue
+        elif itype == "message" or "role" in item:
+            messages.append(
+                {
+                    "role": item.get("role", "user"),
+                    "content": _text_of(item.get("content")),
+                }
+            )
+        else:
+            raise UnsupportedResponsesFeatureError(f"unsupported input item type {itype!r}.")
+
+    return messages
+
+
+def _text_of(content: Any) -> str | None:
+    """Reduce a Responses content value to plain text (Phase A is text-only)."""
+    if content is None or isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        parts = [p["text"] for p in content if isinstance(p, dict) and isinstance(p.get("text"), str)]
+        return "".join(parts) if parts else None
+    return str(content)
+
+
+def _tools_to_chat(tools: list[dict[str, Any]] | None) -> list[dict[str, Any]] | None:
+    if not tools:
+        return None
+    out: list[dict[str, Any]] = []
+    for tool in tools:
+        ttype = tool.get("type")
+        if ttype != "function":
+            raise UnsupportedResponsesFeatureError(
+                f"hosted tool type {ttype!r} is not supported; only client-defined 'function' tools are."
+            )
+        # Responses flattens the function fields onto the tool; chat nests them.
+        fn = {k: tool[k] for k in ("name", "description", "parameters", "strict") if k in tool}
+        out.append({"type": "function", "function": fn})
+    return out
+
+
+def _tool_choice_to_chat(tool_choice: str | dict[str, Any] | None) -> str | dict[str, Any] | None:
+    if tool_choice is None or isinstance(tool_choice, str):
+        return tool_choice
+    if tool_choice.get("type") == "function":
+        return {"type": "function", "function": {"name": tool_choice.get("name")}}
+    raise UnsupportedResponsesFeatureError(f"tool_choice type {tool_choice.get('type')!r} is not supported.")
+
+
+def _response_format_from_text(text: dict[str, Any] | None) -> dict[str, Any] | None:
+    """Translate Responses ``text.format`` into chat ``response_format``."""
+    if not text:
+        return None
+    fmt = text.get("format")
+    if not fmt:
+        return None
+    ftype = fmt.get("type")
+    if ftype == "json_schema":
+        # Responses flattens name/schema/strict; chat nests them under json_schema.
+        nested = {k: fmt[k] for k in ("name", "schema", "strict", "description") if k in fmt}
+        return {"type": "json_schema", "json_schema": nested}
+    if ftype in ("json_object", "text"):
+        return {"type": ftype}
+    raise UnsupportedResponsesFeatureError(f"text.format type {ftype!r} is not supported.")
+
+
+# ---------------------------------------------------------------------------
+# Response: chat → Responses
+# ---------------------------------------------------------------------------
+
+
+def chat_response_to_responses(chat: ChatCompletionResponse, request: ResponsesRequest) -> ResponseObject:
+    """Translate a non-streaming ``ChatCompletionResponse`` into a ``ResponseObject``."""
+    choice = chat.choices[0]
+    message = choice.message
+
+    output: list[Any] = []
+    # OpenAI emits reasoning first, then the assistant message / tool calls.
+    if message.reasoning:
+        output.append(ResponseReasoningItem(summary=[ResponseReasoningSummary(text=message.reasoning)]))
+    if message.content:
+        output.append(ResponseOutputMessage(content=[ResponseOutputText(text=message.content)]))
+    for call in message.tool_calls:
+        output.append(
+            ResponseFunctionToolCall(
+                call_id=call.id,
+                name=call.function.name,
+                arguments=call.function.arguments,
+            )
+        )
+
+    status, incomplete = _status_for(choice.finish_reason)
+
+    usage = ResponseUsage(
+        input_tokens=chat.usage.prompt_tokens,
+        output_tokens=chat.usage.completion_tokens or 0,
+        total_tokens=chat.usage.total_tokens,
+        input_tokens_details=ResponseInputTokensDetails(cached_tokens=0),
+        output_tokens_details=ResponseOutputTokensDetails(reasoning_tokens=0),
+    )
+
+    return ResponseObject(
+        model=chat.model,
+        status=status,
+        output=output,
+        usage=usage,
+        incomplete_details=incomplete,
+        # Echo the request settings OpenAI returns on the response object.
+        instructions=request.instructions,
+        max_output_tokens=request.max_output_tokens,
+        temperature=request.temperature,
+        top_p=request.top_p,
+        tools=request.tools or [],
+        tool_choice=request.tool_choice if request.tool_choice is not None else "auto",
+        parallel_tool_calls=request.parallel_tool_calls if request.parallel_tool_calls is not None else True,
+        text=request.text,
+        reasoning=request.reasoning,
+        metadata=request.metadata or {},
+        store=False,
+    )
+
+
+def _status_for(
+    finish_reason: str | None,
+) -> tuple[Literal["completed", "incomplete"], dict[str, Any] | None]:
+    if finish_reason == "length":
+        return "incomplete", {"reason": "max_output_tokens"}
+    return "completed", None

--- a/modelship/openai/protocol/responses/schemas.py
+++ b/modelship/openai/protocol/responses/schemas.py
@@ -1,0 +1,170 @@
+"""Pydantic schemas for the ``/v1/responses`` endpoint (OpenAI Responses API).
+
+Phase A is a *stateless* shape adapter: it accepts the Responses request shape
+and returns the Responses response object, translating to/from the existing
+chat-completion pipeline at the gateway edge (the translation logic lives in
+:mod:`modelship.openai.protocol.responses.adapter`). Server-side conversation
+state (``store`` / ``previous_response_id``), background execution, and OpenAI's
+hosted built-in tools are out of scope here and rejected by the adapter.
+
+Input items are kept as plain ``dict`` (matching ``ChatCompletionMessageParam``)
+so the adapter, not pydantic, owns the role/content/typed-item translation.
+"""
+
+import time
+from typing import Any, Literal
+
+from pydantic import Field
+
+from modelship.openai.protocol.base import OpenAIBaseModel, random_uuid
+
+# ---------------------------------------------------------------------------
+# Request
+# ---------------------------------------------------------------------------
+
+# Input items are typed dicts in the OpenAI spec (message / function_call /
+# function_call_output / reasoning / ...). We keep them loose and translate in
+# the adapter, mirroring how ChatCompletionRequest treats messages.
+ResponseInputItem = dict[str, Any]
+
+
+class ResponsesRequest(OpenAIBaseModel):
+    input: str | list[ResponseInputItem]
+    model: str | None = None
+    instructions: str | None = None
+    max_output_tokens: int | None = None
+    temperature: float | None = None
+    top_p: float | None = None
+    tools: list[dict[str, Any]] | None = None
+    tool_choice: str | dict[str, Any] | None = None
+    parallel_tool_calls: bool | None = None
+    text: dict[str, Any] | None = None
+    reasoning: dict[str, Any] | None = None
+    stream: bool | None = False
+    metadata: dict[str, Any] | None = None
+    user: str | None = None
+    # Stateful / background features — accepted into the schema so the adapter
+    # can reject them explicitly rather than have pydantic drop them silently.
+    store: bool | None = None
+    previous_response_id: str | None = None
+    background: bool | None = None
+
+
+# ---------------------------------------------------------------------------
+# Output items
+# ---------------------------------------------------------------------------
+
+
+class ResponseOutputText(OpenAIBaseModel):
+    type: Literal["output_text"] = "output_text"
+    text: str
+    annotations: list[Any] = Field(default_factory=list)
+
+
+class ResponseOutputMessage(OpenAIBaseModel):
+    type: Literal["message"] = "message"
+    id: str = Field(default_factory=lambda: f"msg_{random_uuid()}")
+    role: Literal["assistant"] = "assistant"
+    status: Literal["completed", "incomplete"] = "completed"
+    content: list[ResponseOutputText] = Field(default_factory=list)
+
+
+class ResponseReasoningText(OpenAIBaseModel):
+    type: Literal["reasoning_text"] = "reasoning_text"
+    text: str
+
+
+class ResponseReasoningSummary(OpenAIBaseModel):
+    type: Literal["summary_text"] = "summary_text"
+    text: str
+
+
+class ResponseReasoningItem(OpenAIBaseModel):
+    type: Literal["reasoning"] = "reasoning"
+    id: str = Field(default_factory=lambda: f"rs_{random_uuid()}")
+    summary: list[ResponseReasoningSummary] = Field(default_factory=list)
+    content: list[ResponseReasoningText] = Field(default_factory=list)
+    encrypted_content: str | None = None
+
+
+class ResponseFunctionToolCall(OpenAIBaseModel):
+    type: Literal["function_call"] = "function_call"
+    id: str = Field(default_factory=lambda: f"fc_{random_uuid()}")
+    call_id: str = Field(default_factory=lambda: f"call_{random_uuid()}")
+    name: str
+    arguments: str
+    status: Literal["completed", "incomplete"] = "completed"
+
+
+# Discriminated only by the literal ``type``; kept as a plain union since we
+# always construct these ourselves rather than parse them from the wire.
+ResponseOutputItem = ResponseReasoningItem | ResponseOutputMessage | ResponseFunctionToolCall
+
+
+# ---------------------------------------------------------------------------
+# Usage
+# ---------------------------------------------------------------------------
+
+
+class ResponseOutputTokensDetails(OpenAIBaseModel):
+    reasoning_tokens: int = 0
+
+
+class ResponseInputTokensDetails(OpenAIBaseModel):
+    cached_tokens: int = 0
+
+
+class ResponseUsage(OpenAIBaseModel):
+    input_tokens: int = 0
+    output_tokens: int = 0
+    total_tokens: int = 0
+    input_tokens_details: ResponseInputTokensDetails | None = None
+    output_tokens_details: ResponseOutputTokensDetails | None = None
+
+
+# ---------------------------------------------------------------------------
+# Response object
+# ---------------------------------------------------------------------------
+
+
+class ResponseObject(OpenAIBaseModel):
+    id: str = Field(default_factory=lambda: f"resp_{random_uuid()}")
+    object: Literal["response"] = "response"
+    created_at: int = Field(default_factory=lambda: int(time.time()))
+    status: Literal["completed", "failed", "incomplete", "in_progress"] = "completed"
+    model: str
+    output: list[ResponseOutputItem] = Field(default_factory=list)
+    usage: ResponseUsage | None = None
+    # Echoed request settings (OpenAI returns these on the response object).
+    instructions: str | None = None
+    max_output_tokens: int | None = None
+    temperature: float | None = None
+    top_p: float | None = None
+    tools: list[dict[str, Any]] = Field(default_factory=list)
+    tool_choice: str | dict[str, Any] = "auto"
+    parallel_tool_calls: bool = True
+    text: dict[str, Any] | None = None
+    reasoning: dict[str, Any] | None = None
+    metadata: dict[str, Any] = Field(default_factory=dict)
+    previous_response_id: str | None = None
+    # Phase A never persists, so this is always False regardless of the request.
+    store: bool = False
+    error: Any | None = None
+    incomplete_details: Any | None = None
+
+
+__all__ = [
+    "ResponseFunctionToolCall",
+    "ResponseInputItem",
+    "ResponseInputTokensDetails",
+    "ResponseObject",
+    "ResponseOutputItem",
+    "ResponseOutputMessage",
+    "ResponseOutputText",
+    "ResponseOutputTokensDetails",
+    "ResponseReasoningItem",
+    "ResponseReasoningSummary",
+    "ResponseReasoningText",
+    "ResponseUsage",
+    "ResponsesRequest",
+]

--- a/modelship/openai/protocol/usage.py
+++ b/modelship/openai/protocol/usage.py
@@ -7,14 +7,20 @@ class PromptTokenUsageInfo(OpenAIBaseModel):
     cached_tokens: int | None = None
 
 
+class CompletionTokenUsageInfo(OpenAIBaseModel):
+    reasoning_tokens: int | None = None
+
+
 class UsageInfo(OpenAIBaseModel):
     prompt_tokens: int = 0
     total_tokens: int = 0
     completion_tokens: int | None = 0
     prompt_tokens_details: PromptTokenUsageInfo | None = None
+    completion_tokens_details: CompletionTokenUsageInfo | None = None
 
 
 __all__ = [
+    "CompletionTokenUsageInfo",
     "PromptTokenUsageInfo",
     "UsageInfo",
 ]

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1622,3 +1622,143 @@ class TestChatTransformersFunctionGemma:
         assert parsed_args.get("city")
         assert "Paris" in parsed_args["city"]
         assert collected["finish_reason"] == "tool_calls"
+
+
+# Responses tools use the *flattened* function shape (name/parameters at the
+# top level), unlike chat completions which nests them under "function".
+_WEATHER_TOOL_RESPONSES = {
+    "type": "function",
+    "name": "get_weather",
+    "description": "Get weather for a city",
+    "parameters": {
+        "type": "object",
+        "properties": {"city": {"type": "string"}},
+        "required": ["city"],
+    },
+}
+
+
+@pytest.mark.integration
+@pytest.mark.vllm
+class TestResponsesEndpoint:
+    """End-to-end /v1/responses through the stateless adapter over the vLLM
+    chat pipeline. Verifies the official OpenAI SDK's ``responses.create``
+    parses our payload and that unsupported features are rejected, not
+    silently dropped."""
+
+    @pytest.fixture(autouse=True, scope="class")
+    def _deploy(self, model_deployer):
+        model_deployer.deploy("chat-capable")
+
+    def test_basic_response_parses_with_openai_sdk(self, client):
+        resp = client.responses.create(
+            model="chat-capable",
+            input="Say hello in one word.",
+            max_output_tokens=20,
+        )
+        assert resp.object == "response"
+        assert resp.status in {"completed", "incomplete"}
+        assert resp.output_text.strip()
+        assert resp.usage.input_tokens > 0
+        # Phase A never persists, so the echoed store flag must be False.
+        assert resp.store is False
+
+    def test_instructions_and_message_list_input(self, client):
+        resp = client.responses.create(
+            model="chat-capable",
+            instructions="Answer in exactly one word.",
+            input=[{"role": "user", "content": "What color is a clear daytime sky?"}],
+            max_output_tokens=20,
+        )
+        assert resp.output_text.strip()
+
+    def test_tool_call_emits_function_call_item(self, client):
+        resp = client.responses.create(
+            model="chat-capable",
+            input="What is the weather in Paris?",
+            tools=[_WEATHER_TOOL_RESPONSES],
+            tool_choice="required",
+            max_output_tokens=128,
+        )
+        function_calls = [item for item in resp.output if item.type == "function_call"]
+        assert function_calls, f"expected a function_call output item, got {[i.type for i in resp.output]}"
+        assert function_calls[0].name == "get_weather"
+        assert "Paris" in function_calls[0].arguments
+
+    def test_stream_true_rejected_400(self):
+        response = httpx.post(
+            f"{OPENAI_API_BASE}/responses",
+            json={"model": "chat-capable", "input": "hi", "stream": True},
+            timeout=60,
+        )
+        assert response.status_code == 400, response.text
+        assert "streaming" in response.json()["error"]["message"]
+
+    def test_previous_response_id_rejected_400(self):
+        response = httpx.post(
+            f"{OPENAI_API_BASE}/responses",
+            json={"model": "chat-capable", "input": "hi", "previous_response_id": "resp_does_not_exist"},
+            timeout=60,
+        )
+        assert response.status_code == 400, response.text
+        assert "previous_response_id" in response.json()["error"]["message"]
+
+    def test_hosted_tool_rejected_400(self):
+        response = httpx.post(
+            f"{OPENAI_API_BASE}/responses",
+            json={"model": "chat-capable", "input": "search the web", "tools": [{"type": "web_search"}]},
+            timeout=60,
+        )
+        assert response.status_code == 400, response.text
+        assert "hosted tool" in response.json()["error"]["message"]
+
+
+@pytest.mark.integration
+@pytest.mark.vllm
+class TestResponsesReasoning:
+    """Reasoning surfaces as a first-class ``reasoning`` output item on
+    /v1/responses (its spec-correct home), distinct from the off-spec
+    ``message.reasoning`` field on chat completions."""
+
+    @pytest.fixture(autouse=True, scope="class")
+    def _deploy(self, model_deployer):
+        model_deployer.deploy("chat-reasoning")
+
+    def test_reasoning_output_item_present(self):
+        response = httpx.post(
+            f"{OPENAI_API_BASE}/responses",
+            json={"model": "chat-reasoning", "input": "Briefly: what is 7 times 8?", "max_output_tokens": 512},
+            timeout=120,
+        )
+        assert response.status_code == 200, response.text
+        output = response.json()["output"]
+
+        reasoning_items = [item for item in output if item["type"] == "reasoning"]
+        assert reasoning_items, f"expected a reasoning output item, got {[i['type'] for i in output]}"
+        summary_text = "".join(s["text"] for item in reasoning_items for s in item.get("summary", []))
+        assert summary_text.strip(), "expected non-empty reasoning summary text"
+        # `<think>` markers must be stripped before reshaping into the item.
+        assert "<think>" not in summary_text
+
+        message_items = [item for item in output if item["type"] == "message"]
+        assert message_items, "expected an assistant message output item alongside reasoning"
+
+
+@pytest.mark.integration
+@pytest.mark.llama_cpp
+class TestResponsesLlamaCpp:
+    """The adapter is loader-agnostic: /v1/responses works over the llama_cpp
+    chat pipeline with no loader-side changes, same as it does over vLLM."""
+
+    @pytest.fixture(autouse=True, scope="class")
+    def _deploy(self, model_deployer):
+        model_deployer.deploy("chat-llama-mship")
+
+    def test_basic_response_through_llama_cpp(self, client):
+        resp = client.responses.create(
+            model="chat-llama-mship",
+            input="Say hello in one word.",
+            max_output_tokens=20,
+        )
+        assert resp.status in {"completed", "incomplete"}
+        assert resp.output_text.strip()

--- a/tests/test_responses_adapter.py
+++ b/tests/test_responses_adapter.py
@@ -6,7 +6,9 @@ from modelship.openai.protocol import (
     ChatCompletionResponse,
     ChatCompletionResponseChoice,
     ChatMessage,
+    CompletionTokenUsageInfo,
     FunctionCall,
+    PromptTokenUsageInfo,
     ResponsesRequest,
     ToolCall,
     UsageInfo,
@@ -129,6 +131,12 @@ class TestRequestRejections:
         with pytest.raises(UnsupportedResponsesFeatureError, match="hosted tool"):
             responses_request_to_chat(_req(tools=[{"type": "web_search"}]))
 
+    def test_text_format_as_string_rejected(self):
+        # A malformed text.format (string instead of object) must be a clean
+        # 400, not an AttributeError -> 500.
+        with pytest.raises(UnsupportedResponsesFeatureError, match="must be an object"):
+            responses_request_to_chat(_req(text={"format": "json_object"}))
+
     def test_store_true_is_accepted(self):
         # store defaults to true on OpenAI; we accept-but-don't-persist rather than reject.
         chat = responses_request_to_chat(_req(store=True))
@@ -185,10 +193,44 @@ class TestResponseTranslation:
         assert resp.usage.output_tokens == 7
         assert resp.usage.total_tokens == 12
 
+    def test_token_details_propagated_when_present(self):
+        # vLLM (prefix caching / reasoning models) reports these; they must
+        # reach the client, not be discarded.
+        chat = ChatCompletionResponse(
+            model="m",
+            choices=[
+                ChatCompletionResponseChoice(
+                    index=0,
+                    message=ChatMessage(role="assistant", content="x"),
+                    finish_reason="stop",
+                )
+            ],
+            usage=UsageInfo(
+                prompt_tokens=5,
+                completion_tokens=7,
+                total_tokens=12,
+                prompt_tokens_details=PromptTokenUsageInfo(cached_tokens=3),
+                completion_tokens_details=CompletionTokenUsageInfo(reasoning_tokens=4),
+            ),
+        )
+        resp = chat_response_to_responses(chat, _req())
+        assert resp.usage.input_tokens_details.cached_tokens == 3
+        assert resp.usage.output_tokens_details.reasoning_tokens == 4
+
+    def test_token_details_default_zero_when_absent(self):
+        resp = chat_response_to_responses(_chat_response(content="x"), _req())
+        assert resp.usage.input_tokens_details.cached_tokens == 0
+        assert resp.usage.output_tokens_details.reasoning_tokens == 0
+
     def test_length_finish_reason_is_incomplete(self):
         resp = chat_response_to_responses(_chat_response(content="x", finish_reason="length"), _req())
         assert resp.status == "incomplete"
         assert resp.incomplete_details == {"reason": "max_output_tokens"}
+
+    def test_content_filter_finish_reason_is_incomplete(self):
+        resp = chat_response_to_responses(_chat_response(content="x", finish_reason="content_filter"), _req())
+        assert resp.status == "incomplete"
+        assert resp.incomplete_details == {"reason": "content_filter"}
 
     def test_store_always_false_and_settings_echoed(self):
         resp = chat_response_to_responses(

--- a/tests/test_responses_adapter.py
+++ b/tests/test_responses_adapter.py
@@ -71,6 +71,18 @@ class TestRequestInputTranslation:
         assert chat.messages[1]["tool_calls"][0]["function"]["name"] == "get_weather"
         assert chat.messages[2] == {"role": "tool", "tool_call_id": "call_1", "content": "sunny"}
 
+    def test_function_call_missing_name_rejected(self):
+        with pytest.raises(UnsupportedResponsesFeatureError, match="function_call"):
+            responses_request_to_chat(_req(input=[{"type": "function_call", "call_id": "call_1", "arguments": "{}"}]))
+
+    def test_function_call_missing_call_id_rejected(self):
+        with pytest.raises(UnsupportedResponsesFeatureError, match="function_call"):
+            responses_request_to_chat(_req(input=[{"type": "function_call", "name": "f", "arguments": "{}"}]))
+
+    def test_function_call_output_missing_call_id_rejected(self):
+        with pytest.raises(UnsupportedResponsesFeatureError, match="function_call_output"):
+            responses_request_to_chat(_req(input=[{"type": "function_call_output", "output": "sunny"}]))
+
     def test_reasoning_input_item_is_dropped(self):
         chat = responses_request_to_chat(
             _req(

--- a/tests/test_responses_adapter.py
+++ b/tests/test_responses_adapter.py
@@ -1,0 +1,201 @@
+"""Tests for the stateless Responses <-> chat-completions adapter (Phase A)."""
+
+import pytest
+
+from modelship.openai.protocol import (
+    ChatCompletionResponse,
+    ChatCompletionResponseChoice,
+    ChatMessage,
+    FunctionCall,
+    ResponsesRequest,
+    ToolCall,
+    UsageInfo,
+)
+from modelship.openai.protocol.responses import (
+    UnsupportedResponsesFeatureError,
+    chat_response_to_responses,
+    responses_request_to_chat,
+)
+
+
+def _req(**overrides) -> ResponsesRequest:
+    payload = {"model": "m", "input": "hello"}
+    payload.update(overrides)
+    return ResponsesRequest(**payload)
+
+
+class TestRequestInputTranslation:
+    def test_string_input_becomes_user_message(self):
+        chat = responses_request_to_chat(_req(input="hi there"))
+        assert chat.messages == [{"role": "user", "content": "hi there"}]
+        assert chat.model == "m"
+        assert chat.stream is False
+
+    def test_instructions_become_leading_system_message(self):
+        chat = responses_request_to_chat(_req(input="hi", instructions="be terse"))
+        assert chat.messages[0] == {"role": "system", "content": "be terse"}
+        assert chat.messages[1] == {"role": "user", "content": "hi"}
+
+    def test_message_items_with_content_parts_flatten_to_text(self):
+        chat = responses_request_to_chat(
+            _req(
+                input=[
+                    {
+                        "type": "message",
+                        "role": "user",
+                        "content": [{"type": "input_text", "text": "a"}, {"type": "input_text", "text": "b"}],
+                    },
+                ]
+            )
+        )
+        assert chat.messages == [{"role": "user", "content": "ab"}]
+
+    def test_role_shorthand_without_type_is_a_message(self):
+        chat = responses_request_to_chat(_req(input=[{"role": "user", "content": "yo"}]))
+        assert chat.messages == [{"role": "user", "content": "yo"}]
+
+    def test_function_call_and_output_round_trip(self):
+        chat = responses_request_to_chat(
+            _req(
+                input=[
+                    {"role": "user", "content": "weather?"},
+                    {"type": "function_call", "call_id": "call_1", "name": "get_weather", "arguments": "{}"},
+                    {"type": "function_call_output", "call_id": "call_1", "output": "sunny"},
+                ]
+            )
+        )
+        assert chat.messages[1]["role"] == "assistant"
+        assert chat.messages[1]["tool_calls"][0]["id"] == "call_1"
+        assert chat.messages[1]["tool_calls"][0]["function"]["name"] == "get_weather"
+        assert chat.messages[2] == {"role": "tool", "tool_call_id": "call_1", "content": "sunny"}
+
+    def test_reasoning_input_item_is_dropped(self):
+        chat = responses_request_to_chat(
+            _req(
+                input=[
+                    {"type": "reasoning", "summary": [{"type": "summary_text", "text": "x"}]},
+                    {"role": "user", "content": "go"},
+                ]
+            )
+        )
+        assert chat.messages == [{"role": "user", "content": "go"}]
+
+    def test_unknown_input_item_type_rejected(self):
+        with pytest.raises(UnsupportedResponsesFeatureError):
+            responses_request_to_chat(_req(input=[{"type": "image_generation_call"}]))
+
+
+class TestRequestFieldTranslation:
+    def test_max_output_tokens_maps_to_max_completion_tokens(self):
+        chat = responses_request_to_chat(_req(max_output_tokens=128))
+        assert chat.max_completion_tokens == 128
+
+    def test_tools_flattened_to_nested(self):
+        chat = responses_request_to_chat(
+            _req(tools=[{"type": "function", "name": "f", "description": "d", "parameters": {"type": "object"}}])
+        )
+        assert chat.tools == [
+            {"type": "function", "function": {"name": "f", "description": "d", "parameters": {"type": "object"}}}
+        ]
+
+    def test_tool_choice_object_translated(self):
+        chat = responses_request_to_chat(_req(tool_choice={"type": "function", "name": "f"}))
+        assert chat.tool_choice == {"type": "function", "function": {"name": "f"}}
+
+    def test_text_format_json_schema_nested(self):
+        chat = responses_request_to_chat(
+            _req(text={"format": {"type": "json_schema", "name": "p", "schema": {"type": "object"}, "strict": True}})
+        )
+        assert chat.response_format == {
+            "type": "json_schema",
+            "json_schema": {"name": "p", "schema": {"type": "object"}, "strict": True},
+        }
+
+    def test_reasoning_effort_passes_through(self):
+        chat = responses_request_to_chat(_req(reasoning={"effort": "high"}))
+        assert chat.reasoning_effort == "high"
+
+
+class TestRequestRejections:
+    def test_previous_response_id_rejected(self):
+        with pytest.raises(UnsupportedResponsesFeatureError, match="previous_response_id"):
+            responses_request_to_chat(_req(previous_response_id="resp_1"))
+
+    def test_background_rejected(self):
+        with pytest.raises(UnsupportedResponsesFeatureError, match="background"):
+            responses_request_to_chat(_req(background=True))
+
+    def test_hosted_tool_rejected(self):
+        with pytest.raises(UnsupportedResponsesFeatureError, match="hosted tool"):
+            responses_request_to_chat(_req(tools=[{"type": "web_search"}]))
+
+    def test_store_true_is_accepted(self):
+        # store defaults to true on OpenAI; we accept-but-don't-persist rather than reject.
+        chat = responses_request_to_chat(_req(store=True))
+        assert chat.messages == [{"role": "user", "content": "hello"}]
+
+
+def _chat_response(*, content=None, reasoning=None, tool_calls=None, finish_reason="stop") -> ChatCompletionResponse:
+    return ChatCompletionResponse(
+        model="m",
+        choices=[
+            ChatCompletionResponseChoice(
+                index=0,
+                message=ChatMessage(
+                    role="assistant",
+                    content=content,
+                    reasoning=reasoning,
+                    tool_calls=tool_calls or [],
+                ),
+                finish_reason=finish_reason,
+            )
+        ],
+        usage=UsageInfo(prompt_tokens=5, completion_tokens=7, total_tokens=12),
+    )
+
+
+class TestResponseTranslation:
+    def test_text_becomes_output_message(self):
+        resp = chat_response_to_responses(_chat_response(content="hi"), _req())
+        assert resp.object == "response"
+        assert resp.status == "completed"
+        assert len(resp.output) == 1
+        msg = resp.output[0]
+        assert msg.type == "message"
+        assert msg.content[0].type == "output_text"
+        assert msg.content[0].text == "hi"
+
+    def test_reasoning_becomes_reasoning_item_first(self):
+        resp = chat_response_to_responses(_chat_response(content="answer", reasoning="because"), _req())
+        assert resp.output[0].type == "reasoning"
+        assert resp.output[0].summary[0].text == "because"
+        assert resp.output[1].type == "message"
+
+    def test_tool_calls_become_function_call_items(self):
+        tc = ToolCall(id="call_9", function=FunctionCall(name="f", arguments="{}"))
+        resp = chat_response_to_responses(_chat_response(tool_calls=[tc]), _req())
+        fc = [o for o in resp.output if o.type == "function_call"]
+        assert len(fc) == 1
+        assert fc[0].call_id == "call_9"
+        assert fc[0].name == "f"
+
+    def test_usage_remapped(self):
+        resp = chat_response_to_responses(_chat_response(content="x"), _req())
+        assert resp.usage.input_tokens == 5
+        assert resp.usage.output_tokens == 7
+        assert resp.usage.total_tokens == 12
+
+    def test_length_finish_reason_is_incomplete(self):
+        resp = chat_response_to_responses(_chat_response(content="x", finish_reason="length"), _req())
+        assert resp.status == "incomplete"
+        assert resp.incomplete_details == {"reason": "max_output_tokens"}
+
+    def test_store_always_false_and_settings_echoed(self):
+        resp = chat_response_to_responses(
+            _chat_response(content="x"),
+            _req(store=True, instructions="sys", max_output_tokens=64, metadata={"k": "v"}),
+        )
+        assert resp.store is False
+        assert resp.instructions == "sys"
+        assert resp.max_output_tokens == 64
+        assert resp.metadata == {"k": "v"}

--- a/tests/test_responses_api.py
+++ b/tests/test_responses_api.py
@@ -77,6 +77,17 @@ class TestResponsesRoute:
         assert "previous_response_id" in body["error"]["message"]
 
     @pytest.mark.asyncio
+    async def test_invalid_param_returns_400_not_500(self, api):
+        # An invalid reasoning.effort fails when constructing the
+        # ChatCompletionRequest (pydantic ValidationError, not a ValueError);
+        # the route must convert it to a 400, not let it 500.
+        request = ResponsesRequest(model="m", input="hi", reasoning={"effort": "turbo"})
+        result = await api.create_response(request, _raw_request())
+        assert result.status_code == 400
+        body = json.loads(bytes(result.body))
+        assert body["error"]["type"] == "invalid_request_error"
+
+    @pytest.mark.asyncio
     async def test_end_to_end_adaptation_through_handle_response(self, api):
         # Drive the real _handle_response with a mock generator yielding a chat
         # response, and assert the body comes back in Responses shape.

--- a/tests/test_responses_api.py
+++ b/tests/test_responses_api.py
@@ -1,0 +1,110 @@
+"""Route-level tests for /v1/responses (Phase A, non-streaming)."""
+
+import json
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from modelship.openai.api import ModelshipAPI
+from modelship.openai.protocol import (
+    ChatCompletionRequest,
+    ChatCompletionResponse,
+    ChatCompletionResponseChoice,
+    ChatMessage,
+    ResponsesRequest,
+    UsageInfo,
+)
+
+_ModelshipAPI = ModelshipAPI.func_or_class
+
+
+@pytest.fixture
+def api():
+    with patch("modelship.openai.api.serve.get_replica_context") as mock_ctx:
+        mock_ctx.return_value.app_name = "test-gateway"
+        return _ModelshipAPI()
+
+
+def _raw_request():
+    raw = MagicMock()
+    raw.headers = {}
+    return raw
+
+
+class TestResponsesRoute:
+    @pytest.mark.asyncio
+    async def test_adapts_request_and_reuses_handle_response(self, api):
+        handle = MagicMock()
+        remote = handle.generate.options.return_value.remote
+        api.models = {"m": {"m-a1b2c": handle}}
+        api._round_robin = {"m": 0}
+
+        request = ResponsesRequest(model="m", input="hi", instructions="be terse")
+
+        with (
+            patch("modelship.openai.api.RequestWatcher"),
+            patch.object(api, "_handle_response", new=AsyncMock(return_value="OK")) as hr,
+        ):
+            result = await api.create_response(request, _raw_request())
+
+        assert result == "OK"
+        # The chat request handed to the actor must be the translated shape.
+        chat_request = remote.call_args.args[0]
+        assert isinstance(chat_request, ChatCompletionRequest)
+        assert chat_request.messages == [
+            {"role": "system", "content": "be terse"},
+            {"role": "user", "content": "hi"},
+        ]
+        assert chat_request.stream is False
+        hr.assert_awaited_once()
+        # endpoint label flows through to _handle_response for metrics.
+        assert hr.call_args.args[3] == "create_response"
+
+    @pytest.mark.asyncio
+    async def test_stream_true_rejected_400(self, api):
+        request = ResponsesRequest(model="m", input="hi", stream=True)
+        result = await api.create_response(request, _raw_request())
+        assert result.status_code == 400
+        body = json.loads(bytes(result.body))
+        assert "streaming" in body["error"]["message"]
+
+    @pytest.mark.asyncio
+    async def test_previous_response_id_rejected_400(self, api):
+        request = ResponsesRequest(model="m", input="hi", previous_response_id="resp_1")
+        result = await api.create_response(request, _raw_request())
+        assert result.status_code == 400
+        body = json.loads(bytes(result.body))
+        assert "previous_response_id" in body["error"]["message"]
+
+    @pytest.mark.asyncio
+    async def test_end_to_end_adaptation_through_handle_response(self, api):
+        # Drive the real _handle_response with a mock generator yielding a chat
+        # response, and assert the body comes back in Responses shape.
+        handle = MagicMock()
+
+        async def gen():
+            yield ChatCompletionResponse(
+                model="m",
+                choices=[
+                    ChatCompletionResponseChoice(
+                        index=0,
+                        message=ChatMessage(role="assistant", content="hello!"),
+                        finish_reason="stop",
+                    )
+                ],
+                usage=UsageInfo(prompt_tokens=1, completion_tokens=2, total_tokens=3),
+            )
+
+        handle.generate.options.return_value.remote.return_value = gen()
+        api.models = {"m": {"m-a1b2c": handle}}
+        api._round_robin = {"m": 0}
+
+        request = ResponsesRequest(model="m", input="hi")
+        with patch("modelship.openai.api.RequestWatcher"):
+            result = await api.create_response(request, _raw_request())
+
+        body = json.loads(bytes(result.body))
+        assert body["object"] == "response"
+        assert body["output"][0]["type"] == "message"
+        assert body["output"][0]["content"][0]["text"] == "hello!"
+        assert body["usage"]["input_tokens"] == 1


### PR DESCRIPTION
Implement /v1/responses as a gateway-side adapter over the existing chat-completion pipeline rather than a new inference path, so all three chat loaders (vLLM/transformers/llama_cpp) gain the endpoint with no loader-side changes.

- protocol/responses/ package: pydantic schemas + a stateless adapter (ResponsesRequest -> ChatCompletionRequest, ChatCompletionResponse -> ResponseObject). Reasoning surfaces as a first-class reasoning output item -- its spec-correct home, distinct from chat's message.reasoning.
- Request translation: input/instructions -> messages, function_call / function_call_output round-trip, flattened tools -> nested, text.format -> response_format, max_output_tokens -> max_completion_tokens.
- Reject stateful/background/hosted-tool features explicitly with a 400 rather than dropping them silently; store is accepted but not persisted (response echoes store=false).
- Non-streaming only for now; stream=true is rejected (the Responses streaming event protocol is a follow-up slice).

The /v1/responses route reuses _handle_response unchanged by adapting the chat response generator into ResponseObject. Unit tests cover the adapter and route; integration tests exercise the endpoint end-to-end over both the vLLM and llama_cpp loaders (loader-agnostic) plus reasoning items.


