### PR TITLE
fix(llama_cpp): backfill tool-message name for strict chat templates

### DIFF
--- a/modelship/openai/chat_utils.py
+++ b/modelship/openai/chat_utils.py
@@ -32,13 +32,19 @@ def _tool_name_by_call_id(messages: list[dict]) -> dict[str, str]:
     """
     mapping: dict[str, str] = {}
     for msg in messages:
-        if msg.get("role") != "assistant":
+        if not isinstance(msg, dict) or msg.get("role") != "assistant":
             continue
-        for call in msg.get("tool_calls") or []:
+        calls = msg.get("tool_calls")
+        if not isinstance(calls, list):
+            continue
+        for call in calls:
+            if not isinstance(call, dict):
+                continue
+            fn = call.get("function")
             call_id = call.get("id")
-            fn = (call.get("function") or {}).get("name")
-            if call_id and fn:
-                mapping[call_id] = fn
+            name = fn.get("name") if isinstance(fn, dict) else None
+            if call_id and name:
+                mapping[call_id] = name
     return mapping
 
 
@@ -79,7 +85,8 @@ def normalize_chat_messages(
     for idx, msg in enumerate(messages):
         out = dict(msg)
         if out.get("role") == "tool" and not out.get("name"):
-            name = tool_names.get(out.get("tool_call_id") or "")
+            call_id = out.get("tool_call_id")
+            name = tool_names.get(call_id) if isinstance(call_id, str) else None
             if name:
                 out["name"] = name
         content = msg.get("content")

--- a/modelship/openai/chat_utils.py
+++ b/modelship/openai/chat_utils.py
@@ -22,6 +22,26 @@ _IMAGE_TYPES = frozenset({"image_url", "input_image"})
 _AUDIO_TYPES = frozenset({"input_audio", "audio_url"})
 
 
+def _tool_name_by_call_id(messages: list[dict]) -> dict[str, str]:
+    """Map tool_call_id -> function name from assistant tool_calls.
+
+    Strict chat templates (FunctionGemma, Mistral) require ``role: tool``
+    messages to carry ``name``, but the OpenAI API makes it optional and clients
+    like Home Assistant omit it. Recover it from the assistant turn that issued
+    the matching call.
+    """
+    mapping: dict[str, str] = {}
+    for msg in messages:
+        if msg.get("role") != "assistant":
+            continue
+        for call in msg.get("tool_calls") or []:
+            call_id = call.get("id")
+            fn = (call.get("function") or {}).get("name")
+            if call_id and fn:
+                mapping[call_id] = fn
+    return mapping
+
+
 def normalize_chat_messages(
     messages: list[dict],
     *,
@@ -51,10 +71,17 @@ def normalize_chat_messages(
     - List content that ends up text-only is collapsed to a single string
       joined with ``"\\n"`` so loaders whose Jinja templates only accept string
       content keep working.
+    - ``role: tool`` messages missing ``name`` get it backfilled from the
+      matching assistant ``tool_calls`` entry — strict templates require it.
     """
+    tool_names = _tool_name_by_call_id(messages)
     normalized: list[dict] = []
     for idx, msg in enumerate(messages):
         out = dict(msg)
+        if out.get("role") == "tool" and not out.get("name"):
+            name = tool_names.get(out.get("tool_call_id") or "")
+            if name:
+                out["name"] = name
         content = msg.get("content")
         if not isinstance(content, list):
             normalized.append(out)

--- a/modelship/openai/chat_utils.py
+++ b/modelship/openai/chat_utils.py
@@ -43,7 +43,7 @@ def _tool_name_by_call_id(messages: list[dict]) -> dict[str, str]:
             fn = call.get("function")
             call_id = call.get("id")
             name = fn.get("name") if isinstance(fn, dict) else None
-            if call_id and name:
+            if isinstance(call_id, str) and isinstance(name, str):
                 mapping[call_id] = name
     return mapping
 

--- a/tests/test_chat_utils.py
+++ b/tests/test_chat_utils.py
@@ -53,6 +53,7 @@ def test_malformed_tool_calls_do_not_raise():
             "tool_calls": [
                 "not-a-dict",
                 {"id": "x", "function": "not-a-dict"},
+                {"id": ["unhashable"], "function": {"name": "Skipped"}},
                 {"id": "y", "function": {"name": "Real"}},
             ],
         },

