### PR TITLE
fix(utils): make download atomic to avoid corrupt cached files

### DIFF
--- a/modelship/utils/__init__.py
+++ b/modelship/utils/__init__.py
@@ -26,12 +26,26 @@ def base_request_id(raw_request: RawRequestProxy | None = None) -> str:
 
 
 def download(url: str, file_path: str, overwrite: bool = False):
-    if os.path.isfile(file_path) is False:
-        get_response = requests.get(url, stream=True)
-        with open(file_path, "wb") as f:
-            for chunk in get_response.iter_content(chunk_size=1024):
-                if chunk:
-                    f.write(chunk)
+    """Download ``url`` to ``file_path``, skipping if it already exists.
+
+    Streams to a per-call unique temp file and atomically renames it into place
+    only on success
+    """
+    if not overwrite and os.path.isfile(file_path):
+        return
+
+    tmp_path = f"{file_path}.{random_uuid()}.tmp"
+    try:
+        with requests.get(url, stream=True) as response:
+            response.raise_for_status()
+            with open(tmp_path, "wb") as f:
+                for chunk in response.iter_content(chunk_size=1024):
+                    if chunk:
+                        f.write(chunk)
+        os.replace(tmp_path, file_path)
+    finally:
+        if os.path.exists(tmp_path):
+            os.remove(tmp_path)
 
 
 def cache_dir() -> str:

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -1,8 +1,11 @@
 import os
 from unittest import mock
 
+import pytest
+import requests
+
 from modelship.deploy.actor_options import build_cache_env_vars
-from modelship.utils import cache_dir, plugins_dir
+from modelship.utils import cache_dir, download, plugins_dir
 
 
 def test_build_cache_env_vars_defaults():
@@ -32,3 +35,72 @@ def test_utils_cache_dir_default():
 def test_utils_plugins_dir():
     with mock.patch.dict(os.environ, {"MSHIP_CACHE_DIR": "/tmp/cache"}, clear=True), mock.patch("os.makedirs"):
         assert plugins_dir() == "/tmp/cache/plugins"
+
+
+class _FakeResponse:
+    def __init__(self, chunks, status_error=None):
+        self._chunks = chunks
+        self._status_error = status_error
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        return False
+
+    def raise_for_status(self):
+        if self._status_error is not None:
+            raise self._status_error
+
+    def iter_content(self, chunk_size=1024):
+        yield from self._chunks
+
+
+def test_download_writes_file(tmp_path):
+    dest = tmp_path / "model.onnx"
+    with mock.patch("modelship.utils.requests.get", return_value=_FakeResponse([b"abc", b"def"])):
+        download("http://x/model.onnx", str(dest))
+    assert dest.read_bytes() == b"abcdef"
+
+
+def test_download_skips_when_present(tmp_path):
+    dest = tmp_path / "model.onnx"
+    dest.write_bytes(b"existing")
+    with mock.patch("modelship.utils.requests.get") as get:
+        download("http://x/model.onnx", str(dest))
+    get.assert_not_called()
+    assert dest.read_bytes() == b"existing"
+
+
+def test_download_overwrite_refetches(tmp_path):
+    dest = tmp_path / "model.onnx"
+    dest.write_bytes(b"old")
+    with mock.patch("modelship.utils.requests.get", return_value=_FakeResponse([b"new"])):
+        download("http://x/model.onnx", str(dest), overwrite=True)
+    assert dest.read_bytes() == b"new"
+
+
+def test_interrupted_download_leaves_no_corrupt_file(tmp_path):
+    dest = tmp_path / "model.onnx"
+
+    def boom(chunk_size=1024):
+        yield b"partial"
+        raise ConnectionError("dropped mid-stream")
+
+    resp = _FakeResponse([])
+    resp.iter_content = boom
+    with mock.patch("modelship.utils.requests.get", return_value=resp), pytest.raises(ConnectionError):
+        download("http://x/model.onnx", str(dest))
+
+    # Neither the final path nor any temp file is left behind — next run re-downloads.
+    assert not dest.exists()
+    assert list(tmp_path.glob("*.tmp")) == []
+
+
+def test_download_does_not_save_error_body(tmp_path):
+    dest = tmp_path / "model.onnx"
+    err = requests.HTTPError("404")
+    resp = _FakeResponse([b"<html>404</html>"], status_error=err)
+    with mock.patch("modelship.utils.requests.get", return_value=resp), pytest.raises(requests.HTTPError):
+        download("http://x/model.onnx", str(dest))
+    assert not dest.exists()


### PR DESCRIPTION
download() only checked os.path.isfile and streamed straight into the final path, so a download interrupted mid-stream (e.g. the process killed by OOM or a container restart) left a truncated file that the existence check then treated as complete forever — onnxruntime later failed with InvalidProtobuf on the poisoned cache.

Stream to a sibling .tmp and os.replace into place only on success, honour the previously-ignored overwrite flag, and raise_for_status so an HTTP error body isn't saved as the file.


