### PR TITLE
fix: drop stale registry entries for resurrected deployments on recon…

### DIFF
--- a/modelship/deploy/strategy.py
+++ b/modelship/deploy/strategy.py
@@ -24,6 +24,11 @@ class DeployPlan:
 
     models_to_add: list[ModelshipModelConfig]
     apps_to_remove: list[str]
+    # Previously-effective deployments that are no longer desired AND aren't live
+    # (no Serve app to delete) — e.g. reloaded from the durable registry after a
+    # cluster restart. They have no app to delete, but their stale coordinator
+    # registry entry must still be dropped or the gateway routes to a ghost.
+    registry_only_drop: list[str]
 
 
 def compute_deploy_plan(
@@ -59,9 +64,21 @@ def compute_deploy_plan(
 
     desired_names = {c.deployment_name(gateway_name) for c in sorted_models}
 
-    apps_to_remove = sorted((prev_effective_names & existing_apps) - desired_names)
+    # All previously-effective deployments this run drops, split by liveness:
+    # the live ones get serve.delete + registry drop; the rest (tracked but not
+    # live — typically resurrected from the durable registry onto a fresh cluster)
+    # get a registry-only drop so the gateway stops routing to a non-existent app.
+    dropped = prev_effective_names - desired_names
+    apps_to_remove = sorted(dropped & existing_apps)
+    registry_only_drop = sorted(dropped - existing_apps)
     if apps_to_remove:
         logger.info("Reconcile: %d deployment(s) to remove: %s", len(apps_to_remove), apps_to_remove)
+    if registry_only_drop:
+        logger.info(
+            "Reconcile: %d stale registry entr(ies) to drop (no live app): %s",
+            len(registry_only_drop),
+            registry_only_drop,
+        )
 
     # Skip configs already live under their fingerprint — makes re-runs idempotent
     # and adopts a matching un-tracked deployment instead of redeploying it.
@@ -72,7 +89,11 @@ def compute_deploy_plan(
             len(models_to_add),
             [c.deployment_name(gateway_name) for c in models_to_add],
         )
-    return DeployPlan(models_to_add=models_to_add, apps_to_remove=apps_to_remove)
+    return DeployPlan(
+        models_to_add=models_to_add,
+        apps_to_remove=apps_to_remove,
+        registry_only_drop=registry_only_drop,
+    )
 
 
 @dataclass

--- a/mship_deploy.py
+++ b/mship_deploy.py
@@ -30,6 +30,7 @@ from modelship.logging import propagate_lib_log_env  # noqa: E402
 
 propagate_lib_log_env()
 
+import ray  # noqa: E402
 from ray.serve.schema import LoggingConfig  # noqa: E402
 
 from modelship.deploy.config import (  # noqa: E402
@@ -172,6 +173,19 @@ def main(argv: list[str] | None = None) -> None:
         resolve_all_reasoning_parsers(yml_conf)
 
         seed_expected_models(coordinator, gateway_name, yml_conf)
+
+        # Purge registry entries for previously-effective deployments that are no
+        # longer desired and have no live Serve app (e.g. resurrected from the
+        # durable registry onto a fresh cluster). remove_apps handles the live ones
+        # below; these have nothing to serve.delete, so drop them from the registry
+        # directly or the gateway keeps trying (and failing) to route to a ghost.
+        if plan.registry_only_drop:
+            try:
+                ray.get(
+                    [coordinator.unregister_deployment.remote(gateway_name, name) for name in plan.registry_only_drop]
+                )
+            except Exception:
+                logger.exception("Failed to drop stale registry entries: %s", plan.registry_only_drop)
 
         # stop_start: drop old deployments BEFORE deploying new ones, so the
         # freed resources are available for the deploy loop. Used when the

--- a/tests/test_effective_config.py
+++ b/tests/test_effective_config.py
@@ -186,6 +186,32 @@ class TestComputeDeployPlan:
         plan = compute_deploy_plan(desired, existing, {_dep("a")}, "g")
         assert plan.models_to_add == []
         assert plan.apps_to_remove == []
+        assert plan.registry_only_drop == []
+
+    def test_dropped_effective_model_with_no_live_app_is_registry_only(self):
+        # prev effective managed a,b but the cluster is fresh (only the new app a
+        # is live); reconcile to a. b has no Serve app to delete, but its stale
+        # registry entry must still be dropped so the gateway stops routing to it.
+        from modelship.deploy.strategy import compute_deploy_plan
+
+        desired = to_config([_model("a")])
+        existing = {_dep("a"), "g"}
+        prev = {_dep("a"), _dep("b")}
+        plan = compute_deploy_plan(desired, existing, prev, "g")
+        assert plan.apps_to_remove == []  # b isn't live -> nothing to serve.delete
+        assert plan.registry_only_drop == [_dep("b")]  # ...but purge its ghost entry
+
+    def test_dropped_effective_model_split_live_and_ghost(self):
+        # prev managed a,b,c; b is live (delete + registry), c is a ghost (registry
+        # only); reconcile keeps a.
+        from modelship.deploy.strategy import compute_deploy_plan
+
+        desired = to_config([_model("a")])
+        existing = {_dep("a"), _dep("b"), "g"}
+        prev = {_dep("a"), _dep("b"), _dep("c")}
+        plan = compute_deploy_plan(desired, existing, prev, "g")
+        assert plan.apps_to_remove == [_dep("b")]
+        assert plan.registry_only_drop == [_dep("c")]
 
 
 class TestCase2AdditiveAccumulation:


### PR DESCRIPTION
…cile

Previously-effective deployments resurrected from the durable registry onto a fresh cluster have no live Serve app. When reconcile dropped one, apps_to_remove (computed as prev_effective ∩ existing_apps − desired) skipped it, so its coordinator registry entry lingered and the gateway kept routing to a non-existent app.

Split dropped deployments by liveness: live ones get serve.delete + registry drop; the rest get a new registry_only_drop that unregisters them from the coordinator directly.