--- a/tests/test_chat_utils.py
+++ b/tests/test_chat_utils.py
@@ -1,0 +1,61 @@
+"""Tests for modelship.openai.chat_utils.normalize_chat_messages."""
+
+from modelship.openai.chat_utils import normalize_chat_messages
+
+
+def test_tool_message_name_backfilled_from_assistant_call():
+    messages = [
+        {"role": "user", "content": "turn off the lights"},
+        {
+            "role": "assistant",
+            "tool_calls": [{"id": "abc", "type": "function", "function": {"name": "HassTurnOff"}}],
+        },
+        {"role": "tool", "tool_call_id": "abc", "content": '{"success": true}'},
+    ]
+
+    out = normalize_chat_messages(messages)
+
+    tool_msg = out[-1]
+    assert tool_msg["name"] == "HassTurnOff"
+    # caller's dicts are not mutated
+    assert "name" not in messages[-1]
+
+
+def test_existing_tool_message_name_preserved():
+    messages = [
+        {
+            "role": "assistant",
+            "tool_calls": [{"id": "abc", "function": {"name": "HassTurnOff"}}],
+        },
+        {"role": "tool", "tool_call_id": "abc", "name": "explicit", "content": "ok"},
+    ]
+
+    out = normalize_chat_messages(messages)
+
+    assert out[-1]["name"] == "explicit"
+
+
+def test_orphan_tool_message_left_unchanged():
+    messages = [
+        {"role": "tool", "tool_call_id": "missing", "content": "ok"},
+    ]
+
+    out = normalize_chat_messages(messages)
+
+    assert "name" not in out[-1]
+
+
+def test_text_part_collapse_still_works():
+    messages = [
+        {
+            "role": "user",
+            "content": [
+                {"type": "text", "text": "hello"},
+                {"type": "input_text", "text": "world"},
+            ],
+        },
+    ]
+
+    out = normalize_chat_messages(messages)
+
+    assert out[0]["content"] == "hello\nworld"

--- a/tests/test_chat_utils.py
+++ b/tests/test_chat_utils.py
@@ -45,6 +45,44 @@ def test_orphan_tool_message_left_unchanged():
     assert "name" not in out[-1]
 
 
+def test_malformed_tool_calls_do_not_raise():
+    messages = [
+        {
+            "role": "assistant",
+            # tool_calls / function in unexpected shapes must not blow up
+            "tool_calls": [
+                "not-a-dict",
+                {"id": "x", "function": "not-a-dict"},
+                {"id": "y", "function": {"name": "Real"}},
+            ],
+        },
+        {"role": "assistant", "tool_calls": "not-a-list"},
+        {"role": "tool", "tool_call_id": "y", "content": "ok"},
+        {"role": "tool", "tool_call_id": "x", "content": "ok"},
+    ]
+
+    out = normalize_chat_messages(messages)
+
+    assert out[-2]["name"] == "Real"
+    # the call whose function was malformed yields no name
+    assert "name" not in out[-1]
+
+
+def test_non_string_tool_call_id_does_not_raise():
+    messages = [
+        {
+            "role": "assistant",
+            "tool_calls": [{"id": "abc", "function": {"name": "HassTurnOff"}}],
+        },
+        # unhashable tool_call_id must not raise on the mapping lookup
+        {"role": "tool", "tool_call_id": ["abc"], "content": "ok"},
+    ]
+
+    out = normalize_chat_messages(messages)
+
+    assert "name" not in out[-1]
+
+
 def test_text_part_collapse_still_works():
     messages = [
         {


### PR DESCRIPTION
Strict GGUF chat templates (FunctionGemma, Mistral) raise "Invalid tool response: 'name' must be provided" when a role:tool message lacks a name. The OpenAI API makes name optional and clients like Home Assistant omit it, so multi-turn tool histories 500 before inference. Backfill name in normalize_chat_messages from the matching assistant tool_calls entry (keyed by tool_call_id).

