### PR TITLE
feat(responses): streaming event protocol for /v1/responses (Phase A2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ Models can be deployed across multiple GPUs, run on CPU-only, or both — multip
 | Endpoint | Usecase |
 |---|---|
 | `POST /v1/chat/completions` | Chat / text generation (streaming and non-streaming) |
+| `POST /v1/responses` | Responses API — text, reasoning and client-driven tool calls (streaming and non-streaming) |
 | `POST /v1/embeddings` | Text embeddings |
 | `POST /v1/audio/transcriptions` | Speech-to-text |
 | `POST /v1/audio/translations` | Audio translation |

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -44,6 +44,35 @@ Each deployment uses one of the following loaders:
 
 The `transformers` loader is ideal for CPU-only deployments, smaller models, or development/testing without a GPU. It uses HuggingFace `pipeline()` under the hood and handles audio resampling automatically for speech-to-text models. The `llama_cpp` loader provides high-efficiency inference for quantized GGUF models on CPU. The `vllm` loader provides higher throughput on GPU with continuous batching and PagedAttention.
 
+## Responses API (`/v1/responses`)
+
+`/v1/responses` is implemented as a **stateless adapter at the gateway edge**, not a new inference path. The route translates a `ResponsesRequest` into a `ChatCompletionRequest`, runs it through the unchanged `handle.generate` deployment method, and translates the chat result back into the Responses shape. Because it reuses the chat pipeline, it works identically across every chat-capable loader (vLLM, transformers, llama_cpp) with zero loader-side code.
+
+- **Non-streaming** — `chat_response_to_responses` maps `choices[].message` into `output[]` items (`reasoning` → reasoning item, content → message item, tool calls → `function_call` items) and remaps usage.
+- **Streaming** (`stream: true`) — `ResponsesStreamTranslator` consumes the chat SSE chunk stream (the one wire shape all loaders share) and re-emits the Responses event protocol (`response.created` → `output_item.added` → `output_text.delta` / `reasoning_summary_text.delta` / `function_call_arguments.delta` → `output_item.done` → `response.completed`), tracking `output_index` / `sequence_number`. Output items are opened lazily on their first delta and closed at stream end, so the translation is independent of how a model interleaves reasoning, text, and tool calls.
+
+**Supported:** text, reasoning (as a first-class `reasoning` output item), and client-driven tool calling (`function_call` / `function_call_output` round-trip), streaming and non-streaming.
+
+**Rejected with a clear 400** (rather than silently dropped): `previous_response_id`, `background`, and hosted built-in tools (e.g. `web_search`). These require server-side conversation state, which `/v1/responses` does not yet keep — `store` is accepted but never persisted (the response echoes `store: false`). Encrypted reasoning (`reasoning.encrypted_content`) is also not implemented.
+
+Any chat-capable model works — no special `models.yaml` entry is needed:
+
+```python
+from openai import OpenAI
+
+client = OpenAI(base_url="http://localhost:8000/v1", api_key="…")
+
+# Non-streaming
+resp = client.responses.create(model="reasoning-qwen", input="Which is larger, 9.11 or 9.9?")
+print(resp.output_text)
+
+# Streaming — named events; reasoning and tool-call argument deltas stream live
+with client.responses.stream(model="reasoning-qwen", input="Explain why, briefly.") as stream:
+    for event in stream:
+        if event.type == "response.output_text.delta":
+            print(event.delta, end="", flush=True)
+```
+
 ## GPU Allocation
 
 Ray automatically schedules model deployments across available GPUs based on the `num_gpus` fraction each model requests. For example, two models each requesting `num_gpus: 0.9` will be placed on separate GPUs.
@@ -65,6 +94,7 @@ See [Plugin Development](plugins.md) for details.
 |------|---------|
 | `mship_deploy.py` | Entry point — initializes Ray, deploys models additively (or fresh with `--redeploy`) |
 | `modelship/openai/api.py` | FastAPI gateway with OpenAI endpoints |
+| `modelship/openai/protocol/responses/` | `/v1/responses` schemas + stateless chat adapter (`adapter.py`) and streaming translator (`streaming.py`) |
 | `modelship/infer/model_deployment.py` | Ray Serve deployment actor |
 | `modelship/infer/infer_config.py` | Pydantic config models and protocols |
 | `modelship/infer/vllm/vllm_infer.py` | vLLM engine wrapper |

--- a/modelship/openai/api.py
+++ b/modelship/openai/api.py
@@ -1,7 +1,7 @@
 import os
 import time
 from http import HTTPStatus
-from typing import Annotated
+from typing import Annotated, Any, cast
 
 from fastapi import FastAPI, Form, HTTPException, Request
 from fastapi.encoders import jsonable_encoder
@@ -11,7 +11,7 @@ from fastapi.responses import JSONResponse, Response, StreamingResponse
 from pydantic import BaseModel, Field, ValidationError
 from ray import serve
 from ray.exceptions import RayTaskError
-from ray.serve.handle import DeploymentHandle
+from ray.serve.handle import DeploymentHandle, DeploymentResponseGenerator
 from starlette.middleware.base import BaseHTTPMiddleware
 from starlette.types import ASGIApp
 
@@ -46,10 +46,12 @@ from modelship.openai.protocol import (
     TranslationResponse,
     create_error_response,
 )
+from modelship.openai.protocol.chat import StreamOptions
 from modelship.openai.protocol.responses import (
     UnsupportedResponsesFeatureError,
-    chat_response_to_responses,
+    responses_from_chat,
     responses_request_to_chat,
+    responses_stream_from_chat,
 )
 from modelship.utils import random_uuid
 
@@ -141,20 +143,6 @@ def _validation_error_from_cause(cause: BaseException) -> ErrorResponse:
         status_code=HTTPStatus.BAD_REQUEST,
         param=getattr(cause, "parameter", None),
     )
-
-
-async def _responses_from_chat(response_gen, request: ResponsesRequest):
-    """Adapt a chat-completion response generator into Responses output.
-
-    Lets ``/v1/responses`` reuse ``_handle_response`` unchanged: chat
-    response objects are translated to ``ResponseObject`` while errors and
-    Ray exceptions pass through to the same handling as every other endpoint.
-    """
-    async for item in response_gen:
-        if isinstance(item, ChatCompletionResponse):
-            yield chat_response_to_responses(item, request)
-        else:
-            yield item
 
 
 @serve.deployment
@@ -435,16 +423,6 @@ class ModelshipAPI:
         req_id = random_uuid()
         self._set_request_id(req_id)
         model = request.model or ""
