### PR TITLE
feat: add generic chat_template_kwargs for text loaders

### DIFF
--- a/docs/model-configuration.md
+++ b/docs/model-configuration.md
@@ -125,6 +125,7 @@ Selection is **all-or-nothing**: the highest tier whose *complete* stack fits is
 | `llama_cpp_config` | object | llama.cpp loader options (see below) |
 | `stable_diffusion_cpp_config` | object | stable-diffusion.cpp loader options (see below) |
 | `plugin_config` | object | Plugin-specific options passed through to the plugin |
+| `chat_template_kwargs` | object | Extra variables forwarded into the chat-template render on text loaders (`vllm`, `transformers`, `llama_cpp`) — e.g. `enable_thinking: false` for Qwen3. Only has an effect if the model's template branches on the key; ignored on paths that bypass the template (llama.cpp's native chat-handler fallback when `chat_format` is set or no template resolves). A per-request `chat_template_kwargs` overrides the model default on `vllm`. |
 
 ## Model source
 

--- a/modelship/infer/infer_config.py
+++ b/modelship/infer/infer_config.py
@@ -205,6 +205,11 @@ class ModelshipModelConfig(BaseModel):
     llama_cpp_config: LlamaCppConfig | None = None
     stable_diffusion_cpp_config: StableDiffusionCppConfig | None = None
     plugin_config: dict[str, Any] | None = None  # plugin devs parse this themselves
+    # Extra variables forwarded verbatim into the chat-template Jinja render on
+    # every text loader (e.g. `enable_thinking: false` for Qwen3). Only does
+    # something if the model's template branches on the key; ignored on paths
+    # that bypass the template (llama_cpp's native chat-handler fallback).
+    chat_template_kwargs: dict[str, Any] = Field(default_factory=dict)
 
     _resolved_path: str | None = PrivateAttr(default=None)
     _resolved_tool_call_parser: str | None = PrivateAttr(default=None)

--- a/modelship/infer/llama_cpp/llama_cpp_infer.py
+++ b/modelship/infer/llama_cpp/llama_cpp_infer.py
@@ -121,9 +121,16 @@ class LlamaCppInfer(BaseInfer):
             #   - no chat template was resolvable (we'd have nothing to
             #     render with).
             if self.config.chat_format is None and template is not None:
-                renderer = build_tool_call_renderer(self.llamacpp, template)
+                renderer = build_tool_call_renderer(self.llamacpp, template, self.model_config.chat_template_kwargs)
             else:
                 renderer = None
