### PR TITLE
feat: add llama.cpp native prompt cache support

### DIFF
--- a/docs/model-configuration.md
+++ b/docs/model-configuration.md
@@ -403,9 +403,10 @@ When set, llama.cpp's native prompt-state cache is attached to the model (via `L
 
 | Field | Type | Default | Description |
 |---|---|---|---|
-| `type` | string | `ram` | `ram` keeps states in process memory; `disk` persists them under `cache_dir` (survives replica restarts, at the cost of disk I/O) |
+| `type` | string | `ram` | `ram` keeps states in process memory; `disk` persists them (survives replica restarts, at the cost of disk I/O) |
 | `capacity` | string/int | `2GiB` | Eviction ceiling for cached states. Accepts a human-readable size — `2GiB`, `512MB`, `1.5gb` — or a bare byte count. Decimal units (`KB`/`MB`/`GB`/`TB`) are powers of 1000; binary units (`KiB`/`MiB`/`GiB`/`TiB`) powers of 1024 |
-| `cache_dir` | string | `.cache/llama_cache` | Directory for persisted states (only used when `type: disk`) |
+
+The `disk` cache is stored under `$MSHIP_CACHE_DIR/llama_cache/<model-name>` (default `/.cache`), isolated per model so different models never share — and cross-load — incompatible cached states.
 
 ```yaml
 models:

--- a/docs/model-configuration.md
+++ b/docs/model-configuration.md
@@ -406,7 +406,7 @@ When set, llama.cpp's native prompt-state cache is attached to the model (via `L
 | `type` | string | `ram` | `ram` keeps states in process memory; `disk` persists them (survives replica restarts, at the cost of disk I/O) |
 | `capacity` | string/int | `2GiB` | Eviction ceiling for cached states. Accepts a human-readable size — `2GiB`, `512MB`, `1.5gb` — or a bare byte count. Decimal units (`KB`/`MB`/`GB`/`TB`) are powers of 1000; binary units (`KiB`/`MiB`/`GiB`/`TiB`) powers of 1024 |
 
-The `disk` cache is stored under `$MSHIP_CACHE_DIR/llama_cache/<model-name>` (default `/.cache`), isolated per model so different models never share — and cross-load — incompatible cached states.
+The `disk` cache is stored under `$MSHIP_CACHE_DIR/llama_cache/<deployment-name>` (default `/.cache`), keyed by the deployment name (model name + config fingerprint + gateway). This isolates the store per model configuration version and per gateway, so a different model, a changed config, or another gateway never cross-loads — or concurrently corrupts — an incompatible cache. The fingerprint is stable across redeploys of the same config, so persistence holds.
 
 > **Note:** `type: disk` requires a single replica. llama.cpp's on-disk cache has no file locking, so replicas sharing the store would corrupt it — combining `disk` with `num_replicas > 1` (or an `autoscaling_config` whose `max_replicas > 1`) is a config error that stops the deploy. Use `type: ram` (per-process, always safe) for multi-replica models.
 