-        if request.stream:
-            # Phase A is non-streaming only; the Responses streaming event
-            # protocol is a separate (A2) deliverable. Reject rather than
-            # silently downgrade to a single non-streamed body.
-            return _error_response(
-                create_error_response(
-                    "streaming is not yet supported on /v1/responses; set stream=false.",
-                    status_code=HTTPStatus.BAD_REQUEST,
-                )
-            )
         try:
             chat_request = responses_request_to_chat(request)
         except UnsupportedResponsesFeatureError as e:
@@ -455,17 +433,35 @@ class ModelshipAPI:
             # which is not a ValueError — return a 400 rather than a generic 500.
             return _error_response(_validation_error_from_cause(e))
 
+        if request.stream:
+            # Drive the chat pipeline in streaming mode and translate its SSE
+            # chunks into the Responses event protocol. include_usage so the
+            # terminal response.completed event carries token counts.
+            chat_request.stream = True
+            chat_request.stream_options = StreamOptions(include_usage=True)
+
         handle = self._get_handle(request.model)
         watcher = RequestWatcher(raw_request, model=model, endpoint="create_response")
         headers = dict(raw_request.headers)
         logger.info(
-            "responses model=%s input_items=%s max_output_tokens=%s",
+            "responses model=%s input_items=%s max_output_tokens=%s stream=%s",
             model,
             1 if isinstance(request.input, str) else len(request.input),
             request.max_output_tokens,
+            bool(request.stream),
         )
-        response_gen = handle.generate.options(stream=True).remote(chat_request, headers, watcher.event, req_id)
-        adapted = _responses_from_chat(response_gen, request)
+        # Under stream=True the remote() result is an async-iterable
+        # DeploymentResponseGenerator; Ray's stub widens it to a union because it
+        # doesn't overload on the stream literal, so narrow it explicitly.
+        response_gen = cast(
+            "DeploymentResponseGenerator[Any]",
+            handle.generate.options(stream=True).remote(chat_request, headers, watcher.event, req_id),
+        )
+        adapted = (
+            responses_stream_from_chat(response_gen, request)
+            if request.stream
+            else responses_from_chat(response_gen, request)
+        )
         return await self._handle_response(adapted, watcher, model, "create_response")
 
     @app.post("/v1/embeddings")

--- a/modelship/openai/protocol/responses/__init__.py
+++ b/modelship/openai/protocol/responses/__init__.py
@@ -8,14 +8,16 @@ into a Responses :class:`ResponseObject`.
 
 Thin re-exporter over the leaf submodules (mirrors the parent ``protocol``
 package): :mod:`.schemas` holds the pydantic models, :mod:`.adapter` the
-translation logic. The two submodules import cleanly in either order —
-``adapter`` pulls in ``schemas`` itself, and neither reaches back into the
-top-level ``protocol`` package — so no import cycle exists here.
+non-streaming translation, :mod:`.streaming` the streaming translator. The
+submodules import cleanly — ``adapter`` pulls in ``schemas``, ``streaming``
+pulls in ``adapter`` + ``schemas``, and none reach back into the top-level
+``protocol`` package — so no import cycle exists here.
 """
 
 from modelship.openai.protocol.responses.adapter import (
     UnsupportedResponsesFeatureError,
     chat_response_to_responses,
+    responses_from_chat,
     responses_request_to_chat,
 )
 from modelship.openai.protocol.responses.schemas import (
@@ -33,6 +35,10 @@ from modelship.openai.protocol.responses.schemas import (
     ResponsesRequest,
     ResponseUsage,
 )
+from modelship.openai.protocol.responses.streaming import (
+    ResponsesStreamTranslator,
+    responses_stream_from_chat,
+)
 
 __all__ = [
     "ResponseFunctionToolCall",
@@ -48,7 +54,10 @@ __all__ = [
     "ResponseReasoningText",
     "ResponseUsage",
     "ResponsesRequest",
+    "ResponsesStreamTranslator",
     "UnsupportedResponsesFeatureError",
     "chat_response_to_responses",
+    "responses_from_chat",
     "responses_request_to_chat",
+    "responses_stream_from_chat",
 ]

--- a/modelship/openai/protocol/responses/adapter.py
+++ b/modelship/openai/protocol/responses/adapter.py
@@ -24,6 +24,7 @@ imports this one, so reaching back into it would create an import cycle.
 
 from __future__ import annotations
 
+from collections.abc import AsyncIterator
 from typing import Any, Literal
 
 from modelship.openai.protocol.chat import ChatCompletionRequest, ChatCompletionResponse
@@ -253,25 +254,72 @@ def chat_response_to_responses(chat: ChatCompletionResponse, request: ResponsesR
 
     status, incomplete = _status_for(choice.finish_reason)
 
-    return ResponseObject(
-        model=chat.model,
+    return build_response_object(
+        request,
         status=status,
         output=output,
         usage=_usage_from_chat(chat.usage),
-        incomplete_details=incomplete,
-        # Echo the request settings OpenAI returns on the response object.
-        instructions=request.instructions,
-        max_output_tokens=request.max_output_tokens,
-        temperature=request.temperature,
-        top_p=request.top_p,
-        tools=request.tools or [],
-        tool_choice=request.tool_choice if request.tool_choice is not None else "auto",
-        parallel_tool_calls=request.parallel_tool_calls if request.parallel_tool_calls is not None else True,
-        text=request.text,
-        reasoning=request.reasoning,
-        metadata=request.metadata or {},
-        store=False,
+        incomplete=incomplete,
+        model=chat.model,
     )
+
+
+async def responses_from_chat(response_gen: AsyncIterator[Any], request: ResponsesRequest) -> AsyncIterator[Any]:
+    """Adapt a non-streaming chat response generator into Responses output.
+
+    Lets ``/v1/responses`` reuse ``_handle_response`` unchanged: chat response
+    objects are translated to ``ResponseObject`` while errors and Ray exceptions
+    pass through to the same handling as every other endpoint. The streaming
+    counterpart is ``responses_stream_from_chat`` in :mod:`.streaming`.
+    """
+    async for item in response_gen:
+        if isinstance(item, ChatCompletionResponse):
+            yield chat_response_to_responses(item, request)
+        else:
+            yield item
+
+
+def build_response_object(
+    request: ResponsesRequest,
+    *,
+    status: str,
+    output: list[Any],
+    usage: ResponseUsage | None,
+    incomplete: dict[str, Any] | None,
+    model: str | None = None,
+    response_id: str | None = None,
+    created_at: int | None = None,
+) -> ResponseObject:
+    """Build a ``ResponseObject``, echoing the request settings OpenAI returns.
+
+    Shared by the non-streaming adapter and the streaming translator so the
+    ``response.created`` / ``response.completed`` envelopes and the
+    non-streaming body carry an identical shape. ``response_id`` / ``created_at``
+    let the streaming translator keep one stable id across all of its events.
+    """
+    kwargs: dict[str, Any] = {
+        "model": model or request.model or "",
+        "status": status,
+        "output": output,
+        "usage": usage,
+        "incomplete_details": incomplete,
+        "instructions": request.instructions,
+        "max_output_tokens": request.max_output_tokens,
+        "temperature": request.temperature,
+        "top_p": request.top_p,
+        "tools": request.tools or [],
+        "tool_choice": request.tool_choice if request.tool_choice is not None else "auto",
+        "parallel_tool_calls": request.parallel_tool_calls if request.parallel_tool_calls is not None else True,
+        "text": request.text,
+        "reasoning": request.reasoning,
+        "metadata": request.metadata or {},
+        "store": False,
+    }
+    if response_id is not None:
+        kwargs["id"] = response_id
+    if created_at is not None:
+        kwargs["created_at"] = created_at
+    return ResponseObject(**kwargs)
 
 
 def _usage_from_chat(usage: UsageInfo) -> ResponseUsage:

--- a/modelship/openai/protocol/responses/schemas.py
+++ b/modelship/openai/protocol/responses/schemas.py
@@ -65,7 +65,7 @@ class ResponseOutputMessage(OpenAIBaseModel):
     type: Literal["message"] = "message"
     id: str = Field(default_factory=lambda: f"msg_{random_uuid()}")
     role: Literal["assistant"] = "assistant"
-    status: Literal["completed", "incomplete"] = "completed"
+    status: Literal["in_progress", "completed", "incomplete"] = "completed"
     content: list[ResponseOutputText] = Field(default_factory=list)
 
 
@@ -93,7 +93,7 @@ class ResponseFunctionToolCall(OpenAIBaseModel):
     call_id: str = Field(default_factory=lambda: f"call_{random_uuid()}")
     name: str
     arguments: str
-    status: Literal["completed", "incomplete"] = "completed"
+    status: Literal["in_progress", "completed", "incomplete"] = "completed"
 
 
 # Discriminated only by the literal ``type``; kept as a plain union since we

--- a/modelship/openai/protocol/responses/streaming.py
+++ b/modelship/openai/protocol/responses/streaming.py
@@ -57,11 +57,12 @@ def _sse(event_type: str, payload: dict[str, Any]) -> str:
     return f"event: {event_type}\ndata: {json.dumps({'type': event_type, **payload})}\n\n"
 
 
-def _parse_chat_sse(raw: str) -> ChatCompletionStreamResponse | None:
-    """Parse a chat ``data: {...}`` SSE string into a stream chunk.
+def _parse_chat_sse(raw: str) -> Iterator[ChatCompletionStreamResponse]:
+    """Parse chat ``data: {...}`` SSE messages into stream chunks.
 
-    Returns ``None`` for the ``[DONE]`` sentinel or any non-data line so the
-    caller can simply skip it.
+    A single ``raw`` string may bundle several SSE messages (e.g. from
+    buffering or batching). Yields a chunk for every ``data:`` line, skipping
+    the ``[DONE]`` sentinel and any non-data lines.
     """
     for line in raw.splitlines():
         line = line.strip()