+                if self.model_config.chat_template_kwargs:
+                    logger.warning(
+                        "model '%s' sets chat_template_kwargs but `chat_format` is set or no chat "
+                        "template is available; falling back to llama-cpp's native chat handler and "
+                        "the kwargs will not be honored.",
+                        self.model_config.name,
+                    )
                 if parser_name is not None or reasoning_name is not None:
                     logger.warning(
                         "model '%s' has parsers resolved (tool=%s, reasoning=%s) but `chat_format` is set "

--- a/modelship/infer/llama_cpp/llama_cpp_infer.py
+++ b/modelship/infer/llama_cpp/llama_cpp_infer.py
@@ -126,7 +126,17 @@ class LlamaCppInfer(BaseInfer):
                 # a collision is a duplicate-keyword TypeError at render time.
                 template_kwargs = drop_reserved_kwargs(
                     self.model_config.chat_template_kwargs,
-                    {"conversations", "tools", "chat_template", "add_generation_prompt", "bos_token", "eos_token"},
+                    # `messages` is the conversation in the template context; the rest
+                    # are render_jinja_template's own positional args.
+                    {
+                        "messages",
+                        "conversations",
+                        "tools",
+                        "chat_template",
+                        "add_generation_prompt",
+                        "bos_token",
+                        "eos_token",
+                    },
                     logger=logger,
                     context=f"model '{self.model_config.name}'",
                 )

--- a/modelship/infer/llama_cpp/llama_cpp_infer.py
+++ b/modelship/infer/llama_cpp/llama_cpp_infer.py
@@ -19,6 +19,7 @@ from modelship.openai.protocol import (
     ErrorResponse,
 )
 from modelship.preflight import discover_hardware, merge_with_user_overrides, run_preflight
+from modelship.utils import drop_reserved_kwargs
 
 logger = get_logger("infer.llama_cpp")
 
@@ -121,7 +122,15 @@ class LlamaCppInfer(BaseInfer):
             #   - no chat template was resolvable (we'd have nothing to
             #     render with).
             if self.config.chat_format is None and template is not None:
-                renderer = build_tool_call_renderer(self.llamacpp, template, self.model_config.chat_template_kwargs)
+                # Strip keys render_jinja_template already receives positionally —
+                # a collision is a duplicate-keyword TypeError at render time.
+                template_kwargs = drop_reserved_kwargs(
+                    self.model_config.chat_template_kwargs,
+                    {"conversations", "tools", "chat_template", "add_generation_prompt", "bos_token", "eos_token"},
+                    logger=logger,
+                    context=f"model '{self.model_config.name}'",
+                )
+                renderer = build_tool_call_renderer(self.llamacpp, template, template_kwargs)
             else:
                 renderer = None
                 if self.model_config.chat_template_kwargs:

--- a/modelship/infer/llama_cpp/utils.py
+++ b/modelship/infer/llama_cpp/utils.py
@@ -2,8 +2,8 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
-from typing import TYPE_CHECKING
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any
 
 from modelship.logging import get_logger
 
@@ -34,6 +34,7 @@ class LlamaCppToolCallRenderer:
     bos_token: str
     eos_token: str
     _llama: Llama
+    template_kwargs: dict[str, Any] = field(default_factory=dict)
 
     def render(self, messages: list[dict], tools: list[dict] | None) -> str:
         from transformers.utils.chat_template_utils import render_jinja_template
@@ -51,6 +52,7 @@ class LlamaCppToolCallRenderer:
             add_generation_prompt=True,
             bos_token=self.bos_token,
             eos_token=self.eos_token,
+            **self.template_kwargs,
         )
         return rendered[0]
 
@@ -63,13 +65,16 @@ class LlamaCppToolCallRenderer:
             return 0
 
 
-def build_tool_call_renderer(llama: Llama, chat_template: str) -> LlamaCppToolCallRenderer:
+def build_tool_call_renderer(
+    llama: Llama, chat_template: str, template_kwargs: dict[str, Any] | None = None
+) -> LlamaCppToolCallRenderer:
     """Build a renderer from a loaded ``Llama`` and the pre-resolved template."""
     return LlamaCppToolCallRenderer(
         chat_template=chat_template,
         bos_token=_detokenize_special(llama, llama.token_bos()),
         eos_token=_detokenize_special(llama, llama.token_eos()),
         _llama=llama,
+        template_kwargs=template_kwargs or {},
     )
 
 

--- a/modelship/infer/transformers/openai/serving_chat.py
+++ b/modelship/infer/transformers/openai/serving_chat.py
@@ -37,6 +37,7 @@ class OpenAIServingChat(OpenAIServing):
         tool_call_parser: str | None = None,
         reasoning_parser: str | None = None,
         skip_special_tokens: bool | None = None,
+        chat_template_kwargs: dict[str, Any] | None = None,
     ):
         self.pipeline = pipeline
         self.model_name = model_name
@@ -44,6 +45,7 @@ class OpenAIServingChat(OpenAIServing):
         self.capabilities = capabilities
         self.tool_call_parser = tool_call_parser
         self.reasoning_parser = reasoning_parser
+        self.chat_template_kwargs = chat_template_kwargs or {}
         assert pipeline.tokenizer is not None, "text-generation pipeline must have a tokenizer"
         self.tokenizer: PreTrainedTokenizerBase = pipeline.tokenizer
         self._lock = asyncio.Lock()
@@ -203,18 +205,19 @@ class OpenAIServingChat(OpenAIServing):
 
     def _count_prompt_tokens(self, messages: list[dict], tools: list[dict[str, Any]] | None) -> int:
         # apply_chat_template returns a string by default (character count!) — force tokenize=True.
