### PR TITLE
feat(loaders): add stable_diffusion_cpp CPU image-generation loader

### DIFF
--- a/config/examples/stable-diffusion-cpp.yaml
+++ b/config/examples/stable-diffusion-cpp.yaml
@@ -1,0 +1,28 @@
+# stable-diffusion.cpp loader — CPU-only image generation.
+# Runs GGUF-quantized diffusion models (SD1.5 / SDXL / SD-Turbo, all-in-one Flux)
+# with no GPU. Ideal for NAS / mini-PC hosts. Serves /v1/images/generations,
+# /v1/images/edits and /v1/images/variations.
+
+models:
+  # SDXL-Turbo: fast, few-step single-file GGUF pulled from a HuggingFace repo
+  # (the glob after `:` picks the quant).
+  - name: "sdxl-turbo"
+    model: "second-state/stable-diffusion-xl-turbo-GGUF:*Q4_0.gguf"
+    usecase: "image"
+    loader: "stable_diffusion_cpp"
+    num_cpus: 4
+    stable_diffusion_cpp_config:
+      sample_steps: 4
+      cfg_scale: 1.0
+
+  # All-in-one Flux-schnell from a local path (bind-mount the file into the
+  # container). High quality, 4 steps. Enable vae_tiling to cap peak RAM.
+  - name: "flux-schnell"
+    model: "/.cache/models/flux1-schnell-q4_k.gguf"
+    usecase: "image"
+    loader: "stable_diffusion_cpp"
+    num_cpus: 6
+    stable_diffusion_cpp_config:
+      sample_steps: 4
+      cfg_scale: 1.0
+      vae_tiling: true

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -40,6 +40,7 @@ Each deployment uses one of the following loaders:
 | `llama_cpp` | llama-cpp-python | Chat/generation, embeddings (GGUF models) | No — currently CPU-only |
 | `transformers` | PyTorch + HuggingFace | Chat/generation, embeddings, transcription, translation, TTS | No — runs on CPU or GPU |
 | `diffusers` | HuggingFace Diffusers | Image generation (any `AutoPipelineForText2Image` model) | Yes |
+| `stable_diffusion_cpp` | stable-diffusion.cpp | Image generation (GGUF models: SD1.5/SDXL/SD-Turbo, all-in-one Flux) | No — currently CPU-only |
 | `custom` | Plugin system | TTS backends (Kokoro ONNX, Bark, Orpheus), STT backends (whisper.cpp) | No |
 
 The `transformers` loader is ideal for CPU-only deployments, smaller models, or development/testing without a GPU. It uses HuggingFace `pipeline()` under the hood and handles audio resampling automatically for speech-to-text models. The `llama_cpp` loader provides high-efficiency inference for quantized GGUF models on CPU. The `vllm` loader provides higher throughput on GPU with continuous batching and PagedAttention.
@@ -100,5 +101,6 @@ See [Plugin Development](plugins.md) for details.
 | `modelship/infer/vllm/vllm_infer.py` | vLLM engine wrapper |
 | `modelship/infer/transformers/transformers_infer.py` | Transformers pipeline wrapper (CPU/GPU) |
 | `modelship/infer/diffusers/diffusers_infer.py` | Diffusers pipeline wrapper |
+| `modelship/infer/stable_diffusion_cpp/stable_diffusion_cpp_infer.py` | stable-diffusion.cpp wrapper (CPU image gen) |
 | `modelship/plugins/base_plugin.py` | Plugin base classes |
 | `config/models.yaml` | Model configuration |

