### PR TITLE
feat: reclaim Ray temp disk on restart and drop --redeploy

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -58,7 +58,7 @@ Entry point is `mship_deploy.py` (not a console script, not `python -m`). It:
 
 1. Reads `config/models.yaml` (gitignored — copy one from `config/examples/`).
 2. Starts its **own** Ray head by default (sized from `RAY_HEAD_CPU_NUM`/`RAY_HEAD_GPU_NUM`, auto-detected if unset; metrics on `RAY_METRICS_EXPORT_PORT`) and tears it down on exit. With `--use-existing-ray-cluster` it instead connects to a cluster you manage via `ray.init(address="auto")` and deploys-and-exits without teardown — the driver must run **on** a cluster node (Docker co-located / k8s RayJob / bare-metal node); it cannot attach from off-cluster.
-3. Deploys models **additively** by default (new deployments get a random suffix, e.g. `qwen-a3f9k`). Pass `--redeploy` to tear everything down first.
+3. Deploys models **additively** by default (new deployments get a random suffix, e.g. `qwen-a3f9k`). Pass `--reconcile` to instead make the cluster match the config exactly (add/remove/replace) — it never tears the cluster down.
 4. Starts a FastAPI gateway Ray Serve app named `modelship api` (override with `--gateway-name`), listening on port `8000`.
 
 The Docker image's `CMD` is `uv run --no-sync mship_deploy.py` (against the venv baked at build time; extras selected by `--build-arg MSHIP_VARIANT=gpu|cpu`), which starts its own Ray head and runs the deploy loop. Plugin wheels under `MSHIP_PLUGIN_WHEEL_DIR` are injected per-deployment via Ray `runtime_env`, resolved automatically from `models.yaml`. The Dev Container overrides this `CMD`, so inside a Dev Container you run `mship_deploy.py` manually (see `docs/development.md`).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,7 +38,7 @@ When running tests on your own initiative, skip the slow integration suite: `uv 
 
 1. Reads `config/models.yaml` (gitignored — copy from `config/examples/`; `mship_deploy.py` errors out pointing there if missing).
 2. Starts its **own** Ray head by default and tears it down on exit. With `--use-existing-ray-cluster` it instead connects to a cluster you manage via `ray.init(address="auto")` and deploys-and-exits without teardown — the driver must run **on** a cluster node (it can't attach from off-cluster; k8s does this via a KubeRay RayJob).
-3. Deploys models **additively** by default (each gets a random suffix like `qwen-a3f9k`). Use `--redeploy` to tear everything down first.
+3. Deploys models **additively** by default (each gets a random suffix like `qwen-a3f9k`). Use `--reconcile` to instead make the cluster match the config exactly (add/remove/replace) — it never tears the cluster down.
 4. Starts a FastAPI Ray Serve app named `modelship api` on port 8000. Override via `--gateway-name` (multiple gateways can coexist on one cluster).
 
 Docker's `CMD` is `uv run --no-sync mship_deploy.py` (auto-detecting CPUs/GPUs unless `RAY_HEAD_CPU_NUM`/`RAY_HEAD_GPU_NUM` set), against the prebuilt venv (extras chosen by `--build-arg MSHIP_VARIANT=gpu|cpu`). Plugin wheels in `MSHIP_PLUGIN_WHEEL_DIR` ship to Ray workers per-deployment via `runtime_env`, resolved from `models.yaml`. The Dev Container overrides this — inside it you must `uv sync` and run `mship_deploy.py` manually.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -26,7 +26,7 @@ Each model in `models.yaml` becomes an isolated Ray Serve deployment (`ModelDepl
 - **Independent lifecycle** — one model crashing doesn't affect others
 - **Per-model GPU budgeting** — `num_gpus` controls VRAM allocation (e.g. 0.70 for 70%)
 - **Sequential startup** — models deploy one at a time to prevent memory spikes, ordered by tensor parallelism size (TP > 1 first)
-- **Additive deploys** — by default, `mship_deploy.py` adds models to a running cluster without disrupting existing deployments, enabling incremental composition from multiple config files. Use `--redeploy` to tear down and start fresh
+- **Additive deploys** — by default, `mship_deploy.py` adds models to a running cluster without disrupting existing deployments, enabling incremental composition from multiple config files. Use `--reconcile` to instead make the cluster match a config exactly (add/remove/replace), without ever tearing down the cluster
 - **Multi-deployment routing** — the same model name can appear multiple times with different configs (e.g. GPU + CPU). The gateway round-robins requests across all deployments sharing a name. Each deployment also supports `num_replicas` for scaling identical copies via Ray Serve's built-in load balancing
 - **Multi-gateway support** — multiple independent gateways can run on the same cluster via `--gateway-name`, each managing its own set of models
 
@@ -93,7 +93,7 @@ See [Plugin Development](plugins.md) for details.
 
 | File | Purpose |
 |------|---------|
-| `mship_deploy.py` | Entry point — initializes Ray, deploys models additively (or fresh with `--redeploy`) |
+| `mship_deploy.py` | Entry point — initializes Ray, deploys models additively (or reconciles with `--reconcile`) |
 | `modelship/openai/api.py` | FastAPI gateway with OpenAI endpoints |
 | `modelship/openai/protocol/responses/` | `/v1/responses` schemas + stateless chat adapter (`adapter.py`) and streaming translator (`streaming.py`) |
 | `modelship/infer/model_deployment.py` | Ray Serve deployment actor |

--- a/docs/model-configuration.md
+++ b/docs/model-configuration.md
@@ -12,7 +12,9 @@ Models are configured in a YAML file (default: `config/models.yaml`). Each entry
 | `--model-stack` | `MSHIP_MODEL_STACK` | — | Auto-generate a config from a [profile](#profiles-mship_model_stack) (`chat`/`assistant`/`studio`/`everything`) sized to detected hardware |
 | `--gateway-name` | `MSHIP_GATEWAY_NAME` | `modelship api` | Name for the API gateway app |
 | `--use-existing-ray-cluster` | `MSHIP_USE_EXISTING_RAY_CLUSTER` | `false` | Connect to a Ray cluster you manage (must run on a cluster node) instead of starting one. Implies deploy-and-exit (no teardown) |
-| `--redeploy` | — | `false` | Tear down all existing deployments before deploying |
+| `--prune-ray-sessions` | `MSHIP_PRUNE_RAY_SESSIONS` | `true` | When starting its own Ray head, delete stale `session_*` dirs left under the Ray temp root (default `/tmp/ray`) by previous, no-longer-running heads — Ray never cleans these up, so they fill the disk across restarts. A live head's session is always kept. Set `false` to keep them (e.g. for debugging). No effect with `--use-existing-ray-cluster` |
+| `--reconcile` | — | `false` | Reconcile the cluster to the config: add new models, remove dropped ones, replace changed ones (vs. the default additive union). With no `--config`, reconciles to this gateway's persisted effective config (self-heal) |
+| `--replace-strategy` | — | `blue_green` | How to replace a changed model: `blue_green` (deploy new before dropping old, no request loss) or `stop_start` (drop old first, brief unavailability) |
 | `--cache-dir` | `MSHIP_CACHE_DIR` | `/.cache` | Base cache directory |
 | `--state-store` | `MSHIP_STATE_STORE` | `memory://` | State-store connection URI for the effective config + deploy coordinator (see [State store](#state-store-mship_state_store)) |
 | — | `MSHIP_LOG_LEVEL` | `INFO` | Log level (env-var-only: must be set before `import ray` so library loggers latch the right level) |
@@ -47,10 +49,12 @@ python mship_deploy.py --config config/tts.yaml
 python mship_deploy.py --config config/embeddings.yaml
 ```
 
-Use `--redeploy` to tear down everything and start fresh:
+Use `--reconcile` to make the running cluster match a config exactly — new models
+are added, dropped ones removed, and changed ones replaced (gracefully, draining
+in-flight requests). Unlike additive mode it never tears down the Ray cluster:
 
 ```bash
-python mship_deploy.py --config config/models.yaml --redeploy
+python mship_deploy.py --config config/models.yaml --reconcile
 ```
 
 Multiple gateways can run independently by using `--gateway-name`:

--- a/modelship/deploy/effective_config.py
+++ b/modelship/deploy/effective_config.py
@@ -1,7 +1,7 @@
 """Per-gateway *effective config* — the durable desired-state for deploys.
 
 Every ``mship_deploy`` invocation, whatever its mode, folds the user's input into
-the gateway's effective set (additive = union; reconcile/redeploy = replace), then
+the gateway's effective set (additive = union; reconcile = replace), then
 the deploy ALWAYS reconciles the live cluster to that effective set. Self-heal is
 then just "re-run the deploy": it reads the persisted effective set and reconciles
 onto an empty cluster, restoring the TRUE live set after the cluster dies — not
@@ -23,19 +23,15 @@ from modelship.state import StateStore
 
 logger = get_logger("startup")
 
-DeployMode = Literal["additive", "reconcile", "redeploy"]
+DeployMode = Literal["additive", "reconcile"]
 
 # State-store namespace; one key per gateway: "effective/<gateway-name>".
 _NAMESPACE = "effective"
 
 
-def resolve_mode(*, reconcile: bool, redeploy: bool) -> DeployMode:
-    """Map the mutually-exclusive CLI flags to the effective-config merge verb."""
-    if redeploy:
-        return "redeploy"
-    if reconcile:
-        return "reconcile"
-    return "additive"
+def resolve_mode(*, reconcile: bool) -> DeployMode:
+    """Map the CLI flags to the effective-config merge verb."""
+    return "reconcile" if reconcile else "additive"
 
 
 def _deployment_name(raw: dict, gateway_name: str) -> str:
@@ -57,9 +53,9 @@ def merge(
     - additive: union — append input dicts whose deployment name isn't already
       present (identical config = idempotent skip; same name + different config =
       a distinct deployment the gateway round-robins, preserved as today).
-    - reconcile / redeploy: input replaces the effective set entirely.
+    - reconcile: input replaces the effective set entirely.
     """
-    if mode in ("reconcile", "redeploy"):
+    if mode == "reconcile":
         return list(input_raw)
 
     present = {_deployment_name(d, gateway_name) for d in effective_raw}

--- a/modelship/deploy/serve_utils.py
+++ b/modelship/deploy/serve_utils.py
@@ -1,9 +1,13 @@
 import logging
 import os
+import re
+import shutil
 import socket
+from pathlib import Path
 
 import ray
 from ray import serve
+from ray._common.utils import get_ray_temp_dir
 from ray.serve.config import HTTPOptions, ProxyLocation
 from ray.serve.schema import LoggingConfig
 
@@ -14,6 +18,10 @@ from modelship.utils import rand_suffix
 
 logger = get_logger("startup")
 _DEFAULT_OPENAI_API_PORT = 8000
+
+# Ray names each head's session dir `session_<timestamp>_<pid>` under its temp
+# root and never cleans them up; the trailing group captures the owning pid.
+_RAY_SESSION_DIR_RE = re.compile(r"^session_.*_(\d+)$")
 
 
 def make_operator_id() -> str:
@@ -82,6 +90,63 @@ def _own_cluster_init_kwargs() -> dict[str, object]:
     return kwargs
 
 
+def _pid_alive(pid: int) -> bool:
+    """True if a process with *pid* currently exists. Used to avoid deleting a
+    still-running head's session dir."""
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        # Process exists but is owned by another user — treat as alive (keep it).
+        return True
+    except OSError:
+        return True
+    return True
+
+
+def prune_ray_sessions() -> None:
+    """Delete stale `session_<timestamp>_<pid>` dirs Ray leaves under its temp
+    root (default /tmp/ray). Ray never cleans them up, so they accumulate across
+    container/process restarts and slowly fill the disk on long-lived self-hosted
+    boxes.
+
+    Called only when we start our OWN head (connect_ray's own-cluster branch),
+    before ray.init creates this run's session — so this run's dir doesn't exist
+    yet and can't be removed. A session whose owning pid is still alive is kept:
+    on a single machine a second non---use-existing deploy joins this machine's
+    running head (ray.init reads /tmp/ray/ray_current_cluster), so a live head may
+    be present even on the own-cluster path. The `session_latest` symlink and
+    non-session files (e.g. ray_current_cluster) never match and are left alone.
+
+    Best-effort: pruning never aborts startup — any failure is logged as a
+    warning and the deploy proceeds. Set MSHIP_PRUNE_RAY_SESSIONS=false to disable
+    (e.g. to keep a crashed session's logs for debugging)."""
+    if os.environ.get("MSHIP_PRUNE_RAY_SESSIONS", "true").lower() != "true":
+        return
+    try:
+        temp_root = Path(get_ray_temp_dir())
+        if not temp_root.is_dir():
+            return
+        removed = 0
+        for entry in temp_root.iterdir():
+            match = _RAY_SESSION_DIR_RE.match(entry.name)
+            if not match or entry.is_symlink() or not entry.is_dir():
+                continue
+            if _pid_alive(int(match.group(1))):
+                continue
+            try:
+                shutil.rmtree(entry)
+                removed += 1
+            except OSError:
+                logger.warning("Failed to prune stale Ray session dir %s (continuing).", entry, exc_info=True)
+        if removed:
+            logger.info("Pruned %d stale Ray session dir(s) under %s", removed, temp_root)
+    except Exception:
+        # Cleanup is never worth failing a deploy over — warn and carry on.
+        logger.warning("Ray session pruning failed; continuing without it.", exc_info=True)
+
+
 def connect_ray(lib_level: int) -> None:
     use_existing_cluster = os.environ.get("MSHIP_USE_EXISTING_RAY_CLUSTER", "false").lower() == "true"
     os.environ.setdefault("RAY_GCS_RPC_TIMEOUT_S", "30")
@@ -97,6 +162,10 @@ def connect_ray(lib_level: int) -> None:
         # start_ray.sh used to do). mship_deploy stays alive as the operator and
         # tears it down on exit (owns_cluster in mship_deploy).
         os.environ.setdefault("RAY_USAGE_STATS_ENABLED", "0")
+        # Reclaim disk from prior runs' leftover session dirs before this run's
+        # session is created. Skipped on the existing-cluster branch (KubeRay /
+        # an operator we don't own manages its own temp root).
+        prune_ray_sessions()
         ray.init(ignore_reinit_error=True, logging_level=lib_level, **_own_cluster_init_kwargs())
     # ray.init re-sets ray.* loggers, so re-pin them after init.
     logging.getLogger("ray").setLevel(lib_level)

--- a/modelship/deploy/strategy.py
+++ b/modelship/deploy/strategy.py
@@ -33,8 +33,8 @@ def compute_deploy_plan(
     gateway_name: str,
 ) -> DeployPlan:
     """Diff the desired effective set against what's live. The deploy ALWAYS
-    reconciles live -> desired (the merge verb already folded additive/reconcile/
-    redeploy into `desired_conf`). Deployment names are `{model}-{fingerprint}`, so
+    reconciles live -> desired (the merge verb already folded additive/reconcile
+    into `desired_conf`). Deployment names are `{model}-{fingerprint}`, so
     a pure set comparison detects renames and config drift.
 
     Removal is scoped to `prev_effective_names` — the deployments that were under

--- a/modelship/utils/cli.py
+++ b/modelship/utils/cli.py
@@ -73,6 +73,15 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         help="OpenTelemetry OTLP endpoint e.g. http://collector:4317 (env: OTEL_EXPORTER_OTLP_ENDPOINT)",
     )
     parser.add_argument("--no-metrics", action="store_true", default=None, help="Disable metrics (env: MSHIP_METRICS)")
+    parser.add_argument(
+        "--prune-ray-sessions",
+        choices=["true", "false"],
+        default=None,
+        help=(
+            "Whether to delete stale dead-pid Ray session dirs under the temp root on "
+            "own-cluster startup (env: MSHIP_PRUNE_RAY_SESSIONS, default: true)"
+        ),
+    )
     parser.add_argument("--api-keys", help="Comma-separated API keys (env: MSHIP_API_KEYS)")
     parser.add_argument(
         "--max-request-body-bytes", type=int, help="Max request body size in bytes (env: MSHIP_MAX_REQUEST_BODY_BYTES)"
@@ -83,12 +92,6 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         help="Port for the OpenAI-compatible API (env: MSHIP_OPENAI_API_PORT, default: 8000)",
     )
     parser.add_argument(
-        "--redeploy",
-        action="store_true",
-        default=False,
-        help="Tear down all existing deployments before deploying (default: additive)",
-    )
-    parser.add_argument(
         "--reconcile",
         action="store_true",
         default=False,
@@ -96,8 +99,7 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
             "Diff models.yaml against the cluster: add new models, remove dropped ones, "
             "replace those whose config changed (matched by name + fingerprint). "
             "With no --config, reconciles the live cluster to this gateway's persisted "
-            "effective config only (self-heal after cluster loss). "
-            "Mutually exclusive with --redeploy."
+            "effective config only (self-heal after cluster loss)."
         ),
     )
     parser.add_argument(
@@ -110,10 +112,7 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
             "stop_start: drop old first, then deploy new (brief unavailability, no overlap)."
         ),
     )
-    args = parser.parse_args(argv)
-    if args.redeploy and args.reconcile:
-        parser.error("--redeploy and --reconcile are mutually exclusive")
-    return args
+    return parser.parse_args(argv)
 
 
 def apply_args_to_env(args: argparse.Namespace) -> None:
@@ -127,6 +126,8 @@ def apply_args_to_env(args: argparse.Namespace) -> None:
         os.environ["MSHIP_USE_EXISTING_RAY_CLUSTER"] = "true"
     if args.no_metrics is True:
         os.environ["MSHIP_METRICS"] = "false"
+    if args.prune_ray_sessions is not None:
+        os.environ["MSHIP_PRUNE_RAY_SESSIONS"] = args.prune_ray_sessions
     if args.max_request_body_bytes is not None:
         os.environ["MSHIP_MAX_REQUEST_BODY_BYTES"] = str(args.max_request_body_bytes)
     if args.gateway_replicas is not None:

--- a/mship_deploy.py
+++ b/mship_deploy.py
@@ -86,26 +86,22 @@ def main(argv: list[str] | None = None) -> None:
     lib_level, lib_level_name = get_lib_log_config()
     serve_logging_config = LoggingConfig(log_level=lib_level_name)
 
-    if args.redeploy:
-        logger.info("--redeploy: tearing down existing deployments...")
-        shutdown_ray()
-
     connect_ray(lib_level)
     start_serve(serve_logging_config)
 
-    existing_apps = set() if args.redeploy else get_existing_apps()
+    existing_apps = get_existing_apps()
     fresh_install = gateway_name not in existing_apps
     if existing_apps:
         logger.info("Found existing deployments: %s", ", ".join(sorted(existing_apps)))
-    if fresh_install and not args.redeploy:
+    if fresh_install:
         logger.info("No existing gateway found — treating as fresh install.")
 
     # Fold the user's input into this gateway's durable effective config, then
     # deploy by ALWAYS reconciling live -> effective. The mode only decides how the
-    # input merges (additive=union, reconcile/redeploy=replace); the deploy itself
+    # input merges (additive=union, reconcile=replace); the deploy itself
     # is always a reconcile — that's what makes self-heal just "re-run the deploy"
     # (it reads the persisted effective set and reconciles onto an empty cluster).
-    mode = resolve_mode(reconcile=args.reconcile, redeploy=args.redeploy)
+    mode = resolve_mode(reconcile=args.reconcile)
     store = get_state_store()
     effective_raw = read_effective(store, gateway_name)
 
@@ -113,7 +109,7 @@ def main(argv: list[str] | None = None) -> None:
     # reconcile the live cluster to the persisted effective config as-is (restores
     # the true model set after the cluster is recreated empty). Any other mode, or
     # an explicit --config, loads the user input and folds it into effective per the
-    # merge verb (additive=union, reconcile/redeploy=replace).
+    # merge verb (additive=union, reconcile=replace).
     if mode == "reconcile" and args.config is None:
         desired_raw = effective_raw
         logger.info("Self-heal: reconciling to persisted effective config (no --config given).")

--- a/tests/test_effective_config.py
+++ b/tests/test_effective_config.py
@@ -61,13 +61,10 @@ class TestFileStateStore:
 
 class TestResolveMode:
     def test_default_is_additive(self):
-        assert resolve_mode(reconcile=False, redeploy=False) == "additive"
+        assert resolve_mode(reconcile=False) == "additive"
 
     def test_reconcile(self):
-        assert resolve_mode(reconcile=True, redeploy=False) == "reconcile"
-
-    def test_redeploy_wins(self):
-        assert resolve_mode(reconcile=False, redeploy=True) == "redeploy"
+        assert resolve_mode(reconcile=True) == "reconcile"
 
 
 class TestMerge:
@@ -89,10 +86,6 @@ class TestMerge:
 
     def test_reconcile_replaces(self):
         merged = merge([_model("a"), _model("b")], [_model("c")], "g", "reconcile")
-        assert [m["name"] for m in merged] == ["c"]
-
-    def test_redeploy_replaces(self):
-        merged = merge([_model("a")], [_model("c")], "g", "redeploy")
         assert [m["name"] for m in merged] == ["c"]
 
 

--- a/tests/test_mship_deploy.py
+++ b/tests/test_mship_deploy.py
@@ -22,13 +22,9 @@ class TestParseArgs:
     def test_defaults(self):
         args = parse_args([])
         assert args.config is None
-        assert args.redeploy is False
+        assert args.reconcile is False
         assert args.gateway_name is None
         assert args.use_existing_ray_cluster is None
-
-    def test_redeploy_flag(self):
-        args = parse_args(["--redeploy"])
-        assert args.redeploy is True
 
     def test_reconcile_flag(self):
         args = parse_args(["--reconcile"])
@@ -39,10 +35,6 @@ class TestParseArgs:
         args = parse_args(["--reconcile", "--replace-strategy", "stop_start"])
         assert args.reconcile is True
         assert args.replace_strategy == "stop_start"
-
-    def test_redeploy_and_reconcile_mutually_exclusive(self):
-        with pytest.raises(SystemExit):
-            parse_args(["--redeploy", "--reconcile"])
 
     def test_config_path(self):
         args = parse_args(["--config", "/some/path/models.yaml"])
@@ -72,13 +64,13 @@ class TestParseArgs:
                 "llm.yaml",
                 "--gateway-name",
                 "llm-api",
-                "--redeploy",
+                "--reconcile",
                 "--use-existing-ray-cluster",
             ]
         )
         assert args.config == "llm.yaml"
         assert args.gateway_name == "llm-api"
-        assert args.redeploy is True
+        assert args.reconcile is True
         assert args.use_existing_ray_cluster is True
 
 
@@ -102,6 +94,26 @@ class TestApplyArgsToEnv:
         monkeypatch.delenv("MSHIP_GATEWAY_REPLICAS", raising=False)
         apply_args_to_env(parse_args(["--gateway-replicas", "4"]))
         assert os.environ["MSHIP_GATEWAY_REPLICAS"] == "4"
+
+    def test_prune_ray_sessions_false_sets_env(self):
+        # patch.dict (not monkeypatch.delenv) so the env write is reverted on exit
+        # — otherwise MSHIP_PRUNE_RAY_SESSIONS=false leaks into the prune tests.
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("MSHIP_PRUNE_RAY_SESSIONS", None)
+            apply_args_to_env(parse_args(["--prune-ray-sessions", "false"]))
+            assert os.environ["MSHIP_PRUNE_RAY_SESSIONS"] == "false"
+
+    def test_prune_ray_sessions_true_sets_env(self):
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("MSHIP_PRUNE_RAY_SESSIONS", None)
+            apply_args_to_env(parse_args(["--prune-ray-sessions", "true"]))
+            assert os.environ["MSHIP_PRUNE_RAY_SESSIONS"] == "true"
+
+    def test_prune_ray_sessions_absent_leaves_env_untouched(self):
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("MSHIP_PRUNE_RAY_SESSIONS", None)
+            apply_args_to_env(parse_args([]))
+            assert "MSHIP_PRUNE_RAY_SESSIONS" not in os.environ
 
 
 class TestRandSuffix:
@@ -388,6 +400,8 @@ class TestConnectRay:
         with (
             patch.dict(os.environ, env, clear=False),
             patch.object(serve_utils.ray, "init") as mock_init,
+            # Don't let the own-cluster branch sweep the real /tmp/ray during tests.
+            patch.object(serve_utils, "prune_ray_sessions"),
         ):
             serve_utils.connect_ray(20)
         _, kwargs = mock_init.call_args
@@ -428,3 +442,141 @@ class TestConnectRay:
         kwargs = self._init_call({"MSHIP_USE_EXISTING_RAY_CLUSTER": "false", "MSHIP_METRICS": "false"})
         assert "address" not in kwargs
         assert "_metrics_export_port" not in kwargs
+
+    def test_prunes_stale_sessions_on_own_cluster(self):
+        from modelship.deploy import serve_utils
+
+        with (
+            patch.dict(os.environ, {"MSHIP_USE_EXISTING_RAY_CLUSTER": "false"}, clear=False),
+            patch.object(serve_utils.ray, "init"),
+            patch.object(serve_utils, "prune_ray_sessions") as mock_prune,
+        ):
+            serve_utils.connect_ray(20)
+        mock_prune.assert_called_once()
+
+    def test_skips_prune_on_existing_cluster(self):
+        from modelship.deploy import serve_utils
+
+        # We don't own the temp root on an external cluster — never sweep it.
+        with (
+            patch.dict(os.environ, {"MSHIP_USE_EXISTING_RAY_CLUSTER": "true"}, clear=False),
+            patch.object(serve_utils.ray, "init"),
+            patch.object(serve_utils, "prune_ray_sessions") as mock_prune,
+        ):
+            serve_utils.connect_ray(20)
+        mock_prune.assert_not_called()
+
+
+class TestPruneRaySessions:
+    """`prune_ray_sessions` resolves the temp root via Ray's own
+    `get_ray_temp_dir()`, which returns `<RAY_TMPDIR>/ray` — so pointing
+    RAY_TMPDIR at a tmp dir fully isolates these tests from the real /tmp/ray."""
+
+    def _temp_root(self, tmp_path):
+        root = tmp_path / "ray"
+        root.mkdir()
+        return root
+
+    def _make_session(self, root, pid, name=None):
+        session = root / (name or f"session_2026-06-19_10-00-00_000000_{pid}")
+        (session / "logs").mkdir(parents=True)
+        (session / "logs" / "raylet.out").write_text("log")
+        return session
+
+    def test_removes_dead_pid_session(self, tmp_path):
+        from modelship.deploy import serve_utils
+
+        root = self._temp_root(tmp_path)
+        dead = self._make_session(root, 111)
+        with (
+            patch.dict(
+                os.environ,
+                {"RAY_TMPDIR": str(tmp_path), "MSHIP_PRUNE_RAY_SESSIONS": "true"},
+                clear=False,
+            ),
+            patch.object(serve_utils, "_pid_alive", return_value=False),
+        ):
+            serve_utils.prune_ray_sessions()
+        assert not dead.exists()
+
+    def test_keeps_live_pid_session(self, tmp_path):
+        from modelship.deploy import serve_utils
+
+        root = self._temp_root(tmp_path)
+        live = self._make_session(root, 222)
+        with (
+            patch.dict(
+                os.environ,
+                {"RAY_TMPDIR": str(tmp_path), "MSHIP_PRUNE_RAY_SESSIONS": "true"},
+                clear=False,
+            ),
+            patch.object(serve_utils, "_pid_alive", return_value=True),
+        ):
+            serve_utils.prune_ray_sessions()
+        assert live.exists()
+
+    def test_skips_symlink_and_non_session_entries(self, tmp_path):
+        from modelship.deploy import serve_utils
+
+        root = self._temp_root(tmp_path)
+        dead = self._make_session(root, 333)
+        latest = root / "session_latest"
+        latest.symlink_to(dead)
+        marker = root / "ray_current_cluster"
+        marker.write_text("127.0.0.1:6379")
+        unrelated = root / "not_a_session"
+        unrelated.mkdir()
+        with (
+            patch.dict(
+                os.environ,
+                {"RAY_TMPDIR": str(tmp_path), "MSHIP_PRUNE_RAY_SESSIONS": "true"},
+                clear=False,
+            ),
+            patch.object(serve_utils, "_pid_alive", return_value=False),
+        ):
+            serve_utils.prune_ray_sessions()
+        assert not dead.exists()  # the real session dir is removed
+        assert latest.is_symlink()  # the symlink itself survives (now dangling)
+        assert marker.exists()  # non-session files untouched
+        assert unrelated.exists()  # non-matching dirs untouched
+
+    def test_disabled_via_env_keeps_everything(self, tmp_path):
+        from modelship.deploy import serve_utils
+
+        root = self._temp_root(tmp_path)
+        dead = self._make_session(root, 444)
+        with (
+            patch.dict(
+                os.environ,
+                {"RAY_TMPDIR": str(tmp_path), "MSHIP_PRUNE_RAY_SESSIONS": "false"},
+                clear=False,
+            ),
+            patch.object(serve_utils, "_pid_alive", return_value=False),
+        ):
+            serve_utils.prune_ray_sessions()
+        assert dead.exists()
+
+    def test_missing_temp_root_is_noop(self, tmp_path):
+        from modelship.deploy import serve_utils
+
+        # No <tmp>/ray dir exists — must not raise.
+        with patch.dict(
+            os.environ,
+            {"RAY_TMPDIR": str(tmp_path), "MSHIP_PRUNE_RAY_SESSIONS": "true"},
+            clear=False,
+        ):
+            serve_utils.prune_ray_sessions()
+
+    def test_pid_alive_true_for_current_process(self):
+        from modelship.deploy import serve_utils
+
+        assert serve_utils._pid_alive(os.getpid()) is True
+
+    def test_pid_alive_false_for_reaped_pid(self):
+        import subprocess
+
+        from modelship.deploy import serve_utils
+
+        proc = subprocess.Popen(["true"])
+        proc.wait()
+        assert serve_utils._pid_alive(proc.pid) is False


### PR DESCRIPTION
Two related cluster-lifecycle cleanups.

Prune stale Ray session dirs: when modelship starts its own Ray head, delete leftover `session_<ts>_<pid>` dirs under the Ray temp root (default /tmp/ray) from previous, no-longer-running heads. Ray never cleans these up, so they accumulate across container/process restarts and slowly fill the disk on self-hosted boxes. Pruning runs in connect_ray's own-cluster branch before ray.init creates this run's session; a session whose pid is still alive is always kept (a co-located additive deploy joins the running head via ray_current_cluster, so a live head can be present even here). Skips the existing-cluster branch entirely (KubeRay/an operator we don't own manages its own temp root). Best-effort: any failure is logged as a warning and the deploy proceeds. Toggle with --prune-ray-sessions true|false (env MSHIP_PRUNE_RAY_SESSIONS, default true).

Remove --redeploy: --reconcile already subsumes it (both replace the effective set; a reconcile with a fresh model set adds/removes/replaces gracefully). The flag's only extra behavior was a pre-deploy shutdown_ray() — destructive, and a no-op anyway since it ran before connect_ray — plus blanking existing_apps, which orphaned deployments on a shared cluster and could make a secondary deployer tear down a head it didn't own. With it gone, existing_apps is observed unconditionally and fresh_install reflects reality. The own-head exit teardown (process cleaning up the head it started) is unchanged.


