### PR TITLE
perf(ray): disable Ray dashboard by default to cut host RAM

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -60,4 +60,4 @@ The API binds to `0.0.0.0:8000` by default, but if you're on a remote machine, m
 
 - Set `MSHIP_LOG_LEVEL=DEBUG` for verbose logs.
 - Set `MSHIP_LOG_LEVEL=TRACE` to log full request/response payloads (and enable llama.cpp `verbose` mode).
-- The Ray dashboard on port `8265` shows per-actor logs and resource usage.
+- The Ray dashboard is **disabled by default** to save host RAM. Start the container with `MSHIP_RAY_DASHBOARD=true` (and publish port `8265`) to get per-actor logs and resource usage in the UI. Prometheus metrics on `8079` are exported regardless.

--- a/scripts/start_ray.sh
+++ b/scripts/start_ray.sh
@@ -20,7 +20,7 @@ while [[ $# -gt 0 ]]; do
 done
 
 RAY_FLAGS=(--head --disable-usage-stats)
-if [ "${MSHIP_RAY_DASHBOARD}" = "true" ]; then
+if [ "${MSHIP_RAY_DASHBOARD,,}" = "true" ]; then
     RAY_FLAGS+=(--include-dashboard=true --dashboard-host=0.0.0.0)
 else
     RAY_FLAGS+=(--include-dashboard=false)

--- a/scripts/start_ray.sh
+++ b/scripts/start_ray.sh
@@ -19,7 +19,12 @@ while [[ $# -gt 0 ]]; do
     esac
 done
 
-RAY_FLAGS=(--head --dashboard-host=0.0.0.0 --disable-usage-stats)
+RAY_FLAGS=(--head --disable-usage-stats)
+if [ "${MSHIP_RAY_DASHBOARD}" = "true" ]; then
+    RAY_FLAGS+=(--include-dashboard=true --dashboard-host=0.0.0.0)
+else
+    RAY_FLAGS+=(--include-dashboard=false)
+fi
 
 if [ -n "${NUM_CPUS}" ]; then
     RAY_FLAGS+=(--num-cpus="${NUM_CPUS}")


### PR DESCRIPTION
The Ray dashboard UI runs a heavyweight aiohttp/grpc head process that serves no purpose in a headless deployment but contributes to the host RAM gap over raw vLLM. Start Ray with --include-dashboard=false by default; set MSHIP_RAY_DASHBOARD=true to re-enable the UI for debugging.

Prometheus metrics on 8079 are exported by the per-node dashboard agent and are unaffected by this flag.