--- a/docs/model-configuration.md
+++ b/docs/model-configuration.md
@@ -67,7 +67,7 @@ python mship_deploy.py --config config/tts.yaml --gateway-name "tts-api"
 | `name` | string | Model identifier used in API requests |
 | `model` | string | HuggingFace repo ID, local path, or `repo:filename` (see [Model source](#model-source)). Required for built-in loaders; optional for `loader: custom` |
 | `usecase` | string | `generate`, `embed`, `transcription`, `translation`, `tts`, or `image` |
-| `loader` | string | `vllm`, `transformers`, `diffusers`, `llama_cpp`, or `custom` |
+| `loader` | string | `vllm`, `transformers`, `diffusers`, `llama_cpp`, `stable_diffusion_cpp`, or `custom` |
 | `plugin` | string | Plugin module name (required when `loader: custom`); automatically loaded from wheels when referenced |
 | `num_gpus` | float \| int | GPU allocation. Fractional `< 1` shares one GPU (also sets vLLM `gpu_memory_utilization`); integer `≥ 1` requests that many whole GPUs (for `vllm`, this auto-sets `tensor_parallel_size = num_gpus` unless tp/pp is already specified). |
 | `num_cpus` | float | CPU units to allocate (default `0.1`) |
@@ -77,6 +77,7 @@ python mship_deploy.py --config config/tts.yaml --gateway-name "tts-api"
 | `transformers_config` | object | Transformers loader options (see below) |
 | `diffusers_config` | object | Diffusers pipeline options (see below) |
 | `llama_cpp_config` | object | llama.cpp loader options (see below) |
+| `stable_diffusion_cpp_config` | object | stable-diffusion.cpp loader options (see below) |
 | `plugin_config` | object | Plugin-specific options passed through to the plugin |
 
 ## Model source
@@ -370,6 +371,40 @@ models:
     model: "nomic-ai/nomic-embed-text-v1.5-GGUF:nomic-embed-text-v1.5.Q4_K_M.gguf"
     usecase: embed
     loader: llama_cpp
+```
+
+## stable-diffusion.cpp Loader
+
+The `stable_diffusion_cpp` loader uses [stable-diffusion.cpp](https://github.com/leejet/stable-diffusion.cpp) (via [stable-diffusion-cpp-python](https://github.com/william-murray1204/stable-diffusion-cpp-python)) for **CPU-only image generation** — the image counterpart to the `llama_cpp` text loader. It runs GGUF-quantized single-file diffusion checkpoints (SD1.5, SDXL, SD-Turbo, all-in-one Flux) in a few GB of RAM, with no GPU. Any `num_gpus` is ignored (a warning is logged and the actor is allocated `num_gpus: 0`). `usecase` is always `image` (defaulted if omitted) and it serves `/v1/images/generations`, `/v1/images/edits`, and `/v1/images/variations`.
+
+| Field | Type | Default | Description |
+|---|---|---|---|
+| `sample_steps` | int | `20` | Denoising steps (sd.cpp analogue of `num_inference_steps`) |
+| `cfg_scale` | float | `7.0` | Classifier-free guidance scale (analogue of `guidance_scale`) |
+| `sample_method` | string | `default` | Sampler; `default` lets sd.cpp pick per architecture |
+| `scheduler` | string | `default` | Denoiser sigma scheduler |
+| `wtype` | string | `default` | On-the-fly weight quantization type (e.g. `q4_0`, `q8_0`, `f16`); `default` auto-detects |
+| `n_threads` | int | `-1` | CPU threads; `-1` uses half the cores |
+| `vae_tiling` | bool | `false` | Tile the VAE decode to cut peak RAM (auto-recommended by preflight on low-RAM hosts) |
+| `diffusion_model_path` / `clip_l_path` / `clip_g_path` / `t5xxl_path` / `vae_path` | string | — | Standalone component paths for split checkpoints (accepted as pre-placed local paths; single-file models are the v1 focus) |
+| `model_kwargs` | object | `{}` | Extra keyword arguments passed to the `StableDiffusion` constructor |
+
+> **Note:** Setting `MSHIP_LOG_LEVEL` to `TRACE` enables `verbose` mode in the underlying stable-diffusion.cpp engine.
+
+GGUF variants in a HuggingFace repo are picked via the `:filename` syntax on the `model:` field (see [Model source](#model-source)), exactly like the llama.cpp loader.
+
+### Image Generation (GGUF, CPU)
+
+```yaml
+models:
+  - name: sdxl-turbo
+    model: "second-state/stable-diffusion-xl-turbo-GGUF:*Q4_0.gguf"
+    usecase: image
+    loader: stable_diffusion_cpp
+    num_cpus: 4
+    stable_diffusion_cpp_config:
+      sample_steps: 4
+      cfg_scale: 1.0
 ```
 
 ## Custom Loader (Plugins)

--- a/modelship/deploy/actor_options.py
+++ b/modelship/deploy/actor_options.py
@@ -104,12 +104,13 @@ def build_deployment_options(config: ModelshipModelConfig, plugin_wheel: Path | 
         # wheel reuse the install.
         runtime_env["pip"] = [str(plugin_wheel)]
 
-    if config.loader == ModelLoader.llama_cpp:
+    if config.loader in (ModelLoader.llama_cpp, ModelLoader.stable_diffusion_cpp):
         if config.num_gpus > 0:
             logger.warning(
-                "num_gpus=%s is ignored for model '%s': llama_cpp loader currently only supports CPU.",
+                "num_gpus=%s is ignored for model '%s': %s loader currently only supports CPU.",
                 config.num_gpus,
                 config.name,
+                config.loader.value,
             )
         opts: dict = {"ray_actor_options": {"num_gpus": 0, "num_cpus": config.num_cpus, "runtime_env": runtime_env}}
     else:

--- a/modelship/infer/diffusers/openai/serving_image.py
+++ b/modelship/infer/diffusers/openai/serving_image.py
@@ -1,15 +1,29 @@
 import asyncio
-import base64
-import io
-import time
 
 from diffusers.pipelines.auto_pipeline import (
     AutoPipelineForImage2Image,
     AutoPipelineForInpainting,
     AutoPipelineForText2Image,
 )
-from PIL import Image
 
+from modelship.infer.image_serving_common import (
+    alpha_mask as _alpha_mask,
+)
+from modelship.infer.image_serving_common import (
+    build_response as _build_response,
+)
+from modelship.infer.image_serving_common import (
+    decode_image as _decode_image,
+)
+from modelship.infer.image_serving_common import (
+    load_image as _load_image,
+)
+from modelship.infer.image_serving_common import (
+    load_mask as _load_mask,
+)
+from modelship.infer.image_serving_common import (
+    parse_size as _parse_size,
+)
 from modelship.infer.infer_config import DiffusersConfig, RawRequestProxy
 from modelship.logging import TRACE, get_logger
 from modelship.openai.protocol import (
@@ -17,7 +31,6 @@ from modelship.openai.protocol import (
     ImageEditRequest,
     ImageGenerationRequest,
     ImageGenerationResponse,
-    ImageObject,
     ImageVariationRequest,
     create_error_response,
 )
@@ -215,74 +228,3 @@ class OpenAIServingImage:
         if isinstance(response, ImageGenerationResponse):
             logger.log(TRACE, "image variation response %s: num_images=%d", request_id, len(response.data))
         return response
-
-
-def _build_response(images: list, revised_prompt: str | None) -> ImageGenerationResponse:
-    data = []
-    for img in images:
-        buf = io.BytesIO()
-        img.save(buf, format="PNG")
-        b64 = base64.b64encode(buf.getvalue()).decode("utf-8")
-        data.append(ImageObject(b64_json=b64, revised_prompt=revised_prompt))
-    return ImageGenerationResponse(created=int(time.time()), data=data)
-
-
-def _decode_image(data: bytes) -> Image.Image:
-    try:
-        img = Image.open(io.BytesIO(data))
-        # Image.open is lazy (headers only); force decoding now so truncated /
-        # corrupt pixel data raises here and is wrapped, rather than later
-        # during convert()/resize() where it would escape as an OSError.
-        img.load()
-        return img
-    except Exception as e:
-        raise ValueError(f"Could not decode input image: {e}") from e
-
-
-def _load_image(data: bytes, width: int, height: int, mode: str = "RGB") -> Image.Image:
-    return _decode_image(data).convert(mode).resize((width, height))
-
-
-def _load_mask(data: bytes, width: int, height: int) -> Image.Image:
-    """Load an uploaded edit mask into a diffusers mask (white = edit region).
-    Per the OpenAI spec a mask encodes the edit region in its alpha channel
-    (transparent = edit), so prefer that; fall back to luminance for an
-    opaque / grayscale mask (white = edit)."""
-    img = _decode_image(data)
-    mask = _alpha_mask(img, width, height)
-    if mask is not None:
-        return mask
-    return img.convert("L").resize((width, height))
-
-
-def _alpha_mask(img: Image.Image, width: int, height: int) -> Image.Image | None:
-    """Derive an inpaint mask from an already-decoded image's alpha channel,
-    per the OpenAI edits spec: when no separate mask is supplied, transparent
-    areas of the image mark the region to edit. Returns a diffusers mask
-    (white = edit, black = keep) sized to (width, height), or None when the
-    image has no alpha channel or is fully opaque (so the caller falls back to
-    img2img)."""
-    if "A" not in img.mode and "transparency" not in img.info:
-        return None
-    alpha = img.convert("RGBA").getchannel("A")
-    extrema = alpha.getextrema()  # single-band "L" -> (min, max)
-    if not extrema or not isinstance(extrema[0], int | float) or extrema[0] >= 255:
-        return None  # empty band or fully opaque — nothing marked for editing
-    # Transparent (alpha 0) -> white (repaint); opaque -> black (keep). Threshold
-    # at the source resolution, then resize: the interpolation softens the
-    # binary edge into a gradient, which blends better in inpainting than a hard,
-    # aliased boundary.
-    lut = [255 if a < 128 else 0 for a in range(256)]
-    return alpha.point(lut).resize((width, height))
-
-
-def _parse_size(size: str) -> tuple[int, int]:
-    parts = size.lower().split("x")
-    if len(parts) != 2:
-        raise ValueError(f"Invalid size format '{size}', expected WxH (e.g. '512x512')")
-    w, h = int(parts[0]), int(parts[1])
-    if w <= 0 or h <= 0:
-        raise ValueError(f"Width and height must be positive, got {w}x{h}")
-    if w % 8 != 0 or h % 8 != 0:
-        raise ValueError(f"Width and height must be multiples of 8, got {w}x{h}")
-    return w, h

--- a/modelship/infer/image_serving_common.py
+++ b/modelship/infer/image_serving_common.py
@@ -1,0 +1,83 @@
+"""Loader-agnostic helpers shared by the image serving adapters (`diffusers`,
+`stable_diffusion_cpp`). These deal only in PIL images and the OpenAI images
+protocol — no backend (diffusers / sd.cpp) imports — so both loaders reuse them
+without pulling in each other's dependencies."""
+
+import base64
+import io
+import time
+
+from PIL import Image
+
+from modelship.openai.protocol import ImageGenerationResponse, ImageObject
+
+
+def build_response(images: list, revised_prompt: str | None) -> ImageGenerationResponse:
+    """Encode generated PIL images as base64 PNGs in an OpenAI images response."""
+    data = []
+    for img in images:
+        buf = io.BytesIO()
+        img.save(buf, format="PNG")
+        b64 = base64.b64encode(buf.getvalue()).decode("utf-8")
+        data.append(ImageObject(b64_json=b64, revised_prompt=revised_prompt))
+    return ImageGenerationResponse(created=int(time.time()), data=data)
+
+
+def parse_size(size: str) -> tuple[int, int]:
+    parts = size.lower().split("x")
+    if len(parts) != 2:
+        raise ValueError(f"Invalid size format '{size}', expected WxH (e.g. '512x512')")
+    w, h = int(parts[0]), int(parts[1])
+    if w <= 0 or h <= 0:
+        raise ValueError(f"Width and height must be positive, got {w}x{h}")
+    if w % 8 != 0 or h % 8 != 0:
+        raise ValueError(f"Width and height must be multiples of 8, got {w}x{h}")
+    return w, h
+
+
+def decode_image(data: bytes) -> Image.Image:
+    try:
+        img = Image.open(io.BytesIO(data))
+        # Image.open is lazy (headers only); force decoding now so truncated /
+        # corrupt pixel data raises here and is wrapped, rather than later
+        # during convert()/resize() where it would escape as an OSError.
+        img.load()
+        return img
+    except Exception as e:
+        raise ValueError(f"Could not decode input image: {e}") from e
+
+
+def load_image(data: bytes, width: int, height: int, mode: str = "RGB") -> Image.Image:
+    return decode_image(data).convert(mode).resize((width, height))
+
+
+def load_mask(data: bytes, width: int, height: int) -> Image.Image:
+    """Load an uploaded edit mask into an inpaint mask (white = edit region).
+    Per the OpenAI spec a mask encodes the edit region in its alpha channel
+    (transparent = edit), so prefer that; fall back to luminance for an
+    opaque / grayscale mask (white = edit)."""
+    img = decode_image(data)
+    mask = alpha_mask(img, width, height)
+    if mask is not None:
+        return mask
+    return img.convert("L").resize((width, height))
+
+
+def alpha_mask(img: Image.Image, width: int, height: int) -> Image.Image | None:
+    """Derive an inpaint mask from an already-decoded image's alpha channel,
+    per the OpenAI edits spec: when no separate mask is supplied, transparent
+    areas of the image mark the region to edit. Returns a mask (white = edit,
+    black = keep) sized to (width, height), or None when the image has no alpha
+    channel or is fully opaque (so the caller falls back to plain img2img)."""
+    if "A" not in img.mode and "transparency" not in img.info:
+        return None
+    alpha = img.convert("RGBA").getchannel("A")
+    extrema = alpha.getextrema()  # single-band "L" -> (min, max)
+    if not extrema or not isinstance(extrema[0], int | float) or extrema[0] >= 255:
+        return None  # empty band or fully opaque — nothing marked for editing
+    # Transparent (alpha 0) -> white (repaint); opaque -> black (keep). Threshold
+    # at the source resolution, then resize: the interpolation softens the
+    # binary edge into a gradient, which blends better in inpainting than a hard,
+    # aliased boundary.
+    lut = [255 if a < 128 else 0 for a in range(256)]
+    return alpha.point(lut).resize((width, height))

--- a/modelship/infer/infer_config.py
+++ b/modelship/infer/infer_config.py
@@ -40,6 +40,7 @@ class ModelLoader(StrEnum):
     transformers = "transformers"
     diffusers = "diffusers"
     llama_cpp = "llama_cpp"
+    stable_diffusion_cpp = "stable_diffusion_cpp"
     custom = "custom"
 
 
@@ -100,6 +101,36 @@ class LlamaCppConfig(BaseModel):
     tool_calls_enabled: bool | None = None
 
 
+class StableDiffusionCppConfig(BaseModel):
+    """Tunables for the CPU-only `stable_diffusion_cpp` image loader
+    (stable-diffusion.cpp via stable-diffusion-cpp-python). `sample_steps` and
+    `cfg_scale` are the sd.cpp analogues of DiffusersConfig's
+    `num_inference_steps` / `guidance_scale`."""
+
+    sample_steps: int = 20
+    cfg_scale: float = 7.0
+    # "default" lets sd.cpp pick the sampler/scheduler per architecture
+    # (euler_a for SD, euler for Flux/SD3).
+    sample_method: str = "default"
+    scheduler: str = "default"
+    # On-the-fly weight quantization type ("default" auto-detects from the file;
+    # e.g. "q4_0", "q8_0", "f16" when loading an unquantized checkpoint).
+    wtype: str = "default"
+    # -1 => half the CPU cores (stable-diffusion.cpp default).
+    n_threads: int = -1
+    # Tile the VAE decode to cut peak RAM on large images / low-memory hosts.
+    vae_tiling: bool = False
+    # Standalone component paths for split checkpoints (Flux / SD3.5). v1 resolves
+    # only single-file models; these accept pre-placed local paths for advanced use.
+    diffusion_model_path: str | None = None
+    clip_l_path: str | None = None
+    clip_g_path: str | None = None
+    t5xxl_path: str | None = None
+    vae_path: str | None = None
+    # Forwarded verbatim to the StableDiffusion constructor for knobs not surfaced above.
+    model_kwargs: dict[str, Any] = Field(default_factory=dict)
+
+
 class ModelshipModelConfig(BaseModel):
     name: str
     model: str | None = None
@@ -115,6 +146,7 @@ class ModelshipModelConfig(BaseModel):
     transformers_config: TransformersConfig | None = None
     diffusers_config: DiffusersConfig | None = None
     llama_cpp_config: LlamaCppConfig | None = None
+    stable_diffusion_cpp_config: StableDiffusionCppConfig | None = None
     plugin_config: dict[str, Any] | None = None  # plugin devs parse this themselves
 
     _resolved_path: str | None = PrivateAttr(default=None)
@@ -134,9 +166,11 @@ class ModelshipModelConfig(BaseModel):
     @model_validator(mode="before")
     @classmethod
     def default_diffusers_usecase(cls, data):
-        # Diffusers is image-only, so `usecase` is implicit — let configs omit
-        # it. (An explicit non-image usecase is still rejected below.)
-        if isinstance(data, dict) and data.get("loader") == ModelLoader.diffusers and data.get("usecase") is None:
+        # The image-only loaders (diffusers, stable_diffusion_cpp) leave `usecase`
+        # implicit — let configs omit it. (An explicit non-image usecase is still
+        # rejected below.)
+        image_loaders = (ModelLoader.diffusers, ModelLoader.stable_diffusion_cpp)
+        if isinstance(data, dict) and data.get("loader") in image_loaders and data.get("usecase") is None:
             data = {**data, "usecase": ModelUsecase.image}
         return data
 
@@ -146,8 +180,10 @@ class ModelshipModelConfig(BaseModel):
             raise ValueError("loader='custom' requires plugin to be set")
         if self.loader != ModelLoader.custom and not self.model:
             raise ValueError(f"`model:` is required for loader={self.loader!r}")
-        if self.loader == ModelLoader.diffusers and self.usecase is not ModelUsecase.image:
-            raise ValueError(f"loader='diffusers' only supports usecase='image', got {self.usecase!r}")
+        if self.loader in (ModelLoader.diffusers, ModelLoader.stable_diffusion_cpp) and (
+            self.usecase is not ModelUsecase.image
+        ):
+            raise ValueError(f"loader={self.loader.value!r} only supports usecase='image', got {self.usecase!r}")
         return self
 
     @model_validator(mode="after")

--- a/modelship/infer/model_deployment.py
+++ b/modelship/infer/model_deployment.py
@@ -164,6 +164,10 @@ class ModelDeployment:
                 from modelship.infer.llama_cpp.llama_cpp_infer import LlamaCppInfer
 
                 self.infer = LlamaCppInfer(config)
+            elif config.loader == ModelLoader.stable_diffusion_cpp:
+                from modelship.infer.stable_diffusion_cpp.stable_diffusion_cpp_infer import StableDiffusionCppInfer
+
+                self.infer = StableDiffusionCppInfer(config)
             else:
                 from modelship.infer.custom.custom_infer import CustomInfer
 

--- a/modelship/infer/preflight/base.py
+++ b/modelship/infer/preflight/base.py
@@ -209,6 +209,13 @@ def _ensure_registered() -> None:
             register(ModelLoader.llama_cpp, LlamaCppPreflight())
         except Exception:
             logger.debug("preflight: LlamaCppPreflight registration skipped", exc_info=True)
+    if ModelLoader.stable_diffusion_cpp not in _REGISTRY:
+        try:
+            from modelship.infer.preflight.stable_diffusion_cpp import StableDiffusionCppPreflight
+
+            register(ModelLoader.stable_diffusion_cpp, StableDiffusionCppPreflight())
+        except Exception:
+            logger.debug("preflight: StableDiffusionCppPreflight registration skipped", exc_info=True)
     if ModelLoader.vllm in _REGISTRY:
         return
     try:

--- a/modelship/infer/preflight/stable_diffusion_cpp.py
+++ b/modelship/infer/preflight/stable_diffusion_cpp.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+from typing import Any
+
+from modelship.infer.infer_config import ModelshipModelConfig
+from modelship.infer.preflight.base import HardwareProfile
+from modelship.logging import get_logger
+
+logger = get_logger("infer.preflight.stable_diffusion_cpp")
+
+# Below this total system RAM, default to tiled VAE decode. The VAE decode is the
+# memory high-water mark for SD/SDXL generation, so tiling it trades a little
+# speed for a markedly lower peak — the right default on small NAS-class hosts.
+_VAE_TILING_RAM_THRESHOLD_BYTES = 8 * 1024**3
+
+
+class StableDiffusionCppPreflight:
+    """Hardware-aware defaults for the stable_diffusion_cpp loader. Conservative
+    in v1: the only recommendation is enabling VAE tiling on low-RAM hosts. Sizing
+    by model footprint (like the llama_cpp preflight does for n_ctx) is a
+    follow-up once split-file resolution lands."""
+
+    def recommend(self, config: ModelshipModelConfig, hw: HardwareProfile) -> dict[str, Any]:
+        if hw.ram_bytes <= 0:
+            logger.info("preflight '%s': skipping — system RAM not discoverable", config.name)
+            return {}
+
+        rec: dict[str, Any] = {}
+        if hw.ram_bytes < _VAE_TILING_RAM_THRESHOLD_BYTES:
+            rec["vae_tiling"] = True
+            logger.info(
+                "preflight stable_diffusion_cpp '%s': ram=%.2f GiB < %.0f GiB → recommend vae_tiling=True",
+                config.name,
+                hw.ram_bytes / 1024**3,
+                _VAE_TILING_RAM_THRESHOLD_BYTES / 1024**3,
+            )
+        return rec

--- a/modelship/infer/stable_diffusion_cpp/openai/serving_image.py
+++ b/modelship/infer/stable_diffusion_cpp/openai/serving_image.py
@@ -86,7 +86,7 @@ class OpenAIServingImage:
             images = self._generate(prompt=request.prompt, width=width, height=height, batch_count=request.n)
             return build_response(images, revised_prompt=request.prompt)
 
-        loop = asyncio.get_event_loop()
+        loop = asyncio.get_running_loop()
         async with self._lock:
             response = await loop.run_in_executor(None, _run)
         logger.log(TRACE, "image response %s: num_images=%d", request_id, len(response.data))
@@ -143,7 +143,7 @@ class OpenAIServingImage:
             images = self._generate(**kwargs)
             return build_response(images, revised_prompt=request.prompt)
 
-        loop = asyncio.get_event_loop()
+        loop = asyncio.get_running_loop()
         async with self._lock:
             response = await loop.run_in_executor(None, _run)
         if isinstance(response, ImageGenerationResponse):
@@ -173,7 +173,7 @@ class OpenAIServingImage:
             )
             return build_response(images, revised_prompt=None)
 
-        loop = asyncio.get_event_loop()
+        loop = asyncio.get_running_loop()
         async with self._lock:
             response = await loop.run_in_executor(None, _run)
         if isinstance(response, ImageGenerationResponse):

--- a/modelship/infer/stable_diffusion_cpp/openai/serving_image.py
+++ b/modelship/infer/stable_diffusion_cpp/openai/serving_image.py
@@ -1,0 +1,181 @@
+from __future__ import annotations
+
+import asyncio
+from typing import TYPE_CHECKING
+
+from modelship.infer.image_serving_common import (
+    alpha_mask,
+    build_response,
+    decode_image,
+    load_image,
+    load_mask,
+    parse_size,
+)
+from modelship.infer.infer_config import RawRequestProxy, StableDiffusionCppConfig
+from modelship.logging import TRACE, get_logger
+from modelship.openai.protocol import (
+    ErrorResponse,
+    ImageEditRequest,
+    ImageGenerationRequest,
+    ImageGenerationResponse,
+    ImageVariationRequest,
+    create_error_response,
+)
+from modelship.utils import base_request_id
+
+if TYPE_CHECKING:
+    from stable_diffusion_cpp import StableDiffusion
+
+logger = get_logger("infer.stable_diffusion_cpp.image")
+
+# Default img2img strength when the request omits it. Edits stay closer to the
+# source (lower strength) since the prompt guides the change; variations have no
+# prompt, so they need a higher strength to diverge from the input. Mirrors the
+# diffusers adapter.
+_DEFAULT_EDIT_STRENGTH = 0.7
+_DEFAULT_VARIATION_STRENGTH = 0.8
+
+# sd.cpp treats seed=-1 as random. Use it so repeated generations (and especially
+# variations, which share one input) don't return byte-identical images.
+_RANDOM_SEED = -1
+
+
+class OpenAIServingImage:
+    """OpenAI images adapter over a stable-diffusion.cpp handle. The native
+    `generate_image` call serves all three endpoints — txt2img (no init image),
+    img2img edits (init image, optional mask), and variations (init image, empty
+    prompt)."""
+
+    request_id_prefix = "img"
+
+    def __init__(self, sd: StableDiffusion, config: StableDiffusionCppConfig):
+        self.sd = sd
+        self.config = config
+        # The sd.cpp handle wraps a single native context that is not safe to
+        # call concurrently. Serialize all generation through this lock; it gates
+        # only the executor hop, so the event loop stays free while a render runs.
+        self._lock = asyncio.Lock()
+
+    def _generate(self, **kwargs):
+        """Invoke sd.cpp with the per-model defaults applied. Callers supply the
+        per-request bits (prompt, width/height, init_image, mask, strength, n)."""
+        return self.sd.generate_image(
+            cfg_scale=self.config.cfg_scale,
+            sample_method=self.config.sample_method,
+            scheduler=self.config.scheduler,
+            sample_steps=self.config.sample_steps,
+            vae_tiling=self.config.vae_tiling,
+            seed=_RANDOM_SEED,
+            **kwargs,
+        )
+
+    async def create_image_generation(
+        self, request: ImageGenerationRequest, raw_request: RawRequestProxy
+    ) -> ImageGenerationResponse | ErrorResponse:
+        request_id = f"{self.request_id_prefix}-{base_request_id(raw_request)}"
+        logger.info(
+            "image generation request %s: prompt=%r, n=%d, size=%s", request_id, request.prompt, request.n, request.size
+        )
+
+        try:
+            width, height = parse_size(request.size)
+        except ValueError as e:
+            return create_error_response(str(e))
+
+        def _run() -> ImageGenerationResponse:
+            images = self._generate(prompt=request.prompt, width=width, height=height, batch_count=request.n)
+            return build_response(images, revised_prompt=request.prompt)
+
+        loop = asyncio.get_event_loop()
+        async with self._lock:
+            response = await loop.run_in_executor(None, _run)
+        logger.log(TRACE, "image response %s: num_images=%d", request_id, len(response.data))
+        return response
+
+    async def create_image_edit(
+        self,
+        image_data: bytes,
+        mask_data: bytes | None,
+        request: ImageEditRequest,
+        raw_request: RawRequestProxy,
+    ) -> ImageGenerationResponse | ErrorResponse:
+        request_id = f"{self.request_id_prefix}-{base_request_id(raw_request)}"
+
+        try:
+            width, height = parse_size(request.size)
+        except ValueError as e:
+            return create_error_response(str(e))
+
+        strength = request.strength if request.strength is not None else _DEFAULT_EDIT_STRENGTH
+
+        # Decode / resize / mask work and inference are all CPU-bound; run the
+        # whole chain in the executor so the event loop is never blocked.
+        def _run() -> ImageGenerationResponse | ErrorResponse:
+            try:
+                src = decode_image(image_data)
+                image = src.convert("RGB").resize((width, height))
+                # An explicit `mask` upload wins; otherwise, per the OpenAI edits
+                # spec, the input image's own transparency marks the edit region.
+                mask = load_mask(mask_data, width, height) if mask_data is not None else alpha_mask(src, width, height)
+            except ValueError as e:
+                return create_error_response(str(e))
+
+            inpaint = mask is not None
+            logger.info(
+                "image edit request %s: prompt=%r, n=%d, size=%s, inpaint=%s",
+                request_id,
+                request.prompt,
+                request.n,
+                request.size,
+                inpaint,
+            )
+
+            kwargs: dict = {
+                "prompt": request.prompt,
+                "init_image": image,
+                "width": width,
+                "height": height,
+                "strength": strength,
+                "batch_count": request.n,
+            }
+            if inpaint:
+                kwargs["mask_image"] = mask
+            images = self._generate(**kwargs)
+            return build_response(images, revised_prompt=request.prompt)
+
+        loop = asyncio.get_event_loop()
+        async with self._lock:
+            response = await loop.run_in_executor(None, _run)
+        if isinstance(response, ImageGenerationResponse):
+            logger.log(TRACE, "image edit response %s: num_images=%d", request_id, len(response.data))
+        return response
+
+    async def create_image_variation(
+        self, image_data: bytes, request: ImageVariationRequest, raw_request: RawRequestProxy
+    ) -> ImageGenerationResponse | ErrorResponse:
+        request_id = f"{self.request_id_prefix}-{base_request_id(raw_request)}"
+        logger.info("image variation request %s: n=%d, size=%s", request_id, request.n, request.size)
+
+        try:
+            width, height = parse_size(request.size)
+        except ValueError as e:
+            return create_error_response(str(e))
+
+        strength = request.strength if request.strength is not None else _DEFAULT_VARIATION_STRENGTH
+
+        def _run() -> ImageGenerationResponse | ErrorResponse:
+            try:
+                image = load_image(image_data, width, height)
+            except ValueError as e:
+                return create_error_response(str(e))
+            images = self._generate(
+                prompt="", init_image=image, width=width, height=height, strength=strength, batch_count=request.n
+            )
+            return build_response(images, revised_prompt=None)
+
+        loop = asyncio.get_event_loop()
+        async with self._lock:
+            response = await loop.run_in_executor(None, _run)
+        if isinstance(response, ImageGenerationResponse):
+            logger.log(TRACE, "image variation response %s: num_images=%d", request_id, len(response.data))
+        return response

--- a/modelship/infer/stable_diffusion_cpp/stable_diffusion_cpp_infer.py
+++ b/modelship/infer/stable_diffusion_cpp/stable_diffusion_cpp_infer.py
@@ -64,10 +64,8 @@ class StableDiffusionCppInfer(BaseInfer):
     def shutdown(self) -> None:
         if self.sd is not None:
             logger.info("Shutting down stable-diffusion.cpp engine for %s", self.model_config.name)
-            # The binding releases the native context in __del__.
-            del self.sd
-            self.sd = None
         self.serving_image = None
+        self.sd = None
 
     def __del__(self):
         self.shutdown()

--- a/modelship/infer/stable_diffusion_cpp/stable_diffusion_cpp_infer.py
+++ b/modelship/infer/stable_diffusion_cpp/stable_diffusion_cpp_infer.py
@@ -1,0 +1,140 @@
+import asyncio
+import os
+
+from stable_diffusion_cpp import StableDiffusion
+
+from modelship.infer.base_infer import BaseInfer
+from modelship.infer.infer_config import ModelshipModelConfig, RawRequestProxy, StableDiffusionCppConfig
+from modelship.infer.preflight import discover_hardware, merge_with_user_overrides, run_preflight
+from modelship.infer.stable_diffusion_cpp.openai.serving_image import OpenAIServingImage
+from modelship.logging import get_logger
+from modelship.openai.protocol import (
+    ErrorResponse,
+    ImageEditRequest,
+    ImageGenerationRequest,
+    ImageGenerationResponse,
+    ImageVariationRequest,
+)
+
+logger = get_logger("infer.stable_diffusion_cpp")
+
+
+class StableDiffusionCppInfer(BaseInfer):
+    """CPU-only image-generation loader backed by stable-diffusion.cpp (via the
+    stable-diffusion-cpp-python bindings). Loads GGUF-quantized single-file
+    diffusion checkpoints (SD1.5/SDXL/SD-Turbo, all-in-one Flux) and serves the
+    OpenAI images endpoints. Structurally mirrors the llama_cpp loader."""
+
+    def __init__(self, model_config: ModelshipModelConfig):
+        super().__init__(model_config)
+        user_config = model_config.stable_diffusion_cpp_config or StableDiffusionCppConfig()
+        user_overrides = user_config.model_dump(exclude_unset=True)
+
+        # Preflight: hardware-aware safe defaults the user can override; user
+        # values always win and divergences are logged.
+        recommendation = run_preflight(model_config, discover_hardware())
+        if recommendation:
+            logger.info("preflight recommendation for '%s': %s", model_config.name, recommendation)
+        else:
+            logger.info("preflight recommendation for '%s': none", model_config.name)
+        merged = merge_with_user_overrides(recommendation, user_overrides, model_name=model_config.name)
+        self.config = user_config.model_copy(update=merged)
+
+        # Verbose native logging when MSHIP_LOG_LEVEL is TRACE (mirrors llama_cpp).
+        mship_log_level = os.environ.get("MSHIP_LOG_LEVEL", "INFO").upper()
+        self._verbose = mship_log_level == "TRACE"
+
+        # CPU-only in v1: the actor is given num_gpus=0 in actor_options, so warn
+        # if the config asked for GPUs (the request is ignored).
+        if model_config.num_gpus and model_config.num_gpus > 0:
+            logger.warning(
+                "num_gpus=%s is ignored for model '%s': stable_diffusion_cpp currently only supports CPU.",
+                model_config.num_gpus,
+                model_config.name,
+            )
+
+        self.sd: StableDiffusion | None = None
+        self.serving_image: OpenAIServingImage | None = None
+        logger.info(
+            "initialising stable-diffusion.cpp engine (verbose=%s) with config: %s",
+            self._verbose,
+            self.config.model_dump(),
+        )
+
+    def shutdown(self) -> None:
+        if self.sd is not None:
+            logger.info("Shutting down stable-diffusion.cpp engine for %s", self.model_config.name)
+            # The binding releases the native context in __del__.
+            del self.sd
+            self.sd = None
+        self.serving_image = None
+
+    def __del__(self):
+        self.shutdown()
+
+    async def start(self) -> None:
+        logger.info("Start stable-diffusion.cpp infer for model: %s", self.model_config.name)
+        model_path = self.model_config._resolved_path
+        if not model_path:
+            raise ValueError(
+                f"StableDiffusionCpp deployment '{self.model_config.name}' is missing a resolved model path. "
+                f"Check driver logs for resolution errors."
+            )
+
+        loop = asyncio.get_event_loop()
+        sd = await loop.run_in_executor(None, self._load, model_path)
+        self.sd = sd
+        self.serving_image = OpenAIServingImage(sd, self.config)
+
+    def _load(self, model_path: str) -> StableDiffusion:
+        c = self.config
+        # vae_decode_only=False so the VAE encoder is available for img2img
+        # (edits / variations), not just txt2img decode. Optional aux paths back
+        # split checkpoints; empty string means "unused" to the binding.
+        return StableDiffusion(
+            model_path=model_path,
+            diffusion_model_path=c.diffusion_model_path or "",
+            clip_l_path=c.clip_l_path or "",
+            clip_g_path=c.clip_g_path or "",
+            t5xxl_path=c.t5xxl_path or "",
+            vae_path=c.vae_path or "",
+            n_threads=c.n_threads,
+            wtype=c.wtype,
+            vae_decode_only=False,
+            verbose=self._verbose,
+            **c.model_kwargs,
+        )
+
+    async def warmup(self) -> None:
+        if self.serving_image is None:
+            return
+        logger.info("Warming up stable-diffusion.cpp model: %s", self.model_config.name)
+        proxy = RawRequestProxy(None, {})
+        request = ImageGenerationRequest(model=self.model_config.name, prompt="warmup", n=1, size="64x64")
+        await self.create_image_generation(request, proxy)
+        logger.info("Warmup image generation done for %s", self.model_config.name)
+
+    async def create_image_generation(
+        self, request: ImageGenerationRequest, raw_request: RawRequestProxy
+    ) -> ErrorResponse | ImageGenerationResponse:
+        if self.serving_image is None:
+            return await super().create_image_generation(request, raw_request)
+        return await self.serving_image.create_image_generation(request, raw_request)
+
+    async def create_image_edit(
+        self,
+        image_data: bytes,
+        mask_data: bytes | None,
+        request: ImageEditRequest,
+        raw_request: RawRequestProxy,
+    ) -> ErrorResponse | ImageGenerationResponse:
+        if self.serving_image is None:
+            return await super().create_image_edit(image_data, mask_data, request, raw_request)
+        return await self.serving_image.create_image_edit(image_data, mask_data, request, raw_request)
+
+    async def create_image_variation(
+        self, image_data: bytes, request: ImageVariationRequest, raw_request: RawRequestProxy
+    ) -> ErrorResponse | ImageGenerationResponse:
+        if self.serving_image is None:
+            return await super().create_image_variation(image_data, request, raw_request)
+        return await self.serving_image.create_image_variation(image_data, request, raw_request)

--- a/modelship/infer/stable_diffusion_cpp/stable_diffusion_cpp_infer.py
+++ b/modelship/infer/stable_diffusion_cpp/stable_diffusion_cpp_infer.py
@@ -79,7 +79,7 @@ class StableDiffusionCppInfer(BaseInfer):
                 f"Check driver logs for resolution errors."
             )
 
-        loop = asyncio.get_event_loop()
+        loop = asyncio.get_running_loop()
         sd = await loop.run_in_executor(None, self._load, model_path)
         self.sd = sd
         self.serving_image = OpenAIServingImage(sd, self.config)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,6 +48,7 @@ gpu = [
     "bitsandbytes>=0.49.0",
     "diffusers>=0.31.0",
     "llama-cpp-python>=0.3.6",
+    "stable-diffusion-cpp-python>=0.4.7",
     "onnxruntime-gpu>=1.20.1",
     "nvidia-ml-py",
 ]
@@ -57,6 +58,7 @@ cpu = [
     "transformers>=5.5.3",
     "sentence-transformers>=3.0.0",
     "llama-cpp-python>=0.3.6",
+    "stable-diffusion-cpp-python>=0.4.7",
     "onnxruntime>=1.20.1",
 ]
 kokoroonnx = ["kokoroonnx"]
@@ -155,6 +157,7 @@ markers = [
     "llama_cpp: integration tests that exercise the llama_cpp loader",
     "vllm: integration tests that exercise the vllm loader",
     "diffusers: integration tests that exercise the diffusers loader",
+    "stable_diffusion_cpp: integration tests that exercise the stable_diffusion_cpp loader",
 ]
 
 [tool.pyright]

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -133,6 +133,31 @@ class TestModelshipModelConfig:
                 loader=ModelLoader.diffusers,
             )
 
+    def test_stable_diffusion_cpp_usecase_defaults_to_image(self):
+        config = ModelshipModelConfig(
+            name="test-image",
+            model="org/sd-gguf:*.gguf",
+            loader=ModelLoader.stable_diffusion_cpp,
+        )
+        assert config.usecase is ModelUsecase.image
+
+    def test_stable_diffusion_cpp_rejects_non_image_usecase(self):
+        with pytest.raises(ValidationError, match="loader='stable_diffusion_cpp' only supports usecase='image'"):
+            ModelshipModelConfig(
+                name="test-image",
+                model="org/sd-gguf:*.gguf",
+                usecase=ModelUsecase.generate,
+                loader=ModelLoader.stable_diffusion_cpp,
+            )
+
+    def test_stable_diffusion_cpp_requires_model(self):
+        with pytest.raises(ValidationError, match="`model:` is required"):
+            ModelshipModelConfig(
+                name="test-image",
+                usecase=ModelUsecase.image,
+                loader=ModelLoader.stable_diffusion_cpp,
+            )
+
     def test_gpu_allocation_fraction(self):
         config = ModelshipModelConfig(
             name="test-llm",
@@ -249,9 +274,10 @@ class TestModelshipModelConfig:
             assert config.usecase == usecase
 
     def test_all_loaders_valid(self):
+        image_only = (ModelLoader.diffusers, ModelLoader.stable_diffusion_cpp)
         for loader in ModelLoader:
-            # diffusers is image-only; every other loader supports generate.
-            usecase = ModelUsecase.image if loader == ModelLoader.diffusers else ModelUsecase.generate
+            # diffusers / stable_diffusion_cpp are image-only; the rest support generate.
+            usecase = ModelUsecase.image if loader in image_only else ModelUsecase.generate
             kwargs = {"name": "test", "model": "some-model", "usecase": usecase}
             if loader == ModelLoader.custom:
                 kwargs["plugin"] = "test-plugin"

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -217,6 +217,16 @@ MODEL_CONFIGS: dict[str, dict] = {
         "num_gpus": 1,
         "diffusers_config": {"num_inference_steps": 2, "guidance_scale": 0.0},
     },
+    "image-cpu-model": {
+        "name": "image-cpu-model",
+        # SD2.1 packaged as a single-file sd.cpp GGUF (CLIP + UNet + VAE bundled).
+        # CPU-only; few steps + small size keep the integration run tractable.
+        "model": "jiaowobaba02/stable-diffusion-v2-1-GGUF:*q4_1.gguf",
+        "usecase": "image",
+        "loader": "stable_diffusion_cpp",
+        "num_cpus": 4,
+        "stable_diffusion_cpp_config": {"sample_steps": 6, "cfg_scale": 7.0},
+    },
 }
 
 
@@ -1564,6 +1574,105 @@ class TestImage:
             )
         assert variation.data[0].b64_json
         self._assert_png(self._decode(variation.data[0].b64_json), expect_size=(512, 512))
+
+
+@pytest.mark.integration
+@pytest.mark.stable_diffusion_cpp
+class TestImageStableDiffusionCpp:
+    """End-to-end CPU image generation, editing and variations through the
+    stable_diffusion_cpp loader. One single-file SD2.1 GGUF deployment backs all
+    three endpoints (txt2img + img2img + mask). The generated image is reused as
+    the input for the edit and variation calls. Small size + few steps keep the
+    CPU run tractable; the assertions check a valid PNG of the requested size,
+    not image quality."""
+
+    SIZE = "256x256"
+
+    @pytest.fixture(autouse=True, scope="class")
+    def _deploy(self, model_deployer):
+        model_deployer.deploy("image-cpu-model")
+
+    @staticmethod
+    def _decode(b64: str) -> bytes:
+        return base64.b64decode(b64)
+
+    @staticmethod
+    def _assert_png(data: bytes, *, expect_size: tuple[int, int] | None = None) -> None:
+        from PIL import Image
+
+        img = Image.open(io.BytesIO(data))
+        img.verify()
+        assert img.format == "PNG"
+        if expect_size is not None:
+            assert img.size == expect_size
+
+    def test_image_generation(self, client):
+        response = client.images.generate(
+            model="image-cpu-model", prompt="a red apple on a table", size=self.SIZE, response_format="b64_json"
+        )
+        assert response.data[0].b64_json
+        self._assert_png(self._decode(response.data[0].b64_json), expect_size=(256, 256))
+
+    def test_image_edit(self, client, tmp_path):
+        source = client.images.generate(
+            model="image-cpu-model", prompt="a plain blue sky", size=self.SIZE, response_format="b64_json"
+        )
+        image_path = tmp_path / "source.png"
+        image_path.write_bytes(self._decode(source.data[0].b64_json))
+
+        with open(image_path, "rb") as f:
+            edited = client.images.edit(
+                model="image-cpu-model",
+                image=f,
+                prompt="a blue sky with a bright sun",
+                size=self.SIZE,
+                response_format="b64_json",
+            )
+        assert edited.data[0].b64_json
+        self._assert_png(self._decode(edited.data[0].b64_json), expect_size=(256, 256))
+
+    def test_image_edit_with_mask(self, client, tmp_path):
+        from PIL import Image
+
+        source = client.images.generate(
+            model="image-cpu-model", prompt="a grassy field", size=self.SIZE, response_format="b64_json"
+        )
+        image_path = tmp_path / "source.png"
+        image_path.write_bytes(self._decode(source.data[0].b64_json))
+
+        # White rectangle marks the region to repaint; the rest is preserved.
+        mask = Image.new("RGB", (256, 256), (0, 0, 0))
+        for x in range(64, 192):
+            for y in range(64, 192):
+                mask.putpixel((x, y), (255, 255, 255))
+        mask_path = tmp_path / "mask.png"
+        mask.save(mask_path, format="PNG")
+
+        with open(image_path, "rb") as img_f, open(mask_path, "rb") as mask_f:
+            edited = client.images.edit(
+                model="image-cpu-model",
+                image=img_f,
+                mask=mask_f,
+                prompt="a grassy field with a small red flower",
+                size=self.SIZE,
+                response_format="b64_json",
+            )
+        assert edited.data[0].b64_json
+        self._assert_png(self._decode(edited.data[0].b64_json), expect_size=(256, 256))
+
+    def test_image_variation(self, client, tmp_path):
+        source = client.images.generate(
+            model="image-cpu-model", prompt="a yellow lemon", size=self.SIZE, response_format="b64_json"
+        )
+        image_path = tmp_path / "source.png"
+        image_path.write_bytes(self._decode(source.data[0].b64_json))
+
+        with open(image_path, "rb") as f:
+            variation = client.images.create_variation(
+                model="image-cpu-model", image=f, size=self.SIZE, response_format="b64_json"
+            )
+        assert variation.data[0].b64_json
+        self._assert_png(self._decode(variation.data[0].b64_json), expect_size=(256, 256))
 
 
 @pytest.mark.integration

--- a/tests/test_preflight_stable_diffusion_cpp.py
+++ b/tests/test_preflight_stable_diffusion_cpp.py
@@ -1,0 +1,44 @@
+"""Tests for the StableDiffusionCppPreflight estimator."""
+
+from __future__ import annotations
+
+from modelship.infer.infer_config import (
+    ModelLoader,
+    ModelshipModelConfig,
+    ModelUsecase,
+    StableDiffusionCppConfig,
+)
+from modelship.infer.preflight import HardwareProfile
+from modelship.infer.preflight.stable_diffusion_cpp import (
+    _VAE_TILING_RAM_THRESHOLD_BYTES,
+    StableDiffusionCppPreflight,
+)
+
+_GiB = 1024**3
+
+
+def _make_config(**sdcpp_kwargs) -> ModelshipModelConfig:
+    return ModelshipModelConfig(
+        name="test-image",
+        model="org/test-sd-gguf",
+        usecase=ModelUsecase.image,
+        loader=ModelLoader.stable_diffusion_cpp,
+        stable_diffusion_cpp_config=StableDiffusionCppConfig(**sdcpp_kwargs),
+    )
+
+
+def test_no_ram_returns_empty():
+    rec = StableDiffusionCppPreflight().recommend(_make_config(), HardwareProfile(ram_bytes=0))
+    assert rec == {}
+
+
+def test_low_ram_recommends_vae_tiling():
+    hw = HardwareProfile(ram_bytes=_VAE_TILING_RAM_THRESHOLD_BYTES - _GiB)
+    rec = StableDiffusionCppPreflight().recommend(_make_config(), hw)
+    assert rec == {"vae_tiling": True}
+
+
+def test_high_ram_no_recommendation():
+    hw = HardwareProfile(ram_bytes=_VAE_TILING_RAM_THRESHOLD_BYTES + _GiB)
+    rec = StableDiffusionCppPreflight().recommend(_make_config(), hw)
+    assert rec == {}

--- a/tests/test_stable_diffusion_cpp_image.py
+++ b/tests/test_stable_diffusion_cpp_image.py
@@ -1,0 +1,216 @@
+import asyncio
+import base64
+import io
+import threading
+import time
+
+import pytest
+from PIL import Image
+
+from modelship.infer.infer_config import RawRequestProxy, StableDiffusionCppConfig
+from modelship.infer.stable_diffusion_cpp.openai.serving_image import (
+    _DEFAULT_EDIT_STRENGTH,
+    _DEFAULT_VARIATION_STRENGTH,
+    OpenAIServingImage,
+)
+from modelship.openai.protocol import (
+    ErrorResponse,
+    ImageEditRequest,
+    ImageGenerationRequest,
+    ImageGenerationResponse,
+    ImageVariationRequest,
+)
+
+
+class _StubSD:
+    """Stand-in for a stable-diffusion.cpp handle. Records the kwargs each
+    `generate_image` call received and returns `batch_count` solid PIL images."""
+
+    def __init__(self):
+        self.calls: list[dict] = []
+
+    def generate_image(self, **kwargs):
+        self.calls.append(kwargs)
+        n = kwargs.get("batch_count", 1)
+        return [Image.new("RGB", (8, 8), (10, 20, 30)) for _ in range(n)]
+
+
+class _ConcurrencyProbeSD:
+    """Records the peak number of overlapping generate_image calls."""
+
+    def __init__(self):
+        self.active = 0
+        self.max_active = 0
+        self._lock = threading.Lock()
+
+    def generate_image(self, **kwargs):
+        with self._lock:
+            self.active += 1
+            self.max_active = max(self.max_active, self.active)
+        time.sleep(0.05)  # widen the window so unserialized calls would overlap
+        with self._lock:
+            self.active -= 1
+        n = kwargs.get("batch_count", 1)
+        return [Image.new("RGB", (8, 8)) for _ in range(n)]
+
+
+def _png_bytes(w: int = 16, h: int = 16) -> bytes:
+    buf = io.BytesIO()
+    Image.new("RGB", (w, h), (200, 100, 50)).save(buf, format="PNG")
+    return buf.getvalue()
+
+
+def _rgba_png(w: int = 16, h: int = 16, *, transparent: bool) -> bytes:
+    img = Image.new("RGBA", (w, h), (200, 100, 50, 255))
+    if transparent:
+        for x in range(w // 4, w * 3 // 4):
+            for y in range(h // 4, h * 3 // 4):
+                img.putpixel((x, y), (0, 0, 0, 0))
+    buf = io.BytesIO()
+    img.save(buf, format="PNG")
+    return buf.getvalue()
+
+
+def _serving(sd=None) -> OpenAIServingImage:
+    return OpenAIServingImage(
+        sd=sd if sd is not None else _StubSD(),  # type: ignore[arg-type]
+        config=StableDiffusionCppConfig(
+            sample_steps=5, cfg_scale=3.0, sample_method="euler", scheduler="karras", vae_tiling=True
+        ),
+    )
+
+
+def _proxy() -> RawRequestProxy:
+    return RawRequestProxy(None, {})
+
+
+def _assert_valid_b64_image(obj) -> None:
+    raw = base64.b64decode(obj.b64_json)
+    Image.open(io.BytesIO(raw)).verify()
+
+
+@pytest.mark.asyncio
+class TestImageGeneration:
+    async def test_generation_returns_n_images_and_forwards_config(self):
+        sd = _StubSD()
+        serving = _serving(sd)
+        request = ImageGenerationRequest(model="m", prompt="a red bicycle", n=2, size="64x32")
+
+        result = await serving.create_image_generation(request, _proxy())
+
+        assert isinstance(result, ImageGenerationResponse)
+        assert len(result.data) == 2
+        for obj in result.data:
+            assert obj.revised_prompt == "a red bicycle"
+            _assert_valid_b64_image(obj)
+        call = sd.calls[0]
+        assert call["prompt"] == "a red bicycle"
+        assert call["width"] == 64 and call["height"] == 32
+        assert call["batch_count"] == 2
+        # Per-model config defaults are applied on every call.
+        assert call["cfg_scale"] == 3.0
+        assert call["sample_steps"] == 5
+        assert call["sample_method"] == "euler"
+        assert call["scheduler"] == "karras"
+        assert call["vae_tiling"] is True
+        assert "init_image" not in call  # txt2img
+
+    async def test_generation_invalid_size_errors(self):
+        serving = _serving()
+        request = ImageGenerationRequest(model="m", prompt="x", n=1, size="not-a-size")
+        result = await serving.create_image_generation(request, _proxy())
+        assert isinstance(result, ErrorResponse)
+
+    async def test_calls_are_serialized(self):
+        probe = _ConcurrencyProbeSD()
+        serving = _serving(probe)
+        request = ImageGenerationRequest(model="m", prompt="x", n=1, size="16x16")
+        await asyncio.gather(*(serving.create_image_generation(request, _proxy()) for _ in range(4)))
+        assert probe.max_active == 1
+
+
+@pytest.mark.asyncio
+class TestImageEdit:
+    async def test_edit_without_mask_passes_init_image_no_mask(self):
+        sd = _StubSD()
+        serving = _serving(sd)
+        request = ImageEditRequest.model_construct(model="m", prompt="add a hat", n=2, size="32x32", strength=None)
+
+        result = await serving.create_image_edit(_png_bytes(), None, request, _proxy())
+
+        assert isinstance(result, ImageGenerationResponse)
+        assert len(result.data) == 2
+        call = sd.calls[0]
+        assert call["prompt"] == "add a hat"
+        assert call["init_image"] is not None
+        assert call["strength"] == _DEFAULT_EDIT_STRENGTH
+        assert "mask_image" not in call
+
+    async def test_edit_with_mask_passes_mask_image(self):
+        sd = _StubSD()
+        serving = _serving(sd)
+        request = ImageEditRequest.model_construct(model="m", prompt="erase", n=1, size="16x16", strength=0.5)
+
+        result = await serving.create_image_edit(_png_bytes(), _png_bytes(), request, _proxy())
+
+        assert isinstance(result, ImageGenerationResponse)
+        call = sd.calls[0]
+        assert call["strength"] == 0.5
+        assert "mask_image" in call
+
+    async def test_edit_transparent_image_derives_mask_from_alpha(self):
+        sd = _StubSD()
+        serving = _serving(sd)
+        request = ImageEditRequest.model_construct(model="m", prompt="fill", n=1, size="16x16", strength=None)
+
+        result = await serving.create_image_edit(_rgba_png(transparent=True), None, request, _proxy())
+
+        assert isinstance(result, ImageGenerationResponse)
+        call = sd.calls[0]
+        assert "mask_image" in call
+        # Transparent center -> repaint (white); opaque corner -> keep (black).
+        mask = call["mask_image"]
+        assert mask.getpixel((8, 8)) == 255
+        assert mask.getpixel((0, 0)) == 0
+
+    async def test_edit_opaque_rgba_no_mask_is_plain_img2img(self):
+        sd = _StubSD()
+        serving = _serving(sd)
+        request = ImageEditRequest.model_construct(model="m", prompt="x", n=1, size="16x16", strength=None)
+
+        result = await serving.create_image_edit(_rgba_png(transparent=False), None, request, _proxy())
+
+        assert isinstance(result, ImageGenerationResponse)
+        assert "mask_image" not in sd.calls[0]
+
+    async def test_edit_invalid_size_errors(self):
+        serving = _serving()
+        request = ImageEditRequest.model_construct(model="m", prompt="x", n=1, size="bad", strength=None)
+        result = await serving.create_image_edit(_png_bytes(), None, request, _proxy())
+        assert isinstance(result, ErrorResponse)
+
+
+@pytest.mark.asyncio
+class TestImageVariation:
+    async def test_variation_uses_empty_prompt_and_default_strength(self):
+        sd = _StubSD()
+        serving = _serving(sd)
+        request = ImageVariationRequest.model_construct(model="m", n=3, size="16x16", strength=None)
+
+        result = await serving.create_image_variation(_png_bytes(), request, _proxy())
+
+        assert isinstance(result, ImageGenerationResponse)
+        assert len(result.data) == 3
+        for obj in result.data:
+            assert obj.revised_prompt is None
+            _assert_valid_b64_image(obj)
+        call = sd.calls[0]
+        assert call["prompt"] == ""
+        assert call["init_image"] is not None
+        assert call["strength"] == _DEFAULT_VARIATION_STRENGTH
+
+    async def test_variation_invalid_size_errors(self):
+        serving = _serving()
+        request = ImageVariationRequest.model_construct(model="m", n=1, size="bad", strength=None)
+        result = await serving.create_image_variation(_png_bytes(), request, _proxy())
+        assert isinstance(result, ErrorResponse)

--- a/uv.lock
+++ b/uv.lock
@@ -1608,6 +1608,7 @@ cpu = [
     { name = "llama-cpp-python" },
     { name = "onnxruntime" },
     { name = "sentence-transformers" },
+    { name = "stable-diffusion-cpp-python" },
     { name = "torch", version = "2.11.0", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "(sys_platform == 'darwin' and extra == 'extra-9-modelship-cpu') or (extra == 'extra-9-modelship-cpu' and extra == 'extra-9-modelship-gpu')" },
     { name = "torch", version = "2.11.0+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "(sys_platform != 'darwin' and extra == 'extra-9-modelship-cpu') or (extra == 'extra-9-modelship-cpu' and extra == 'extra-9-modelship-gpu')" },
     { name = "torchvision", version = "0.26.0", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "(sys_platform == 'darwin' and extra == 'extra-9-modelship-cpu') or (extra == 'extra-9-modelship-cpu' and extra == 'extra-9-modelship-gpu')" },
@@ -1630,6 +1631,7 @@ gpu = [
     { name = "nvidia-ml-py" },
     { name = "onnxruntime-gpu" },
     { name = "sentence-transformers" },
+    { name = "stable-diffusion-cpp-python" },
     { name = "torch", version = "2.11.0+cu130", source = { registry = "https://download.pytorch.org/whl/cu130" } },
     { name = "torchvision", version = "0.26.0+cu130", source = { registry = "https://download.pytorch.org/whl/cu130" } },
     { name = "transformers" },
@@ -1688,6 +1690,8 @@ requires-dist = [
     { name = "sentence-transformers", marker = "extra == 'cpu'", specifier = ">=3.0.0" },
     { name = "sentence-transformers", marker = "extra == 'gpu'", specifier = ">=3.0.0" },
     { name = "soundfile", specifier = ">=0.13.0" },
+    { name = "stable-diffusion-cpp-python", marker = "extra == 'cpu'", specifier = ">=0.4.7" },
+    { name = "stable-diffusion-cpp-python", marker = "extra == 'gpu'", specifier = ">=0.4.7" },
     { name = "torch", marker = "extra == 'cpu'", specifier = ">=2.10.0", index = "https://download.pytorch.org/whl/cpu", conflict = { package = "modelship", extra = "cpu" } },
     { name = "torch", marker = "extra == 'gpu'", specifier = ">=2.10.0", index = "https://download.pytorch.org/whl/cu130", conflict = { package = "modelship", extra = "gpu" } },
     { name = "torchvision", marker = "extra == 'cpu'", specifier = ">=0.25.0", index = "https://download.pytorch.org/whl/cpu", conflict = { package = "modelship", extra = "cpu" } },
@@ -3497,6 +3501,16 @@ sdist = { url = "https://files.pythonhosted.org/packages/26/8c/f9290339ef6d79bad
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f8/7f/3de5402f39890ac5660b86bcf5c03f9d855dad5c4ed764866d7b592b46fd/sse_starlette-3.3.4-py3-none-any.whl", hash = "sha256:84bb06e58939a8b38d8341f1bc9792f06c2b53f48c608dd207582b664fc8f3c1", size = 14330, upload-time = "2026-03-29T09:00:21.846Z" },
 ]
+
+[[package]]
+name = "stable-diffusion-cpp-python"
+version = "0.4.7"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pillow" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b1/06/300aba9ac36e2166fbe45b4a29039a76f725ef08796f5472caf3e8c4e08d/stable_diffusion_cpp_python-0.4.7.tar.gz", hash = "sha256:998d1957260dd5ae4e18a8acc0c14b0a8757aaa9f96515197b6d5bbf46df9282", size = 20561087, upload-time = "2026-05-12T11:04:30.294Z" }
 
 [[package]]
 name = "starlette"


### PR DESCRIPTION
Adds a first-class `stable_diffusion_cpp` loader backed by stable-diffusion.cpp (via stable-diffusion-cpp-python), the image counterpart to the CPU-only llama_cpp text loader. Runs GGUF-quantized single-file diffusion checkpoints (SD1.5/SDXL/SD-Turbo, all-in-one Flux) with no GPU and serves /v1/images/generations, /edits and /variations.

- config: ModelLoader.stable_diffusion_cpp + StableDiffusionCppConfig, image-only validators (auto-default usecase) shared with diffusers
- loader + serving adapter mirroring llama_cpp/diffusers; a single generate_image call backs txt2img, img2img edits and variations, serialized through a lock
- extract shared image helpers (parse_size/build_response/decode) into image_serving_common, reused by both image adapters
- CPU forcing (num_gpus=0) in actor_options; loader dispatch in model_deployment; RAM-aware preflight (vae_tiling on low-RAM hosts)
- stable-diffusion-cpp-python>=0.4.7 in cpu+gpu extras; example config; docs (model-configuration, architecture)
- unit tests (adapter, preflight, config) + opt-in integration class marked stable_diffusion_cpp using a single-file SD2.1 GGUF


