### PR TITLE
ci: only run the chart job when the Helm chart changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,22 @@ on:
     branches: [main]
 
 jobs:
+  # Detect whether this PR touches the Helm chart, so the heavy `chart` job (which
+  # spins up a kind cluster) only runs when it's relevant.
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      chart: ${{ steps.filter.outputs.chart }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            chart:
+              - 'helm/**'
+              - '.github/workflows/ci.yml'
+
   lint:
     runs-on: ubuntu-latest
     steps:
@@ -46,6 +62,8 @@ jobs:
         run: uv run pytest tests/ -v -m "not integration"
 
   chart:
+    needs: changes
+    if: needs.changes.outputs.chart == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
The chart job spins up a kind cluster and dry-runs against KubeRay CRDs — heavy to run on every PR. Add a fast paths-filter 'changes' job and gate chart on it so it runs only when helm/** (or this workflow) changes. The job name is kept so any required-status-check config still passes (a skipped required job counts as success).


