### PR TITLE
fix(gateway): forward passthrough env vars and configure logging in g…

### DIFF
--- a/modelship/deploy/actor_options.py
+++ b/modelship/deploy/actor_options.py
@@ -28,6 +28,13 @@ _PASSTHROUGH_ENV_VARS = (
 )
 
 
+def build_passthrough_env_vars() -> dict[str, str]:
+    """Driver→replica env vars (logging, gateway name, metrics) read off the
+    driver's environment. Shared by model and gateway deployments so both
+    replicas inherit the same logging/metrics config."""
+    return {var: os.environ[var] for var in _PASSTHROUGH_ENV_VARS if os.environ.get(var) is not None}
+
+
 def build_cache_env_vars() -> dict[str, str]:
     """Resolve HF / vLLM / FlashInfer cache dirs, all rooted at MSHIP_CACHE_DIR."""
     base_cache = os.environ.get("MSHIP_CACHE_DIR", "/.cache")
@@ -101,10 +108,7 @@ def build_deployment_options(config: ModelshipModelConfig, plugin_wheel: Path | 
     forwarded as the per-replica Ray Serve concurrency cap.
     """
     env_vars = build_cache_env_vars()
-    for passthrough_var in _PASSTHROUGH_ENV_VARS:
-        val = os.environ.get(passthrough_var)
-        if val is not None:
-            env_vars[passthrough_var] = val
+    env_vars.update(build_passthrough_env_vars())
 
     runtime_env: dict = {"env_vars": env_vars}
     if plugin_wheel is not None:

--- a/modelship/deploy/serve_utils.py
+++ b/modelship/deploy/serve_utils.py
@@ -11,6 +11,7 @@ from ray._common.utils import get_ray_temp_dir
 from ray.serve.config import HTTPOptions, ProxyLocation
 from ray.serve.schema import LoggingConfig
 
+from modelship.deploy.actor_options import build_passthrough_env_vars
 from modelship.infer.infer_config import ModelshipConfig
 from modelship.logging import get_logger
 from modelship.openai.api import ModelshipAPI
@@ -203,14 +204,18 @@ def start_gateway(gateway_name: str, serve_logging_config: LoggingConfig) -> Non
     logger.info("Starting API gateway...")
     gateway_replicas = _positive_int_env("MSHIP_GATEWAY_REPLICAS", 1)
     gateway_max_ongoing = _positive_int_env("MSHIP_GATEWAY_MAX_ONGOING", 1024)
+    # Forward logging/metrics/gateway-name env vars so the gateway replica configures
+    # logging at the driver's level even when it lands on a node whose env carries
+    # different (or no) values. MSHIP_GATEWAY_NAME is pinned from the gateway_name arg
+    # (not just os.environ) so metrics stamping stays correct regardless of driver env.
+    env_vars = build_passthrough_env_vars()
+    env_vars["MSHIP_GATEWAY_NAME"] = gateway_name
     serve.run(
         ModelshipAPI.options(
             name=gateway_name,
             num_replicas=gateway_replicas,
             max_ongoing_requests=gateway_max_ongoing,
-            # Forward the gateway name so metrics.py stamps it on a replica that
-            # lands on a node whose env carries a different (or no) value.
-            ray_actor_options={"num_cpus": 0, "runtime_env": {"env_vars": {"MSHIP_GATEWAY_NAME": gateway_name}}},
+            ray_actor_options={"num_cpus": 0, "runtime_env": {"env_vars": env_vars}},
             logging_config=serve_logging_config,
         ).bind(gateway_name),
         name=gateway_name,

--- a/modelship/openai/api.py
+++ b/modelship/openai/api.py
@@ -19,7 +19,7 @@ from starlette.types import ASGIApp
 
 from modelship.infer import deploy_coordinator
 from modelship.infer.infer_config import RequestWatcher
-from modelship.logging import get_logger
+from modelship.logging import configure_logging, get_logger
 from modelship.metrics import (
     GATEWAY_RECONCILES_TOTAL,
     GATEWAY_ROUTING_GENERATION,
@@ -158,6 +158,9 @@ def _validation_error_from_cause(cause: BaseException) -> ErrorResponse:
 @serve.ingress(app)
 class ModelshipAPI:
     def __init__(self, gateway_name: str):
+        # Set up modelship-formatted application loggers at the driver's level;
+        # MSHIP_LOG_* are forwarded to this replica via runtime_env (see serve_utils).
+        configure_logging()
         # model_name -> (app_name -> handle). The inner dict is keyed by app_name
         # so a specific deployment can be dropped by name in remove_deployments.
         self.models: dict[str, dict[str, DeploymentHandle]] = {}

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -25,7 +25,15 @@ def api():
     """Create a ModelshipAPI instance with mocked Ray Serve context. The watch
     loop is marked started so `_ensure_watching` is a no-op — tests drive routing
     directly via `_apply` / `_apply_snapshot`; watch-specific tests reset it."""
-    with patch("modelship.openai.api.serve.get_replica_context") as mock_ctx:
+    with (
+        patch("modelship.openai.api.serve.get_replica_context") as mock_ctx,
+        # configure_logging() mutates the global "modelship" logger (propagate=False,
+        # guarded by a module-level flag) — stub it so instantiating the gateway here
+        # doesn't leak that state into other tests' caplog assertions. The cloudpickled
+        # class carries a reconstructed globals dict (see above), so patch through a
+        # method's __globals__ rather than the live module attribute.
+        patch.dict(_ModelshipAPI._handle_response.__globals__, {"configure_logging": lambda: None}),
+    ):
         mock_ctx.return_value.app_name = "test-gateway"
         inst = _ModelshipAPI("test-gateway")
         inst._watch_task = MagicMock()

--- a/tests/test_mship_deploy.py
+++ b/tests/test_mship_deploy.py
@@ -8,7 +8,9 @@ import mship_deploy
 import pytest
 
 from modelship.deploy.actor_options import (
+    build_cache_env_vars,
     build_deployment_options,
+    build_passthrough_env_vars,
     resolve_plugin_wheel,
     total_cpu_reservation,
     total_gpu_reservation,
@@ -201,6 +203,26 @@ class TestBuildDeploymentOptions:
         env_vars = build_deployment_options(config)["ray_actor_options"]["runtime_env"]["env_vars"]
         assert "MSHIP_METRICS" not in env_vars
 
+    def test_log_level_in_passthrough_and_deployment_env(self):
+        # The gateway-replica bug: MSHIP_LOG_LEVEL must flow through the shared
+        # passthrough helper and into a model deployment's runtime_env alongside
+        # the cache vars (which the gateway path omits but the model path keeps).
+        with patch.dict(os.environ, {"MSHIP_LOG_LEVEL": "TRACE"}, clear=True):
+            assert build_passthrough_env_vars()["MSHIP_LOG_LEVEL"] == "TRACE"
+
+            config = ModelshipModelConfig(
+                name="test-model",
+                model="some-model",
+                usecase=ModelUsecase.generate,
+                loader=ModelLoader.vllm,
+                num_gpus=1,
+            )
+            env_vars = build_deployment_options(config)["ray_actor_options"]["runtime_env"]["env_vars"]
+            assert env_vars["MSHIP_LOG_LEVEL"] == "TRACE"
+            # Cache vars still present (the model path keeps them).
+            for key in build_cache_env_vars():
+                assert key in env_vars
+
     def test_pipeline_parallel_uses_placement_group(self):
         # num_gpus=2 + pp=2 satisfies the world_size==num_gpus invariant; the
         # outer actor sits in bundle 0 with no GPU and vLLM workers claim the
@@ -382,6 +404,37 @@ class TestStartGateway:
         _, kwargs = options.call_args
         assert kwargs["num_replicas"] == 3
         assert kwargs["max_ongoing_requests"] == 256
+
+    def test_forwards_log_level_to_gateway_replica(self):
+        # The gateway replica must inherit MSHIP_LOG_LEVEL (and the gateway name)
+        # via runtime_env, else it can't configure logging at the driver's level.
+        options, _ = self._run(
+            {
+                "MSHIP_GATEWAY_REPLICAS": "1",
+                "MSHIP_GATEWAY_MAX_ONGOING": "1024",
+                "MSHIP_LOG_LEVEL": "TRACE",
+            }
+        )
+        _, kwargs = options.call_args
+        env_vars = kwargs["ray_actor_options"]["runtime_env"]["env_vars"]
+        assert env_vars["MSHIP_LOG_LEVEL"] == "TRACE"
+
+    def test_gateway_name_pinned_from_arg(self):
+        # MSHIP_GATEWAY_NAME is forwarded from the gateway_name arg even when absent
+        # from os.environ, so metrics stamping stays correct on isolated environments.
+        from modelship.deploy import serve_utils
+
+        bound = MagicMock()
+        options = MagicMock()
+        options.return_value.bind.return_value = bound
+        with (
+            patch.dict(os.environ, {}, clear=True),
+            patch.object(serve_utils.ModelshipAPI, "options", options),
+            patch.object(serve_utils.serve, "run"),
+        ):
+            serve_utils.start_gateway("edge", MagicMock())
+        _, kwargs = options.call_args
+        assert kwargs["ray_actor_options"]["runtime_env"]["env_vars"]["MSHIP_GATEWAY_NAME"] == "edge"
 
     @pytest.mark.parametrize(
         "name, value",

--- a/tests/test_responses_api.py
+++ b/tests/test_responses_api.py
@@ -23,7 +23,12 @@ _ModelshipAPI = ModelshipAPI.func_or_class
 
 @pytest.fixture
 def api():
-    with patch("modelship.openai.api.serve.get_replica_context") as mock_ctx:
+    with (
+        patch("modelship.openai.api.serve.get_replica_context") as mock_ctx,
+        # See test_api.py's api fixture: stub configure_logging (via the cloudpickled
+        # class's globals) so gateway instantiation doesn't leak global logging state.
+        patch.dict(_ModelshipAPI._handle_response.__globals__, {"configure_logging": lambda: None}),
+    ):
         mock_ctx.return_value.app_name = "test-gateway"
         inst = _ModelshipAPI("test-gateway")
         # Tests set api.models directly; mark the watch loop started so the routing


### PR DESCRIPTION
…ateway replica

The gateway replica's runtime_env only carried MSHIP_GATEWAY_NAME, so MSHIP_LOG_LEVEL/FORMAT/TARGET and MSHIP_METRICS never reached it, and ModelshipAPI.__init__ never called configure_logging() — so the gateway emitted no application-logger output regardless of the configured level.

- Extract build_passthrough_env_vars() in actor_options.py and reuse it in build_deployment_options.
- Forward it to the gateway's runtime_env in serve_utils.start_gateway (MSHIP_GATEWAY_NAME is in the set, so no regression).
- Call configure_logging() first in ModelshipAPI.__init__, matching ModelDeployment.