-        kwargs: dict[str, Any] = {"tokenize": True}
+        kwargs: dict[str, Any] = {"tokenize": True, **self.chat_template_kwargs}
         if tools:
             kwargs["tools"] = tools
         token_ids = self.tokenizer.apply_chat_template(messages, **kwargs)
         return len(token_ids)
 
-    def _render_prompt(self, messages: list[dict], tools: list[dict[str, Any]]) -> str:
+    def _render_prompt(self, messages: list[dict], tools: list[dict[str, Any]] | None = None) -> str:
         rendered = self.tokenizer.apply_chat_template(
             messages,
             tools=tools,  # type: ignore[arg-type]
             tokenize=False,
             add_generation_prompt=True,
+            **self.chat_template_kwargs,
         )
         assert isinstance(rendered, str), "apply_chat_template(tokenize=False) must return str"
         return rendered
@@ -228,10 +231,11 @@ class OpenAIServingChat(OpenAIServing):
         # marker (the pipeline defaults ``skip_special_tokens=True``).
         if not self._skip_special_tokens:
             kwargs["skip_special_tokens"] = False
-        if tools:
-            # The standard text-generation pipeline does not forward `tools` to
-            # `apply_chat_template`, so we render the prompt ourselves and feed
-            # it as a plain string.
+        # The pipeline applies the chat template internally and forwards neither
+        # `tools` nor our `chat_template_kwargs`. Render ourselves whenever either
+        # is in play so both reach `apply_chat_template`; otherwise let the
+        # pipeline handle the plain message list.
+        if tools or self.chat_template_kwargs:
             prompt = self._render_prompt(messages, tools)
             return self.pipeline(prompt, return_full_text=False, **kwargs)  # type: ignore[return-value]
         return self.pipeline(messages, return_full_text=False, **kwargs)  # type: ignore[return-value]

--- a/modelship/infer/transformers/openai/serving_chat.py
+++ b/modelship/infer/transformers/openai/serving_chat.py
@@ -291,7 +291,9 @@ class OpenAIServingChat(OpenAIServing):
         if max_tokens is not None:
             kwargs["max_new_tokens"] = max_tokens
 
-        if tools:
+        # Mirror _run: render ourselves whenever tools or chat_template_kwargs are
+        # set, since the pipeline forwards neither to apply_chat_template.
+        if tools or self.chat_template_kwargs:
             prompt: Any = self._render_prompt(messages, tools)
         else:
             prompt = messages

--- a/modelship/infer/transformers/openai/serving_chat.py
+++ b/modelship/infer/transformers/openai/serving_chat.py
@@ -20,7 +20,7 @@ from modelship.openai.protocol import (
     ErrorResponse,
     create_error_response,
 )
-from modelship.utils import base_request_id
+from modelship.utils import base_request_id, drop_reserved_kwargs
 
 logger = get_logger("infer.transformers.chat")
 
@@ -45,7 +45,14 @@ class OpenAIServingChat(OpenAIServing):
         self.capabilities = capabilities
         self.tool_call_parser = tool_call_parser
         self.reasoning_parser = reasoning_parser
-        self.chat_template_kwargs = chat_template_kwargs or {}
+        # Drop keys we pass to apply_chat_template ourselves — a collision would
+        # crash _render_prompt (duplicate kwarg) or flip tokenize in the counter.
+        self.chat_template_kwargs = drop_reserved_kwargs(
+            chat_template_kwargs or {},
+            {"tokenize", "tools", "add_generation_prompt"},
+            logger=logger,
+            context=f"model '{model_name}'",
+        )
         assert pipeline.tokenizer is not None, "text-generation pipeline must have a tokenizer"
         self.tokenizer: PreTrainedTokenizerBase = pipeline.tokenizer
         self._lock = asyncio.Lock()

--- a/modelship/infer/transformers/openai/serving_chat.py
+++ b/modelship/infer/transformers/openai/serving_chat.py
@@ -47,9 +47,12 @@ class OpenAIServingChat(OpenAIServing):
         self.reasoning_parser = reasoning_parser
         # Drop keys we pass to apply_chat_template ourselves — a collision would
         # crash _render_prompt (duplicate kwarg) or flip tokenize in the counter.