@@ -69,9 +70,8 @@ def _parse_chat_sse(raw: str) -> ChatCompletionStreamResponse | None:
             continue
         payload = line[len("data:") :].strip()
         if not payload or payload == "[DONE]":
-            return None
-        return ChatCompletionStreamResponse.model_validate_json(payload)
-    return None
+            continue
+        yield ChatCompletionStreamResponse.model_validate_json(payload)
 
 
 class ResponsesStreamTranslator:
@@ -349,11 +349,9 @@ async def responses_stream_from_chat(response_gen: AsyncIterator[Any], request: 
             started = True
             for event in translator.start():
                 yield event
-        chunk = _parse_chat_sse(item)
-        if chunk is None:
-            continue
-        for event in translator.process(chunk):
-            yield event
+        for chunk in _parse_chat_sse(item):
+            for event in translator.process(chunk):
+                yield event
     if started:
         for event in translator.finish():
             yield event

--- a/modelship/openai/protocol/responses/streaming.py
+++ b/modelship/openai/protocol/responses/streaming.py
@@ -151,7 +151,7 @@ class ResponsesStreamTranslator:
                 yield from self._on_reasoning(delta.reasoning)
             if delta.content:
                 yield from self._on_content(delta.content)
-            for tc in delta.tool_calls:
+            for tc in delta.tool_calls or []:
                 yield from self._on_tool_call(tc)
             if choice.finish_reason is not None:
                 self.finish_reason = choice.finish_reason

--- a/modelship/openai/protocol/responses/streaming.py
+++ b/modelship/openai/protocol/responses/streaming.py
@@ -1,0 +1,359 @@
+"""Streaming translation: chat-completion SSE → Responses event stream.
+
+The chat loaders all emit Server-Sent Events as ``data: {chunk}\\n\\n`` strings
+(``ChatCompletionStreamResponse`` payloads) terminated by ``data: [DONE]`` — this
+is the one wire shape vLLM and the ``ChatOutputStreamer`` loaders (transformers,
+llama_cpp, plugins) share. The Responses API instead wants a *semantic* event
+protocol: named events (``response.created``, ``response.output_text.delta``, …)
+each carrying a monotonically increasing ``sequence_number`` plus the relevant
+output index, wrapping each output item in explicit added/done brackets.
+
+:class:`ResponsesStreamTranslator` consumes the parsed chat chunks and brackets
+them. Design choices that matter:
+
+- **Three flat channels, no nesting.** Each chat ``DeltaMessage`` carries
+  independent ``content`` / ``reasoning`` / ``tool_calls`` fields; the upstream
+  scanner already resolved any marker nesting. Responses ``output`` is likewise
+  a flat list of items. So we map channels → items 1:1 (one message item, one
+  reasoning item, one ``function_call`` per tool index).
+- **Open on first delta, close at ``finish``.** No ordering is assumed between
+  channels (a model may interleave answer/tool/answer text). An item's bracket
+  is opened the first time its channel produces a delta and stays open until the
+  stream ends, so late text on an already-seen channel always has a home. The
+  only cost is that an earlier item's ``output_item.done`` arrives at the end
+  rather than the instant the next item starts — spec-valid, and SDK accumulators
+  key off ``item_id`` so they reconstruct identically.
+
+Imports stay within the package's leaf submodules (``schemas`` + ``adapter``),
+never the top-level ``modelship.openai.protocol`` package, to avoid an import
+cycle (that package imports this one).
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import AsyncIterator, Iterator
+from typing import Any
+
+from modelship.openai.protocol.base import random_uuid
+from modelship.openai.protocol.chat import ChatCompletionStreamResponse, DeltaToolCall
+from modelship.openai.protocol.responses.adapter import (
+    _status_for,
+    _usage_from_chat,
+    build_response_object,
+)
+from modelship.openai.protocol.responses.schemas import (
+    ResponseFunctionToolCall,
+    ResponseOutputMessage,
+    ResponseOutputText,
+    ResponseReasoningItem,
+    ResponseReasoningSummary,
+    ResponsesRequest,
+)
+
+
+def _sse(event_type: str, payload: dict[str, Any]) -> str:
+    """Format one Responses SSE event (named event line + JSON data line)."""
+    return f"event: {event_type}\ndata: {json.dumps({'type': event_type, **payload})}\n\n"
+
+
+def _parse_chat_sse(raw: str) -> ChatCompletionStreamResponse | None:
+    """Parse a chat ``data: {...}`` SSE string into a stream chunk.
+
+    Returns ``None`` for the ``[DONE]`` sentinel or any non-data line so the
+    caller can simply skip it.
+    """
+    for line in raw.splitlines():
+        line = line.strip()
+        if not line.startswith("data:"):
+            continue
+        payload = line[len("data:") :].strip()
+        if not payload or payload == "[DONE]":
+            return None
+        return ChatCompletionStreamResponse.model_validate_json(payload)
+    return None
+
+
+class ResponsesStreamTranslator:
+    """Stateful translator from chat stream chunks to Responses SSE events.
+
+    One instance per request. Emit :meth:`start` first, feed every parsed chunk
+    to :meth:`process`, then emit :meth:`finish` once the chat stream ends.
+    """
+
+    def __init__(self, request: ResponsesRequest):
+        self.request = request
+        self.response_id = f"resp_{random_uuid()}"
+        self.created_at: int | None = None  # pinned after the first envelope
+        self.model = request.model or ""
+        self._seq = 0
+        self._next_oi = 0
+
+        self.usage = None
+        self.finish_reason: str | None = None
+
+        # One reasoning item (mapped to a single summary part).
+        self._reasoning: ResponseReasoningItem | None = None
+        self._reasoning_oi = -1
+        self._reasoning_text = ""
+
+        # One assistant message item (single output_text part).
+        self._message: ResponseOutputMessage | None = None
+        self._message_oi = -1
+        self._message_text = ""
+
+        # Tool calls, keyed by their chat-stream delta index.
+        self._tools: dict[int, ResponseFunctionToolCall] = {}
+        self._tool_args: dict[int, str] = {}
+        self._tool_oi: dict[int, int] = {}
+
+    # -- low-level helpers --------------------------------------------------
+
+    def _event(self, event_type: str, payload: dict[str, Any]) -> str:
+        out = _sse(event_type, {"sequence_number": self._seq, **payload})
+        self._seq += 1
+        return out
+
+    def _take_oi(self) -> int:
+        oi = self._next_oi
+        self._next_oi += 1
+        return oi
+
+    def _envelope(self, event_type: str, status: str, output: list[Any], usage, incomplete) -> str:
+        response = build_response_object(
+            self.request,
+            status=status,
+            output=output,
+            usage=usage,
+            incomplete=incomplete,
+            model=self.model,
+            response_id=self.response_id,
+            created_at=self.created_at,
+        )
+        # Pin created_at after the first build so every envelope is identical.
+        self.created_at = response.created_at
+        return self._event(event_type, {"response": response.model_dump(mode="json")})
+
+    # -- lifecycle ----------------------------------------------------------
+
+    def start(self) -> Iterator[str]:
+        yield self._envelope("response.created", "in_progress", [], None, None)
+        yield self._envelope("response.in_progress", "in_progress", [], None, None)
+
+    def process(self, chunk: ChatCompletionStreamResponse) -> Iterator[str]:
+        if chunk.model:
+            self.model = chunk.model
+        if chunk.usage is not None:
+            self.usage = chunk.usage
+        for choice in chunk.choices:
+            delta = choice.delta
+            if delta.reasoning:
+                yield from self._on_reasoning(delta.reasoning)
+            if delta.content:
+                yield from self._on_content(delta.content)
+            for tc in delta.tool_calls:
+                yield from self._on_tool_call(tc)
+            if choice.finish_reason is not None:
+                self.finish_reason = choice.finish_reason
+
+    def finish(self) -> Iterator[str]:
+        # Close every open item, in output-index (first-seen) order.
+        yield from self._close_reasoning()
+        yield from self._close_message()
+        yield from self._close_tools()
+
+        output: list[Any] = []
+        if self._reasoning is not None:
+            output.append(self._reasoning)
+        if self._message is not None:
+            output.append(self._message)
+        for idx in sorted(self._tools):
+            output.append(self._tools[idx])
+
+        status, incomplete = _status_for(self.finish_reason)
+        usage = _usage_from_chat(self.usage) if self.usage is not None else None
+        terminal = "response.incomplete" if status == "incomplete" else "response.completed"
+        yield self._envelope(terminal, status, output, usage, incomplete)
+
+    # -- reasoning channel --------------------------------------------------
+
+    def _on_reasoning(self, text: str) -> Iterator[str]:
+        if self._reasoning is None:
+            self._reasoning = ResponseReasoningItem(summary=[])
+            self._reasoning_oi = self._take_oi()
+            yield self._event(
+                "response.output_item.added",
+                {"output_index": self._reasoning_oi, "item": self._reasoning.model_dump(mode="json")},
+            )
+            yield self._event(
+                "response.reasoning_summary_part.added",
+                {
+                    "item_id": self._reasoning.id,
+                    "output_index": self._reasoning_oi,
+                    "summary_index": 0,
+                    "part": {"type": "summary_text", "text": ""},
+                },
+            )
+        self._reasoning_text += text
+        yield self._event(
+            "response.reasoning_summary_text.delta",
+            {
+                "item_id": self._reasoning.id,
+                "output_index": self._reasoning_oi,
+                "summary_index": 0,
+                "delta": text,
+            },
+        )
+
+    def _close_reasoning(self) -> Iterator[str]:
+        if self._reasoning is None:
+            return
+        item = self._reasoning
+        yield self._event(
+            "response.reasoning_summary_text.done",
+            {"item_id": item.id, "output_index": self._reasoning_oi, "summary_index": 0, "text": self._reasoning_text},
+        )
+        yield self._event(
+            "response.reasoning_summary_part.done",
+            {
+                "item_id": item.id,
+                "output_index": self._reasoning_oi,
+                "summary_index": 0,
+                "part": {"type": "summary_text", "text": self._reasoning_text},
+            },
+        )
+        item.summary = [ResponseReasoningSummary(text=self._reasoning_text)]
+        yield self._event(
+            "response.output_item.done",
+            {"output_index": self._reasoning_oi, "item": item.model_dump(mode="json")},
+        )
+
+    # -- message (content) channel -----------------------------------------
+
+    def _on_content(self, text: str) -> Iterator[str]:
+        if self._message is None:
+            self._message = ResponseOutputMessage(status="in_progress", content=[])
+            self._message_oi = self._take_oi()
+            yield self._event(
+                "response.output_item.added",
+                {"output_index": self._message_oi, "item": self._message.model_dump(mode="json")},
+            )
+            yield self._event(
+                "response.content_part.added",
+                {
+                    "item_id": self._message.id,
+                    "output_index": self._message_oi,
+                    "content_index": 0,
+                    "part": {"type": "output_text", "text": "", "annotations": []},
+                },
+            )
+        self._message_text += text
+        yield self._event(
+            "response.output_text.delta",
+            {
+                "item_id": self._message.id,
+                "output_index": self._message_oi,
+                "content_index": 0,
+                "delta": text,
+            },
+        )
+
+    def _close_message(self) -> Iterator[str]:
+        if self._message is None:
+            return
+        item = self._message
+        yield self._event(
+            "response.output_text.done",
+            {"item_id": item.id, "output_index": self._message_oi, "content_index": 0, "text": self._message_text},
+        )
+        yield self._event(
+            "response.content_part.done",
+            {
+                "item_id": item.id,
+                "output_index": self._message_oi,
+                "content_index": 0,
+                "part": {"type": "output_text", "text": self._message_text, "annotations": []},
+            },
+        )
+        item.content = [ResponseOutputText(text=self._message_text)]
+        item.status = "completed"
+        yield self._event(
+            "response.output_item.done",
+            {"output_index": self._message_oi, "item": item.model_dump(mode="json")},
+        )
+
+    # -- tool-call channel --------------------------------------------------
+
+    def _on_tool_call(self, tc: DeltaToolCall) -> Iterator[str]:
+        idx = tc.index
+        if idx not in self._tools:
+            call_id = tc.id or f"call_{random_uuid()}"
+            name = tc.function.name if tc.function else None
+            item = ResponseFunctionToolCall(call_id=call_id, name=name or "", arguments="", status="in_progress")
+            self._tools[idx] = item
+            self._tool_args[idx] = ""
+            self._tool_oi[idx] = self._take_oi()
+            yield self._event(
+                "response.output_item.added",
+                {"output_index": self._tool_oi[idx], "item": item.model_dump(mode="json")},
+            )
+        else:
+            item = self._tools[idx]
+            # Some loaders send the function name in a later chunk than the id.
+            if tc.function and tc.function.name and not item.name:
+                item.name = tc.function.name
+
+        if tc.function and tc.function.arguments:
+            self._tool_args[idx] += tc.function.arguments
+            yield self._event(
+                "response.function_call_arguments.delta",
+                {"item_id": item.id, "output_index": self._tool_oi[idx], "delta": tc.function.arguments},
+            )
+
+    def _close_tools(self) -> Iterator[str]:
+        for idx in sorted(self._tools):
+            item = self._tools[idx]
+            args = self._tool_args[idx]
+            oi = self._tool_oi[idx]
+            item.arguments = args
+            item.status = "completed"
+            yield self._event(
+                "response.function_call_arguments.done",
+                {"item_id": item.id, "output_index": oi, "arguments": args},
+            )
+            yield self._event(
+                "response.output_item.done",
+                {"output_index": oi, "item": item.model_dump(mode="json")},
+            )
+
+
+async def responses_stream_from_chat(response_gen: AsyncIterator[Any], request: ResponsesRequest) -> AsyncIterator[Any]:
+    """Adapt a streaming chat response generator into Responses SSE events.
+
+    Lets ``/v1/responses`` reuse ``_handle_response`` unchanged. The first item
+    decides the path: an early ``ErrorResponse`` (loader rejected before
+    streaming) is passed through so the gateway renders the proper HTTP error
+    instead of a ``200`` event stream; chat SSE strings start the event stream.
+    """
+    translator = ResponsesStreamTranslator(request)
+    started = False
+    async for item in response_gen:
+        if not isinstance(item, str):
+            if not started:
+                # Pre-stream error/object — let _handle_response handle it.
+                yield item
+                return
+            # A non-string mid-stream is unexpected; skip rather than corrupt the stream.
+            continue
+        if not started:
+            started = True
+            for event in translator.start():
+                yield event
+        chunk = _parse_chat_sse(item)
+        if chunk is None:
+            continue
+        for event in translator.process(chunk):
+            yield event
+    if started:
+        for event in translator.finish():
+            yield event

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1685,14 +1685,58 @@ class TestResponsesEndpoint:
         assert function_calls[0].name == "get_weather"
         assert "Paris" in function_calls[0].arguments
 
-    def test_stream_true_rejected_400(self):
-        response = httpx.post(
-            f"{OPENAI_API_BASE}/responses",
-            json={"model": "chat-capable", "input": "hi", "stream": True},
-            timeout=60,
+    def test_streaming_emits_event_protocol(self, client):
+        # stream=True drives the chat pipeline in streaming mode and translates
+        # its chunks into the Responses event protocol. The official SDK parses
+        # the named events and reconstructs the final response.
+        stream = client.responses.create(
+            model="chat-capable",
+            input="Say hello in one word.",
+            max_output_tokens=20,
+            stream=True,
         )
-        assert response.status_code == 400, response.text
-        assert "streaming" in response.json()["error"]["message"]
+        types: list[str] = []
+        text_deltas: list[str] = []
+        completed = None
+        for event in stream:
+            types.append(event.type)
+            if event.type == "response.output_text.delta":
+                text_deltas.append(event.delta)
+            elif event.type == "response.completed":
+                completed = event.response
+
+        assert types[0] == "response.created"
+        assert "response.output_text.delta" in types
+        assert types[-1] == "response.completed"
+        assert "".join(text_deltas).strip(), "expected streamed output text"
+        assert completed is not None
+        assert completed.status in {"completed", "incomplete"}
+        # The streamed deltas must reconstruct the final message text.
+        assert "".join(text_deltas).strip() == completed.output_text.strip()
+        assert completed.usage.input_tokens > 0
+
+    def test_streaming_tool_call_emits_argument_deltas(self, client):
+        stream = client.responses.create(
+            model="chat-capable",
+            input="What is the weather in Paris?",
+            tools=[_WEATHER_TOOL_RESPONSES],
+            tool_choice="required",
+            max_output_tokens=128,
+            stream=True,
+        )
+        arg_deltas: list[str] = []
+        completed = None
+        for event in stream:
+            if event.type == "response.function_call_arguments.delta":
+                arg_deltas.append(event.delta)
+            elif event.type == "response.completed":
+                completed = event.response
+        assert completed is not None
+        function_calls = [item for item in completed.output if item.type == "function_call"]
+        assert function_calls, f"expected a function_call item, got {[i.type for i in completed.output]}"
+        assert function_calls[0].name == "get_weather"
+        # streamed argument fragments must reconstruct the final arguments
+        assert "".join(arg_deltas) == function_calls[0].arguments
 
     def test_previous_response_id_rejected_400(self):
         response = httpx.post(
@@ -1743,6 +1787,26 @@ class TestResponsesReasoning:
         message_items = [item for item in output if item["type"] == "message"]
         assert message_items, "expected an assistant message output item alongside reasoning"
 
+    def test_streaming_emits_reasoning_summary_deltas(self, client):
+        stream = client.responses.create(
+            model="chat-reasoning",
+            input="Briefly: what is 7 times 8?",
+            max_output_tokens=512,
+            stream=True,
+        )
+        reasoning_deltas: list[str] = []
+        completed = None
+        for event in stream:
+            if event.type == "response.reasoning_summary_text.delta":
+                reasoning_deltas.append(event.delta)
+            elif event.type == "response.completed":
+                completed = event.response
+        assert reasoning_deltas, "expected streamed reasoning summary deltas"
+        assert "<think>" not in "".join(reasoning_deltas)
+        assert completed is not None
+        reasoning_items = [item for item in completed.output if item.type == "reasoning"]
+        assert reasoning_items, "expected a reasoning output item in the completed response"
+
 
 @pytest.mark.integration
 @pytest.mark.llama_cpp
@@ -1762,3 +1826,23 @@ class TestResponsesLlamaCpp:
         )
         assert resp.status in {"completed", "incomplete"}
         assert resp.output_text.strip()
+
+    def test_streaming_response_through_llama_cpp(self, client):
+        # The streaming translator is loader-agnostic too: it consumes the same
+        # chat SSE chunk stream llama_cpp emits.
+        stream = client.responses.create(
+            model="chat-llama-mship",
+            input="Say hello in one word.",
+            max_output_tokens=20,
+            stream=True,
+        )
+        text_deltas: list[str] = []
+        completed = None
+        for event in stream:
+            if event.type == "response.output_text.delta":
+                text_deltas.append(event.delta)
+            elif event.type == "response.completed":
+                completed = event.response
+        assert "".join(text_deltas).strip()
+        assert completed is not None
+        assert completed.status in {"completed", "incomplete"}

--- a/tests/test_responses_api.py
+++ b/tests/test_responses_api.py
@@ -10,7 +10,10 @@ from modelship.openai.protocol import (
     ChatCompletionRequest,
     ChatCompletionResponse,
     ChatCompletionResponseChoice,
+    ChatCompletionResponseStreamChoice,
+    ChatCompletionStreamResponse,
     ChatMessage,
+    DeltaMessage,
     ResponsesRequest,
     UsageInfo,
 )
@@ -61,12 +64,42 @@ class TestResponsesRoute:
         assert hr.call_args.args[3] == "create_response"
 
     @pytest.mark.asyncio
-    async def test_stream_true_rejected_400(self, api):
+    async def test_stream_true_drives_streaming_translation(self, api):
+        # stream=True sets stream + include_usage on the chat request and routes
+        # the chat SSE chunks through the Responses event translator, yielding a
+        # text/event-stream of Responses events.
+        handle = MagicMock()
+
+        async def gen():
+            chunk = ChatCompletionStreamResponse(
+                model="m",
+                choices=[
+                    ChatCompletionResponseStreamChoice(
+                        index=0, delta=DeltaMessage(content="hello!"), finish_reason="stop"
+                    )
+                ],
+            )
+            yield f"data: {json.dumps(chunk.model_dump(mode='json'))}\n\n"
+            yield "data: [DONE]\n\n"
+
+        handle.generate.options.return_value.remote.return_value = gen()
+        api.models = {"m": {"m-a1b2c": handle}}
+        api._round_robin = {"m": 0}
+
         request = ResponsesRequest(model="m", input="hi", stream=True)
-        result = await api.create_response(request, _raw_request())
-        assert result.status_code == 400
-        body = json.loads(bytes(result.body))
-        assert "streaming" in body["error"]["message"]
+        with patch("modelship.openai.api.RequestWatcher"):
+            result = await api.create_response(request, _raw_request())
+
+        assert result.media_type == "text/event-stream"
+        # The chat request handed to the loader must be streaming with usage on.
+        chat_request = handle.generate.options.return_value.remote.call_args.args[0]
+        assert chat_request.stream is True
+        assert chat_request.stream_options is not None and chat_request.stream_options.include_usage is True
+
+        body = "".join([chunk async for chunk in result.body_iterator])
+        assert "event: response.created" in body
+        assert "event: response.output_text.delta" in body
+        assert "event: response.completed" in body
 
     @pytest.mark.asyncio
     async def test_previous_response_id_rejected_400(self, api):

--- a/tests/test_responses_streaming.py
+++ b/tests/test_responses_streaming.py
@@ -63,15 +63,24 @@ class TestSseParsing:
     def test_parses_data_chunk(self):
         chunk = _chunk(DeltaMessage(content="hi"))
         raw = f"data: {json.dumps(chunk.model_dump(mode='json'))}\n\n"
-        parsed = _parse_chat_sse(raw)
-        assert parsed is not None
-        assert parsed.choices[0].delta.content == "hi"
+        parsed = list(_parse_chat_sse(raw))
+        assert len(parsed) == 1
+        assert parsed[0].choices[0].delta.content == "hi"
 
-    def test_done_sentinel_is_none(self):
-        assert _parse_chat_sse("data: [DONE]\n\n") is None
+    def test_done_sentinel_yields_nothing(self):
+        assert list(_parse_chat_sse("data: [DONE]\n\n")) == []
 
-    def test_non_data_line_is_none(self):
-        assert _parse_chat_sse(": keep-alive\n\n") is None
+    def test_non_data_line_yields_nothing(self):
+        assert list(_parse_chat_sse(": keep-alive\n\n")) == []
+
+    def test_bundled_messages_all_parsed(self):
+        # A single raw string may bundle several SSE messages; every data line
+        # must be parsed (not just the first), [DONE] skipped.
+        a = json.dumps(_chunk(DeltaMessage(content="a")).model_dump(mode="json"))
+        b = json.dumps(_chunk(DeltaMessage(content="b")).model_dump(mode="json"))
+        raw = f"data: {a}\n\ndata: {b}\n\ndata: [DONE]\n\n"
+        parsed = list(_parse_chat_sse(raw))
+        assert [c.choices[0].delta.content for c in parsed] == ["a", "b"]
 
 
 class TestTextStream:

--- a/tests/test_responses_streaming.py
+++ b/tests/test_responses_streaming.py
@@ -1,0 +1,270 @@
+"""Tests for the streaming Responses <-> chat-completions translator (Phase A2).
+
+The translator consumes the chat SSE chunk stream every loader emits and emits
+the Responses event protocol. These tests drive it directly with synthesized
+chat chunks (no Ray, no loader) and assert the event sequence/shape.
+"""
+
+import json
+
+import pytest
+
+from modelship.openai.protocol import (
+    ChatCompletionResponseStreamChoice,
+    ChatCompletionStreamResponse,
+    DeltaFunctionCall,
+    DeltaMessage,
+    DeltaToolCall,
+    ResponsesRequest,
+    UsageInfo,
+)
+from modelship.openai.protocol.responses.streaming import (
+    ResponsesStreamTranslator,
+    _parse_chat_sse,
+    responses_stream_from_chat,
+)
+
+
+def _req(**overrides) -> ResponsesRequest:
+    payload = {"model": "m", "input": "hi"}
+    payload.update(overrides)
+    return ResponsesRequest(**payload)
+
+
+def _chunk(delta: DeltaMessage | None = None, *, finish_reason=None, usage=None) -> ChatCompletionStreamResponse:
+    choices = []
+    if delta is not None or finish_reason is not None:
+        choices = [
+            ChatCompletionResponseStreamChoice(index=0, delta=delta or DeltaMessage(), finish_reason=finish_reason)
+        ]
+    return ChatCompletionStreamResponse(model="m", choices=choices, usage=usage)
+
+
+def _events(translator: ResponsesStreamTranslator, chunks) -> list[dict]:
+    """Run start -> process(chunks) -> finish and return parsed event payloads."""
+    raw: list[str] = []
+    raw.extend(translator.start())
+    for c in chunks:
+        raw.extend(translator.process(c))
+    raw.extend(translator.finish())
+    out = []
+    for line in raw:
+        # each is "event: <type>\ndata: {json}\n\n"
+        data_line = next(ln for ln in line.splitlines() if ln.startswith("data:"))
+        out.append(json.loads(data_line[len("data:") :].strip()))
+    return out
+
+
+def _types(events: list[dict]) -> list[str]:
+    return [e["type"] for e in events]
+
+
+class TestSseParsing:
+    def test_parses_data_chunk(self):
+        chunk = _chunk(DeltaMessage(content="hi"))
+        raw = f"data: {json.dumps(chunk.model_dump(mode='json'))}\n\n"
+        parsed = _parse_chat_sse(raw)
+        assert parsed is not None
+        assert parsed.choices[0].delta.content == "hi"
+
+    def test_done_sentinel_is_none(self):
+        assert _parse_chat_sse("data: [DONE]\n\n") is None
+
+    def test_non_data_line_is_none(self):
+        assert _parse_chat_sse(": keep-alive\n\n") is None
+
+
+class TestTextStream:
+    def test_envelope_and_text_event_sequence(self):
+        translator = ResponsesStreamTranslator(_req())
+        chunks = [
+            _chunk(DeltaMessage(role="assistant")),
+            _chunk(DeltaMessage(content="Hel")),
+            _chunk(DeltaMessage(content="lo")),
+            _chunk(finish_reason="stop", usage=UsageInfo(prompt_tokens=1, completion_tokens=2, total_tokens=3)),
+        ]
+        events = _events(translator, chunks)
+        assert _types(events) == [
+            "response.created",
+            "response.in_progress",
+            "response.output_item.added",
+            "response.content_part.added",
+            "response.output_text.delta",
+            "response.output_text.delta",
+            "response.output_text.done",
+            "response.content_part.done",
+            "response.output_item.done",
+            "response.completed",
+        ]
+
+    def test_text_deltas_carry_pieces_and_done_carries_full(self):
+        translator = ResponsesStreamTranslator(_req())
+        events = _events(
+            translator,
+            [_chunk(DeltaMessage(content="Hel")), _chunk(DeltaMessage(content="lo"), finish_reason="stop")],
+        )
+        deltas = [e["delta"] for e in events if e["type"] == "response.output_text.delta"]
+        assert deltas == ["Hel", "lo"]
+        done = next(e for e in events if e["type"] == "response.output_text.done")
+        assert done["text"] == "Hello"
+
+    def test_sequence_numbers_are_monotonic(self):
+        translator = ResponsesStreamTranslator(_req())
+        events = _events(translator, [_chunk(DeltaMessage(content="x"), finish_reason="stop")])
+        seqs = [e["sequence_number"] for e in events]
+        assert seqs == list(range(len(events)))
+
+    def test_completed_response_carries_full_text_and_usage(self):
+        translator = ResponsesStreamTranslator(_req())
+        events = _events(
+            translator,
+            [
+                _chunk(DeltaMessage(content="hello world")),
+                _chunk(finish_reason="stop", usage=UsageInfo(prompt_tokens=4, completion_tokens=6, total_tokens=10)),
+            ],
+        )
+        completed = events[-1]
+        assert completed["type"] == "response.completed"
+        resp = completed["response"]
+        assert resp["status"] == "completed"
+        assert resp["output"][0]["type"] == "message"
+        assert resp["output"][0]["content"][0]["text"] == "hello world"
+        assert resp["usage"]["input_tokens"] == 4
+        assert resp["usage"]["output_tokens"] == 6
+
+    def test_item_id_is_stable_across_events(self):
+        translator = ResponsesStreamTranslator(_req())
+        events = _events(translator, [_chunk(DeltaMessage(content="x"), finish_reason="stop")])
+        msg_events = [e for e in events if e.get("item_id", "").startswith("msg_")]
+        ids = {e["item_id"] for e in msg_events}
+        assert len(ids) == 1
+        # and the same id appears on the final output item
+        item = next(e for e in events if e["type"] == "response.output_item.done")["item"]
+        assert item["id"] == next(iter(ids))
+
+
+class TestReasoningStream:
+    def test_reasoning_emits_summary_events_before_message(self):
+        translator = ResponsesStreamTranslator(_req())
+        events = _events(
+            translator,
+            [
+                _chunk(DeltaMessage(reasoning="be")),
+                _chunk(DeltaMessage(reasoning="cause")),
+                _chunk(DeltaMessage(content="answer"), finish_reason="stop"),
+            ],
+        )
+        types = _types(events)
+        assert "response.reasoning_summary_text.delta" in types
+        # reasoning item opens before the message item
+        assert types.index("response.reasoning_summary_part.added") < types.index("response.content_part.added")
+        done = next(e for e in events if e["type"] == "response.reasoning_summary_text.done")
+        assert done["text"] == "because"
+
+    def test_completed_has_reasoning_then_message(self):
+        translator = ResponsesStreamTranslator(_req())
+        events = _events(
+            translator,
+            [_chunk(DeltaMessage(reasoning="think")), _chunk(DeltaMessage(content="ans"), finish_reason="stop")],
+        )
+        out = events[-1]["response"]["output"]
+        assert out[0]["type"] == "reasoning"
+        assert out[0]["summary"][0]["text"] == "think"
+        assert out[1]["type"] == "message"
+
+
+class TestToolCallStream:
+    def test_tool_call_args_stream_and_finalize(self):
+        translator = ResponsesStreamTranslator(_req())
+        events = _events(
+            translator,
+            [
+                _chunk(
+                    DeltaMessage(
+                        tool_calls=[DeltaToolCall(index=0, id="call_1", function=DeltaFunctionCall(name="get_weather"))]
+                    )
+                ),
+                _chunk(
+                    DeltaMessage(tool_calls=[DeltaToolCall(index=0, function=DeltaFunctionCall(arguments='{"city":'))])
+                ),
+                _chunk(
+                    DeltaMessage(tool_calls=[DeltaToolCall(index=0, function=DeltaFunctionCall(arguments='"NYC"}'))])
+                ),
+                _chunk(finish_reason="tool_calls"),
+            ],
+        )
+        types = _types(events)
+        assert "response.function_call_arguments.delta" in types
+        arg_deltas = [e["delta"] for e in events if e["type"] == "response.function_call_arguments.delta"]
+        assert "".join(arg_deltas) == '{"city":"NYC"}'
+        done = next(e for e in events if e["type"] == "response.function_call_arguments.done")
+        assert done["arguments"] == '{"city":"NYC"}'
+        # completed output carries the function_call item with name + call_id
+        fc = next(o for o in events[-1]["response"]["output"] if o["type"] == "function_call")
+        assert fc["name"] == "get_weather"
+        assert fc["call_id"] == "call_1"
+        assert fc["arguments"] == '{"city":"NYC"}'
+        # tool_calls finish reason is still a completed response
+        assert events[-1]["type"] == "response.completed"
+
+    def test_interleaved_content_after_tool_call_is_merged_into_one_message(self):
+        # answer -> tool_call -> more answer: the trailing text appends to the
+        # already-open message item (not dropped, not a second message).
+        translator = ResponsesStreamTranslator(_req())
+        events = _events(
+            translator,
+            [
+                _chunk(DeltaMessage(content="before ")),
+                _chunk(
+                    DeltaMessage(tool_calls=[DeltaToolCall(index=0, id="call_1", function=DeltaFunctionCall(name="f"))])
+                ),
+                _chunk(DeltaMessage(content="after"), finish_reason="tool_calls"),
+            ],
+        )
+        out = events[-1]["response"]["output"]
+        messages = [o for o in out if o["type"] == "message"]
+        assert len(messages) == 1
+        assert messages[0]["content"][0]["text"] == "before after"
+
+
+class TestTerminalStatus:
+    def test_length_finish_reason_is_incomplete(self):
+        translator = ResponsesStreamTranslator(_req())
+        events = _events(translator, [_chunk(DeltaMessage(content="x"), finish_reason="length")])
+        assert events[-1]["type"] == "response.incomplete"
+        assert events[-1]["response"]["status"] == "incomplete"
+        assert events[-1]["response"]["incomplete_details"] == {"reason": "max_output_tokens"}
+
+    def test_content_filter_finish_reason_is_incomplete(self):
+        translator = ResponsesStreamTranslator(_req())
+        events = _events(translator, [_chunk(DeltaMessage(content="x"), finish_reason="content_filter")])
+        assert events[-1]["type"] == "response.incomplete"
+        assert events[-1]["response"]["incomplete_details"] == {"reason": "content_filter"}
+
+
+class TestStreamWrapper:
+    @pytest.mark.asyncio
+    async def test_wraps_chat_sse_strings_into_events(self):
+        async def gen():
+            yield f"data: {json.dumps(_chunk(DeltaMessage(content='hi')).model_dump(mode='json'))}\n\n"
+            yield f"data: {json.dumps(_chunk(finish_reason='stop').model_dump(mode='json'))}\n\n"
+            yield "data: [DONE]\n\n"
+
+        out = [e async for e in responses_stream_from_chat(gen(), _req())]
+        assert all(isinstance(e, str) for e in out)
+        assert out[0].startswith("event: response.created")
+        assert "event: response.completed" in out[-1]
+
+    @pytest.mark.asyncio
+    async def test_pre_stream_error_object_passes_through(self):
+        from modelship.openai.protocol import create_error_response
+
+        err = create_error_response("nope")
+
+        async def gen():
+            yield err
+
+        out = [e async for e in responses_stream_from_chat(gen(), _req())]
+        # Passed straight through (not turned into a 200 event stream) so
+        # _handle_response can render the proper HTTP error.
+        assert out == [err]


### PR DESCRIPTION
Translate the chat-completion SSE chunk stream every loader emits into the Responses streaming event protocol (response.created / output_item.added / output_text.delta / reasoning_summary_* / function_call_arguments_* / response.completed), so /v1/responses now supports stream=true.

The translator is a gateway-edge sibling of the non-streaming adapter: it consumes the one wire shape all loaders share (ChatCompletionStreamResponse chunks), so it works across vLLM, transformers and llama_cpp with zero loader changes. Channels (reasoning / message / tool calls) are opened lazily on first delta and closed at stream end, making it independent of inter-channel ordering and of content interleaving around tool calls.

- extract build_response_object so created/completed envelopes and the non-streaming body share one shape; move the non-streaming responses_from_chat wrapper into the adapter package alongside responses_stream_from_chat
- allow in_progress status on message/function_call output items (streaming)
- route stream=true through the translator with include_usage so the terminal response.completed carries token counts