--- a/docs/model-configuration.md
+++ b/docs/model-configuration.md
@@ -393,8 +393,31 @@ The `llama_cpp` loader uses [llama-cpp-python](https://github.com/abetlen/llama-
 | `chat_format` | string | — | Chat template format (e.g. `llama-3`) |
 | `model_kwargs` | object | `{}` | Extra keyword arguments passed to the `Llama` constructor |
 | `constrain_tool_calls` | bool | `false` | Constrain tool-call decoding with a GBNF grammar built from the request's `tools` (see below) |
+| `cache` | object | — | llama.cpp's native prompt-state cache (see below). Omit to disable. |
 
 > **Note:** Setting `MSHIP_LOG_LEVEL` to `TRACE` will enable `verbose` mode in the underlying llama.cpp engine.
+
+#### Prompt cache (`cache`)
+
+When set, llama.cpp's native prompt-state cache is attached to the model (via `Llama.set_cache`). It stores the model's evaluated KV state keyed by prompt prefix, so a later request that shares a prefix skips re-evaluating it — useful for repeated system prompts or long shared contexts.
+
+| Field | Type | Default | Description |
+|---|---|---|---|
+| `type` | string | `ram` | `ram` keeps states in process memory; `disk` persists them under `cache_dir` (survives replica restarts, at the cost of disk I/O) |
+| `capacity` | string/int | `2GiB` | Eviction ceiling for cached states. Accepts a human-readable size — `2GiB`, `512MB`, `1.5gb` — or a bare byte count. Decimal units (`KB`/`MB`/`GB`/`TB`) are powers of 1000; binary units (`KiB`/`MiB`/`GiB`/`TiB`) powers of 1024 |
+| `cache_dir` | string | `.cache/llama_cache` | Directory for persisted states (only used when `type: disk`) |
+
+```yaml
+models:
+  - name: "qwen-gguf-hf"
+    model: "lmstudio-community/Qwen2.5-7B-Instruct-GGUF:*Q4_K_M.gguf"
+    usecase: "generate"
+    loader: "llama_cpp"
+    llama_cpp_config:
+      cache:
+        type: disk
+        capacity: 4GiB
+```
 
 #### Constrained tool calling (`constrain_tool_calls`)
 

--- a/docs/model-configuration.md
+++ b/docs/model-configuration.md
@@ -408,6 +408,8 @@ When set, llama.cpp's native prompt-state cache is attached to the model (via `L
 
 The `disk` cache is stored under `$MSHIP_CACHE_DIR/llama_cache/<model-name>` (default `/.cache`), isolated per model so different models never share — and cross-load — incompatible cached states.
 
+> **Note:** `type: disk` requires a single replica. llama.cpp's on-disk cache has no file locking, so replicas sharing the store would corrupt it — combining `disk` with `num_replicas > 1` (or an `autoscaling_config` whose `max_replicas > 1`) is a config error that stops the deploy. Use `type: ram` (per-process, always safe) for multi-replica models.
+
 ```yaml
 models:
   - name: "qwen-gguf-hf"

--- a/modelship/infer/infer_config.py
+++ b/modelship/infer/infer_config.py
@@ -319,7 +319,7 @@ class ModelshipModelConfig(BaseModel):
             return self
         if self.llama_cpp_config.cache.type != "disk":
             return self
-        multi_replica = ("num_replicas" in self.model_fields_set and self.num_replicas > 1) or (
+        multi_replica = self.num_replicas > 1 or (
             self.autoscaling_config is not None and self.autoscaling_config.max_replicas > 1
         )
         if multi_replica:

--- a/modelship/infer/infer_config.py
+++ b/modelship/infer/infer_config.py
@@ -311,6 +311,27 @@ class ModelshipModelConfig(BaseModel):
         return self
 
     @model_validator(mode="after")
+    def check_disk_cache_single_replica(self):
+        # llama.cpp's LlamaDiskCache reads/writes/prunes its SQLite store with no
+        # file locking. Replicas of the same model share one cache dir, so >1
+        # replica races into corruption. RAM cache is per-process and always safe.
+        if self.llama_cpp_config is None or self.llama_cpp_config.cache is None:
+            return self
+        if self.llama_cpp_config.cache.type != "disk":
+            return self
+        multi_replica = ("num_replicas" in self.model_fields_set and self.num_replicas > 1) or (
+            self.autoscaling_config is not None and self.autoscaling_config.max_replicas > 1
+        )
+        if multi_replica:
+            raise ValueError(
+                f"model '{self.name}': llama_cpp_config.cache.type='disk' cannot be combined with "
+                f"multiple replicas (num_replicas > 1 or autoscaling max_replicas > 1) — the disk "
+                f"cache is not process-safe and replicas would corrupt a shared store. Use "
+                f"cache.type='ram' (per-process, safe) or keep a single replica."
+            )
+        return self
+
+    @model_validator(mode="after")
     def check_custom_requires_plugin(self):
         if self.loader == ModelLoader.custom and self.plugin is None:
             raise ValueError("loader='custom' requires plugin to be set")

--- a/modelship/infer/infer_config.py
+++ b/modelship/infer/infer_config.py
@@ -315,6 +315,8 @@ class ModelshipModelConfig(BaseModel):
         # llama.cpp's LlamaDiskCache reads/writes/prunes its SQLite store with no
         # file locking. Replicas of the same model share one cache dir, so >1
         # replica races into corruption. RAM cache is per-process and always safe.
+        if self.loader != ModelLoader.llama_cpp:
+            return self
         if self.llama_cpp_config is None or self.llama_cpp_config.cache is None:
             return self
         if self.llama_cpp_config.cache.type != "disk":

--- a/modelship/infer/infer_config.py
+++ b/modelship/infer/infer_config.py
@@ -134,14 +134,12 @@ class LlamaCppCacheConfig(BaseModel):
     """llama.cpp's native prompt-state cache (via `Llama.set_cache`). Stores the
     evaluated KV state keyed by prompt prefix, so a later request sharing a prefix
     skips re-evaluating it. `ram` keeps states in process memory; `disk` persists
-    them under `cache_dir` (survives replica restarts at the cost of disk I/O)."""
+    them under MSHIP_CACHE_DIR (survives replica restarts at the cost of disk I/O)."""
 
     type: Literal["ram", "disk"] = "ram"
     # Eviction ceiling for cached states, as a human-readable size ('2GiB',
     # '512MB') or a bare byte count. Default 2 GiB matches llama-cpp-python.
     capacity: str | int = "2GiB"
-    # Only used when type == "disk".
-    cache_dir: str = ".cache/llama_cache"
 
     @field_validator("capacity")
     @classmethod

--- a/modelship/infer/infer_config.py
+++ b/modelship/infer/infer_config.py
@@ -1,5 +1,6 @@
 import asyncio
 import hashlib
+import re
 import time
 from collections.abc import Callable
 from enum import StrEnum
@@ -7,7 +8,7 @@ from typing import Any, Literal
 
 import ray
 from fastapi import Request
-from pydantic import BaseModel, Field, PrivateAttr, model_validator
+from pydantic import BaseModel, Field, PrivateAttr, field_validator, model_validator
 from ray.exceptions import RayActorError
 from starlette.datastructures import Headers, State
 
@@ -95,6 +96,64 @@ class DiffusersConfig(BaseModel):
     guidance_scale: float = 7.5
 
 
+_SIZE_UNITS = {
+    "b": 1,
+    "kb": 1000,
+    "mb": 1000**2,
+    "gb": 1000**3,
+    "tb": 1000**4,
+    "kib": 1 << 10,
+    "mib": 1 << 20,
+    "gib": 1 << 30,
+    "tib": 1 << 40,
+}
+_SIZE_RE = re.compile(r"^\s*([0-9]*\.?[0-9]+)\s*([a-z]*)\s*$", re.IGNORECASE)
+
+
+def parse_size(value: str | int) -> int:
+    """Parse a human-readable byte size ('2GiB', '512MB', '1.5gb') into bytes.
+    A bare number (or int) is taken as bytes. Decimal units (KB/MB/GB/TB) are
+    powers of 1000; binary units (KiB/MiB/GiB/TiB) powers of 1024."""
+    if isinstance(value, int):
+        size = value
+    else:
+        match = _SIZE_RE.match(value)
+        if not match:
+            raise ValueError(f"invalid size '{value}'; use e.g. '2GiB', '512MB', or a byte count")
+        number, unit = match.groups()
+        multiplier = _SIZE_UNITS.get((unit or "b").lower())
+        if multiplier is None:
+            raise ValueError(f"invalid size unit in '{value}'; expected one of B/KB/MB/GB/TB or KiB/MiB/GiB/TiB")
+        size = int(float(number) * multiplier)
+    if size <= 0:
+        raise ValueError(f"size must be positive, got {size} bytes")
+    return size
+
+
+class LlamaCppCacheConfig(BaseModel):
+    """llama.cpp's native prompt-state cache (via `Llama.set_cache`). Stores the
+    evaluated KV state keyed by prompt prefix, so a later request sharing a prefix
+    skips re-evaluating it. `ram` keeps states in process memory; `disk` persists
+    them under `cache_dir` (survives replica restarts at the cost of disk I/O)."""
+
+    type: Literal["ram", "disk"] = "ram"
+    # Eviction ceiling for cached states, as a human-readable size ('2GiB',
+    # '512MB') or a bare byte count. Default 2 GiB matches llama-cpp-python.
+    capacity: str | int = "2GiB"
+    # Only used when type == "disk".
+    cache_dir: str = ".cache/llama_cache"
+
+    @field_validator("capacity")
+    @classmethod
+    def _check_capacity(cls, value: str | int) -> str | int:
+        parse_size(value)  # raises on invalid size/unit or non-positive
+        return value
+
+    @property
+    def capacity_bytes(self) -> int:
+        return parse_size(self.capacity)
+
+
 class LlamaCppConfig(BaseModel):
     n_gpu_layers: int = -1
     n_ctx: int = 2048
@@ -106,6 +165,8 @@ class LlamaCppConfig(BaseModel):
     # tools (enforces the envelope, per-tool JSON schema, and a call-count cap).
     # Free-text answers stay reachable. Only the parser path honors this.
     constrain_tool_calls: bool = False
+    # llama.cpp's native prompt-state cache; None disables it.
+    cache: LlamaCppCacheConfig | None = None
 
 
 class StableDiffusionCppConfig(BaseModel):

--- a/modelship/infer/llama_cpp/llama_cpp_infer.py
+++ b/modelship/infer/llama_cpp/llama_cpp_infer.py
@@ -19,7 +19,7 @@ from modelship.openai.protocol import (
     ErrorResponse,
 )
 from modelship.preflight import discover_hardware, merge_with_user_overrides, run_preflight
-from modelship.utils import drop_reserved_kwargs
+from modelship.utils import cache_dir, drop_reserved_kwargs
 
 logger = get_logger("infer.llama_cpp")
 
@@ -181,19 +181,26 @@ class LlamaCppInfer(BaseInfer):
             return
         assert self.llamacpp is not None
         if cache_config.type == "disk":
-            cache = LlamaDiskCache(
-                cache_dir=cache_config.cache_dir,
-                capacity_bytes=cache_config.capacity_bytes,
+            # Root the cache under MSHIP_CACHE_DIR (not the Ray actor's ephemeral
+            # working dir) so it survives restarts/reschedules, and isolate it
+            # per-model: llama.cpp keys entries on prompt tokens alone, so sharing
+            # a dir across models would cross-load incompatible KV states.
+            cache_path = os.path.join(cache_dir(), "llama_cache", self.model_config.name)
+            cache = LlamaDiskCache(cache_dir=cache_path, capacity_bytes=cache_config.capacity_bytes)
+            logger.info(
+                "enabled llama.cpp disk prompt cache at %s (capacity=%d bytes) for model '%s'",
+                cache_path,
+                cache_config.capacity_bytes,
+                self.model_config.name,
             )
         else:
             cache = LlamaRAMCache(capacity_bytes=cache_config.capacity_bytes)
+            logger.info(
+                "enabled llama.cpp ram prompt cache (capacity=%d bytes) for model '%s'",
+                cache_config.capacity_bytes,
+                self.model_config.name,
+            )
         self.llamacpp.set_cache(cache)
-        logger.info(
-            "enabled llama.cpp %s prompt cache (capacity=%d bytes) for model '%s'",
-            cache_config.type,
-            cache_config.capacity_bytes,
-            self.model_config.name,
-        )
 
     async def warmup(self) -> None:
         if self.serving_chat is not None:

--- a/modelship/infer/llama_cpp/llama_cpp_infer.py
+++ b/modelship/infer/llama_cpp/llama_cpp_infer.py
@@ -182,10 +182,15 @@ class LlamaCppInfer(BaseInfer):
         assert self.llamacpp is not None
         if cache_config.type == "disk":
             # Root the cache under MSHIP_CACHE_DIR (not the Ray actor's ephemeral
-            # working dir) so it survives restarts/reschedules, and isolate it
-            # per-model: llama.cpp keys entries on prompt tokens alone, so sharing
-            # a dir across models would cross-load incompatible KV states.
-            cache_path = os.path.join(cache_dir(), "llama_cache", self.model_config.name)
+            # working dir) so it survives restarts/reschedules, and key it by the
+            # deployment name (name + config fingerprint + gateway). llama.cpp keys
+            # entries on prompt tokens alone, so this prevents a different model,
+            # changed config, or another gateway from cross-loading or concurrently
+            # corrupting an incompatible store. The fingerprint is stable across
+            # redeploys of the same config, so persistence holds.
+            gateway_name = os.environ.get("MSHIP_GATEWAY_NAME", "")
+            deployment_name = self.model_config.deployment_name(gateway_name)
+            cache_path = os.path.join(cache_dir(), "llama_cache", deployment_name)
             cache = LlamaDiskCache(cache_dir=cache_path, capacity_bytes=cache_config.capacity_bytes)
             logger.info(
                 "enabled llama.cpp disk prompt cache at %s (capacity=%d bytes) for model '%s'",

--- a/modelship/infer/llama_cpp/llama_cpp_infer.py
+++ b/modelship/infer/llama_cpp/llama_cpp_infer.py
@@ -2,7 +2,7 @@ import asyncio
 import os
 from collections.abc import AsyncGenerator
 
-from llama_cpp import Llama
+from llama_cpp import Llama, LlamaDiskCache, LlamaRAMCache
 
 from modelship.infer.base_infer import BaseInfer
 from modelship.infer.infer_config import LlamaCppConfig, ModelshipModelConfig, ModelUsecase, RawRequestProxy
@@ -104,6 +104,7 @@ class LlamaCppInfer(BaseInfer):
         self._set_max_context_length(self.config.n_ctx)
 
         assert self.llamacpp is not None
+        self._enable_cache()
         capabilities = LlamaCppCapabilities.detect(self.llamacpp)
         if capabilities.supports_image:
             logger.info("Multimodal (vision) capability detected for model: %s", self.model_config.name)
@@ -172,6 +173,27 @@ class LlamaCppInfer(BaseInfer):
             )
         elif self.model_config.usecase == ModelUsecase.embed:
             self.serving_embedding = OpenAIServingEmbedding(self.llamacpp, self.model_config.name)
+
+    def _enable_cache(self) -> None:
+        """Attach llama.cpp's native prompt-state cache if configured."""
+        cache_config = self.config.cache
+        if cache_config is None:
+            return
+        assert self.llamacpp is not None
+        if cache_config.type == "disk":
+            cache = LlamaDiskCache(
+                cache_dir=cache_config.cache_dir,
+                capacity_bytes=cache_config.capacity_bytes,
+            )
+        else:
+            cache = LlamaRAMCache(capacity_bytes=cache_config.capacity_bytes)
+        self.llamacpp.set_cache(cache)
+        logger.info(
+            "enabled llama.cpp %s prompt cache (capacity=%d bytes) for model '%s'",
+            cache_config.type,
+            cache_config.capacity_bytes,
+            self.model_config.name,
+        )
 
     async def warmup(self) -> None:
         if self.serving_chat is not None:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -90,6 +90,19 @@ class TestLlamaCppConfig:
         config = self._disk_cache_model(autoscaling_config=AutoscalingConfig(min_replicas=0, max_replicas=1))
         assert config.llama_cpp_config.cache.type == "disk"
 
+    def test_disk_cache_ignored_for_non_llama_cpp_loader(self):
+        # A leftover llama_cpp_config on a different loader is ignored, so the
+        # disk-cache multi-replica guard must not fire.
+        config = ModelshipModelConfig(
+            name="qwen-vllm",
+            model="Qwen/Qwen2.5-7B-Instruct",
+            usecase=ModelUsecase.generate,
+            loader=ModelLoader.vllm,
+            llama_cpp_config=LlamaCppConfig(cache={"type": "disk"}),
+            num_replicas=2,
+        )
+        assert config.num_replicas == 2
+
     def test_ram_cache_allows_multiple_replicas(self):
         config = ModelshipModelConfig(
             name="qwen-gguf",

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -64,6 +64,43 @@ class TestLlamaCppConfig:
         with pytest.raises(ValidationError):
             LlamaCppConfig(cache={"capacity": capacity})
 
+    def _disk_cache_model(self, **overrides):
+        return ModelshipModelConfig(
+            name="qwen-gguf",
+            model="repo/Qwen-GGUF:*Q4_K_M.gguf",
+            usecase=ModelUsecase.generate,
+            loader=ModelLoader.llama_cpp,
+            llama_cpp_config=LlamaCppConfig(cache={"type": "disk"}),
+            **overrides,
+        )
+
+    def test_disk_cache_single_replica_allowed(self):
+        config = self._disk_cache_model()
+        assert config.llama_cpp_config.cache.type == "disk"
+
+    def test_disk_cache_rejects_multiple_num_replicas(self):
+        with pytest.raises(ValidationError, match="not process-safe"):
+            self._disk_cache_model(num_replicas=2)
+
+    def test_disk_cache_rejects_autoscaling_above_one(self):
+        with pytest.raises(ValidationError, match="not process-safe"):
+            self._disk_cache_model(autoscaling_config=AutoscalingConfig(min_replicas=1, max_replicas=3))
+
+    def test_disk_cache_allows_scale_to_zero_single_max(self):
+        config = self._disk_cache_model(autoscaling_config=AutoscalingConfig(min_replicas=0, max_replicas=1))
+        assert config.llama_cpp_config.cache.type == "disk"
+
+    def test_ram_cache_allows_multiple_replicas(self):
+        config = ModelshipModelConfig(
+            name="qwen-gguf",
+            model="repo/Qwen-GGUF:*Q4_K_M.gguf",
+            usecase=ModelUsecase.generate,
+            loader=ModelLoader.llama_cpp,
+            llama_cpp_config=LlamaCppConfig(cache={"type": "ram"}),
+            num_replicas=4,
+        )
+        assert config.num_replicas == 4
+
     def test_custom_values(self):
         config = LlamaCppConfig(
             n_gpu_layers=33,

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -24,6 +24,47 @@ class TestLlamaCppConfig:
         assert config.chat_format is None
         assert config.model_kwargs == {}
         assert config.constrain_tool_calls is False
+        assert config.cache is None
+
+    def test_cache_defaults(self):
+        config = LlamaCppConfig(cache={})
+        assert config.cache is not None
+        assert config.cache.type == "ram"
+        assert config.cache.capacity == "2GiB"
+        assert config.cache.capacity_bytes == 2 << 30
+        assert config.cache.cache_dir == ".cache/llama_cache"
+
+    def test_cache_disk(self):
+        config = LlamaCppConfig(cache={"type": "disk", "capacity": "512MB", "cache_dir": "/var/cache/llm"})
+        assert config.cache is not None
+        assert config.cache.type == "disk"
+        assert config.cache.capacity_bytes == 512 * 1000**2
+        assert config.cache.cache_dir == "/var/cache/llm"
+
+    @pytest.mark.parametrize(
+        ("capacity", "expected_bytes"),
+        [
+            ("2GiB", 2 << 30),
+            ("512MB", 512 * 1000**2),
+            ("1.5gb", int(1.5 * 1000**3)),
+            ("100mib", 100 << 20),
+            ("4096", 4096),
+            (1024, 1024),
+        ],
+    )
+    def test_cache_capacity_parsing(self, capacity, expected_bytes):
+        config = LlamaCppConfig(cache={"capacity": capacity})
+        assert config.cache is not None
+        assert config.cache.capacity_bytes == expected_bytes
+
+    def test_cache_rejects_invalid_type(self):
+        with pytest.raises(ValidationError):
+            LlamaCppConfig(cache={"type": "gpu"})
+
+    @pytest.mark.parametrize("capacity", ["0", "-5MB", "2PB", "abc", ""])
+    def test_cache_rejects_invalid_capacity(self, capacity):
+        with pytest.raises(ValidationError):
+            LlamaCppConfig(cache={"capacity": capacity})
 
     def test_custom_values(self):
         config = LlamaCppConfig(

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -32,14 +32,12 @@ class TestLlamaCppConfig:
         assert config.cache.type == "ram"
         assert config.cache.capacity == "2GiB"
         assert config.cache.capacity_bytes == 2 << 30
-        assert config.cache.cache_dir == ".cache/llama_cache"
 
     def test_cache_disk(self):
-        config = LlamaCppConfig(cache={"type": "disk", "capacity": "512MB", "cache_dir": "/var/cache/llm"})
+        config = LlamaCppConfig(cache={"type": "disk", "capacity": "512MB"})
         assert config.cache is not None
         assert config.cache.type == "disk"
         assert config.cache.capacity_bytes == 512 * 1000**2
-        assert config.cache.cache_dir == "/var/cache/llm"
 
     @pytest.mark.parametrize(
         ("capacity", "expected_bytes"),


### PR DESCRIPTION
Expose llama.cpp's native prompt-state cache (Llama.set_cache) via a new `cache` block on llama_cpp_config. Supports `ram` (in-process) and `disk` (persisted) caches, with a human-readable `capacity` (e.g. "2GiB", "512MB"). When configured, the cache is attached after the Llama instance is built so requests sharing a prompt prefix skip re-evaluating it.