+        # `conversation` is apply_chat_template's first positional arg (passed
+        # positionally here); `messages` is the same data inside the template
+        # context. The rest are keyword args we set ourselves.
         self.chat_template_kwargs = drop_reserved_kwargs(
             chat_template_kwargs or {},
-            {"messages", "tokenize", "tools", "add_generation_prompt"},
+            {"conversation", "messages", "tokenize", "tools", "add_generation_prompt"},
             logger=logger,
             context=f"model '{model_name}'",
         )

--- a/modelship/infer/transformers/openai/serving_chat.py
+++ b/modelship/infer/transformers/openai/serving_chat.py
@@ -49,7 +49,7 @@ class OpenAIServingChat(OpenAIServing):
         # crash _render_prompt (duplicate kwarg) or flip tokenize in the counter.
         self.chat_template_kwargs = drop_reserved_kwargs(
             chat_template_kwargs or {},
-            {"tokenize", "tools", "add_generation_prompt"},
+            {"messages", "tokenize", "tools", "add_generation_prompt"},
             logger=logger,
             context=f"model '{model_name}'",
         )

--- a/modelship/infer/transformers/transformers_infer.py
+++ b/modelship/infer/transformers/transformers_infer.py
@@ -98,6 +98,7 @@ class TransformersInfer(BaseInfer):
                 tool_call_parser=tool_call_parser,
                 reasoning_parser=reasoning_parser,
                 skip_special_tokens=skip_special_tokens,
+                chat_template_kwargs=self.model_config.chat_template_kwargs,
             )
             self._serving.append(self.serving_chat)
 

--- a/modelship/infer/vllm/vllm_infer.py
+++ b/modelship/infer/vllm/vllm_infer.py
@@ -363,14 +363,15 @@ class VllmInfer(BaseInfer):
             )
         except UnsupportedContentError as exc:
             return create_error_response(exc)
-        vllm_request = VllmChatCompletionRequest(**request.model_dump())
+        request_data = request.model_dump()
         # vLLM renders the chat template internally; merge the model's default
         # kwargs under any per-request values (request wins).
         if self.model_config.chat_template_kwargs:
-            vllm_request.chat_template_kwargs = {
+            request_data["chat_template_kwargs"] = {
                 **self.model_config.chat_template_kwargs,
-                **(vllm_request.chat_template_kwargs or {}),
+                **(request_data.get("chat_template_kwargs") or {}),
             }
+        vllm_request = VllmChatCompletionRequest(**request_data)
         try:
             result = await self.serving_chat.create_chat_completion(vllm_request, cast("Request", raw_request))
         except VLLMValidationError as exc:

--- a/modelship/infer/vllm/vllm_infer.py
+++ b/modelship/infer/vllm/vllm_infer.py
@@ -364,6 +364,13 @@ class VllmInfer(BaseInfer):
         except UnsupportedContentError as exc:
             return create_error_response(exc)
         vllm_request = VllmChatCompletionRequest(**request.model_dump())
+        # vLLM renders the chat template internally; merge the model's default
+        # kwargs under any per-request values (request wins).
+        if self.model_config.chat_template_kwargs:
+            vllm_request.chat_template_kwargs = {
+                **self.model_config.chat_template_kwargs,
+                **(vllm_request.chat_template_kwargs or {}),
+            }
         try:
             result = await self.serving_chat.create_chat_completion(vllm_request, cast("Request", raw_request))
         except VLLMValidationError as exc:

--- a/modelship/utils/__init__.py
+++ b/modelship/utils/__init__.py
@@ -1,13 +1,33 @@
+import logging
 import os
 import random
 import string
 import uuid
+from collections.abc import Iterable
+from typing import Any
 
 import requests
 
 from modelship.infer.infer_config import RawRequestProxy
 
 _RAND_CHARS = string.ascii_lowercase + string.digits
+
+
+def drop_reserved_kwargs(
+    kwargs: dict[str, Any], reserved: Iterable[str], *, logger: logging.Logger, context: str
+) -> dict[str, Any]:
+    """Strip keys the caller passes to ``apply_chat_template`` itself.
+
+    User-supplied ``chat_template_kwargs`` are splatted alongside explicit
+    arguments (``tokenize``, ``tools``, ``add_generation_prompt``, …); a collision
+    is a duplicate-keyword ``TypeError`` (or silently flips an explicit value).
+    Drop the offenders with a warning so misconfiguration surfaces instead.
+    """
+    reserved = set(reserved)
+    dropped = sorted(k for k in kwargs if k in reserved)
+    if dropped:
+        logger.warning("%s: ignoring reserved chat_template_kwargs %s", context, dropped)
+    return {k: v for k, v in kwargs.items() if k not in reserved}
 
 
 def random_uuid() -> str:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -63,6 +63,19 @@ class TestModelshipModelConfig:
         assert config.loader == ModelLoader.vllm
         assert config.num_gpus == 0
         assert config.num_cpus == 0.1
+        assert config.chat_template_kwargs == {}
+
+    def test_chat_template_kwargs_round_trips(self):
+        config = ModelshipModelConfig.model_validate(
+            {
+                "name": "qwen3",
+                "model": "some-org/qwen3",
+                "usecase": ModelUsecase.generate,
+                "loader": ModelLoader.llama_cpp,
+                "chat_template_kwargs": {"enable_thinking": False},
+            }
+        )
+        assert config.chat_template_kwargs == {"enable_thinking": False}
 
     def test_custom_loader_requires_plugin(self):
         with pytest.raises(ValidationError, match="loader='custom' requires plugin"):

--- a/tests/test_llama_cpp_renderer.py
+++ b/tests/test_llama_cpp_renderer.py
@@ -46,3 +46,32 @@ def test_render_does_not_mutate_caller_messages():
     messages = [{"role": "assistant", "content": None}]
     _renderer().render(messages, tools=None)
     assert messages[0]["content"] is None
+
+
+# Template branching on a chat_template_kwargs variable, mirroring Qwen3's `enable_thinking`.
+_THINKING_TEMPLATE = (
+    "{%- if enable_thinking is defined and not enable_thinking %}NOTHINK\n{%- endif %}"
+    "{%- for message in messages %}{{ message['role'] }}: {{ message['content'] }}\n{%- endfor %}"
+)
+
+
+def _thinking_renderer(template_kwargs: dict) -> LlamaCppToolCallRenderer:
+    return LlamaCppToolCallRenderer(
+        chat_template=_THINKING_TEMPLATE,
+        bos_token="",
+        eos_token="",
+        _llama=None,  # type: ignore[arg-type]  # render() never touches _llama
+        template_kwargs=template_kwargs,
+    )
+
+
+def test_render_forwards_template_kwargs():
+    messages = [{"role": "user", "content": "hi"}]
+    out = _thinking_renderer({"enable_thinking": False}).render(messages, tools=None)
+    assert "NOTHINK" in out
+
+
+def test_render_omits_kwargs_takes_template_default():
+    messages = [{"role": "user", "content": "hi"}]
+    out = _thinking_renderer({}).render(messages, tools=None)
+    assert "NOTHINK" not in out

--- a/tests/test_transformers_chat_tools.py
+++ b/tests/test_transformers_chat_tools.py
@@ -180,6 +180,18 @@ async def test_no_chat_template_kwargs_leaves_no_tools_path_on_message_list():
 
 
 @pytest.mark.asyncio
+async def test_reserved_chat_template_kwargs_are_dropped():
+    # `tokenize` would corrupt the token counter and `tools` collide with our
+    # own argument — both must be stripped, leaving only the safe key.
+    serving, _ = _make_serving(
+        "hi back",
+        tool_call_parser=None,
+        chat_template_kwargs={"enable_thinking": False, "tokenize": False, "tools": []},
+    )
+    assert serving.chat_template_kwargs == {"enable_thinking": False}
+
+
+@pytest.mark.asyncio
 async def test_unknown_parser_at_init_raises():
     pipe = _FakePipeline("anything")
     with pytest.raises(ValueError, match="unknown tool_call_parser"):

--- a/tests/test_transformers_chat_tools.py
+++ b/tests/test_transformers_chat_tools.py
@@ -204,7 +204,7 @@ async def test_reserved_chat_template_kwargs_are_dropped():
     serving, _ = _make_serving(
         "hi back",
         tool_call_parser=None,
-        chat_template_kwargs={"enable_thinking": False, "tokenize": False, "tools": []},
+        chat_template_kwargs={"enable_thinking": False, "tokenize": False, "tools": [], "messages": []},
     )
     assert serving.chat_template_kwargs == {"enable_thinking": False}
 

--- a/tests/test_transformers_chat_tools.py
+++ b/tests/test_transformers_chat_tools.py
@@ -45,6 +45,11 @@ class _FakePipeline:
     def __call__(self, inputs: Any, **kwargs: Any) -> list[dict]:
         self.last_input = inputs
         self.last_kwargs = kwargs
+        # Streaming path runs us in a thread with a streamer; signal end so the
+        # consuming async iterator terminates instead of blocking.
+        streamer = kwargs.get("streamer")
+        if streamer is not None:
+            streamer.end()
         return [{"generated_text": self.generated_text}]
 
 
@@ -177,6 +182,19 @@ async def test_no_chat_template_kwargs_leaves_no_tools_path_on_message_list():
     req = ChatCompletionRequest(messages=[{"role": "user", "content": "hi"}], stream=False)
     await serving.create_chat_completion(req, _raw_request())
     assert isinstance(pipe.last_input, list)
+
+
+@pytest.mark.asyncio
+async def test_chat_template_kwargs_forwarded_on_streaming_no_tools_path():
+    # The streaming path must pre-render like the non-streaming one so the kwargs
+    # reach apply_chat_template instead of being dropped by the pipeline.
+    serving, pipe = _make_serving("hi back", tool_call_parser=None, chat_template_kwargs={"enable_thinking": False})
+    req = ChatCompletionRequest(messages=[{"role": "user", "content": "hi"}], stream=True)
+    gen = await serving.create_chat_completion(req, _raw_request())
+    async for _ in gen:  # type: ignore[union-attr]
+        pass
+    assert isinstance(pipe.last_input, str)
+    assert pipe.last_input.startswith("[NOTHINK]")
 
 
 @pytest.mark.asyncio

--- a/tests/test_transformers_chat_tools.py
+++ b/tests/test_transformers_chat_tools.py
@@ -23,8 +23,10 @@ class _FakeTokenizer:
 
     def apply_chat_template(self, messages: list[dict], **kwargs: Any) -> Any:
         prompt = "\n".join(f"{m['role']}: {m.get('content', '')}" for m in messages)
-        if "tools" in kwargs:
+        if kwargs.get("tools"):
             prompt = f"[TOOLS:{len(kwargs['tools'])}]\n" + prompt
+        if kwargs.get("enable_thinking") is False:  # template branching on a chat_template_kwarg
+            prompt = "[NOTHINK]\n" + prompt
         if kwargs.get("tokenize"):
             return [0] * len(prompt.split())
         return prompt
@@ -46,7 +48,11 @@ class _FakePipeline:
         return [{"generated_text": self.generated_text}]
 
 
-def _make_serving(generated: str, tool_call_parser: str | None = "hermes") -> tuple[OpenAIServingChat, _FakePipeline]:
+def _make_serving(
+    generated: str,
+    tool_call_parser: str | None = "hermes",
+    chat_template_kwargs: dict[str, Any] | None = None,
+) -> tuple[OpenAIServingChat, _FakePipeline]:
     pipe = _FakePipeline(generated)
     serving = OpenAIServingChat(
         pipeline=pipe,  # type: ignore[arg-type]
@@ -54,6 +60,7 @@ def _make_serving(generated: str, tool_call_parser: str | None = "hermes") -> tu
         config=TransformersConfig(),
         capabilities=TransformersCapabilities(supports_image=False, supports_audio=False),
         tool_call_parser=tool_call_parser,
+        chat_template_kwargs=chat_template_kwargs,
     )
     return serving, pipe
 
@@ -150,6 +157,26 @@ async def test_tool_call_with_trailing_text_preserves_content():
     msg = resp.choices[0].message
     assert msg.content == "Calling now.\n"
     assert len(msg.tool_calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_chat_template_kwargs_forwarded_on_no_tools_path():
+    # The no-tools path renders the prompt ourselves when kwargs are set, so the
+    # pipeline receives a string carrying the template's branched-on marker.
+    serving, pipe = _make_serving("hi back", tool_call_parser=None, chat_template_kwargs={"enable_thinking": False})
+    req = ChatCompletionRequest(messages=[{"role": "user", "content": "hi"}], stream=False)
+    await serving.create_chat_completion(req, _raw_request())
+    assert isinstance(pipe.last_input, str)
+    assert pipe.last_input.startswith("[NOTHINK]")
+
+
+@pytest.mark.asyncio
+async def test_no_chat_template_kwargs_leaves_no_tools_path_on_message_list():
+    # Without kwargs (or tools) the pipeline still gets the raw message list.
+    serving, pipe = _make_serving("hi back", tool_call_parser=None)
+    req = ChatCompletionRequest(messages=[{"role": "user", "content": "hi"}], stream=False)
+    await serving.create_chat_completion(req, _raw_request())
+    assert isinstance(pipe.last_input, list)
 
 
 @pytest.mark.asyncio

--- a/tests/test_transformers_chat_tools.py
+++ b/tests/test_transformers_chat_tools.py
@@ -204,7 +204,13 @@ async def test_reserved_chat_template_kwargs_are_dropped():
     serving, _ = _make_serving(
         "hi back",
         tool_call_parser=None,
-        chat_template_kwargs={"enable_thinking": False, "tokenize": False, "tools": [], "messages": []},
+        chat_template_kwargs={
+            "enable_thinking": False,
+            "tokenize": False,
+            "tools": [],
+            "messages": [],
+            "conversation": [],
+        },
     )
     assert serving.chat_template_kwargs == {"enable_thinking": False}
 

--- a/tests/test_vllm_vision.py
+++ b/tests/test_vllm_vision.py
@@ -82,6 +82,7 @@ def _make_infer(*, supports_image: bool) -> VllmInfer:
     chat-completion path reads are populated."""
     infer = VllmInfer.__new__(VllmInfer)
     infer._caps = VllmCapabilities(supports_image=supports_image)  # type: ignore[attr-defined]
+    infer.model_config = MagicMock(chat_template_kwargs={})
     infer.serving_chat = MagicMock()
     infer.serving_chat.create_chat_completion = AsyncMock(return_value=MagicMock())
     return infer

--- a/tests/test_vllm_vision.py
+++ b/tests/test_vllm_vision.py
@@ -128,3 +128,17 @@ async def test_text_only_request_reaches_serving_chat_on_vlm():
     await infer.create_chat_completion(request, raw_request=MagicMock())
 
     infer.serving_chat.create_chat_completion.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_model_chat_template_kwargs_merged_into_vllm_request():
+    """The model's chat_template_kwargs default reaches the vLLM request that
+    serving_chat renders from."""
+    infer = _make_infer(supports_image=False)
+    infer.model_config.chat_template_kwargs = {"enable_thinking": False}
+    request = ChatCompletionRequest(model="llm", messages=[{"role": "user", "content": "hi"}])
+
+    await infer.create_chat_completion(request, raw_request=MagicMock())
+
+    vllm_request = infer.serving_chat.create_chat_completion.await_args.args[0]
+    assert vllm_request.chat_template_kwargs == {"enable_thinking": False}


### PR DESCRIPTION
Add a loader-agnostic chat_template_kwargs field on ModelshipModelConfig, forwarded verbatim into the Jinja chat-template render on every text loader (vllm, transformers, llama_cpp). Motivating use: enable_thinking: false for Qwen3.

- vllm: merged under any per-request chat_template_kwargs (request wins).
- transformers: forwarded in both _render_prompt and _count_prompt_tokens; the no-tools path now renders the prompt itself so the kwargs aren't dropped by the pipeline's internal template application.
- llama_cpp: forwarded through the renderer; warns at load when set but the native chat-handler fallback would ignore them.

