### PR TITLE
feat: constrain FunctionGemma/Gemma4 tool calls with a GBNF grammar

### DIFF
--- a/config/examples/llama-cpp.yaml
+++ b/config/examples/llama-cpp.yaml
@@ -32,6 +32,11 @@ models:
     num_cpus: 2
     llama_cpp_config:
       constrain_tool_calls: true
+      # Force a tool call (drop the free-text escape). Helps tiny checkpoints
+      # that otherwise decline to act; gate non-actions upstream since it fires
+      # even on chit-chat. Implies constrain_tool_calls (the grammar is built
+      # regardless), so it works on its own too.
+      require_tool_call: true
 
   # Embeddings
   - name: "nomic-embed"

--- a/config/examples/llama-cpp.yaml
+++ b/config/examples/llama-cpp.yaml
@@ -19,6 +19,20 @@ models:
       n_ctx: 4096
       n_batch: 512
 
+  # Tool calling: FunctionGemma emits a custom `call:FUNC{...}` syntax. The
+  # tool-call parser is auto-detected from the model. `constrain_tool_calls`
+  # decodes under a GBNF grammar built from each request's tools — it caps the
+  # call count, pins the tool name, and constrains enum args, which stops the
+  # runaway repetition small (270M) checkpoints fall into. Free-text answers
+  # stay reachable; not compatible with reasoning-enabled deployments.
+  - name: "function-gemma"
+    model: "/.cache/huggingface/functiongemma-270m-it.Q8_0.gguf"
+    usecase: "generate"
+    loader: "llama_cpp"
+    num_cpus: 2
+    llama_cpp_config:
+      constrain_tool_calls: true
+
   # Embeddings
   - name: "nomic-embed"
     model: "nomic-ai/nomic-embed-text-v1.5-GGUF:nomic-embed-text-v1.5.Q4_K_M.gguf"

--- a/modelship/infer/infer_config.py
+++ b/modelship/infer/infer_config.py
@@ -163,6 +163,13 @@ class LlamaCppConfig(BaseModel):
     # tools (enforces the envelope, per-tool JSON schema, and a call-count cap).
     # Free-text answers stay reachable. Only the parser path honors this.
     constrain_tool_calls: bool = False
+    # When True, the tool-call grammar's root REQUIRES a tool call — the free-text
+    # escape is dropped, so the model cannot end its turn without calling a tool.
+    # Tiny models (FunctionGemma 270M) often decline to act; forcing a call turns
+    # those into an attempt. Trade-off: it forces a tool even on chit-chat, so
+    # gate non-actions upstream. Forcing a call is done *via* the grammar, so this
+    # implies constrain_tool_calls (the grammar is built even if that is off).
+    require_tool_call: bool = False
     # llama.cpp's native prompt-state cache; None disables it.
     cache: LlamaCppCacheConfig | None = None
 

--- a/modelship/infer/llama_cpp/llama_cpp_infer.py
+++ b/modelship/infer/llama_cpp/llama_cpp_infer.py
@@ -170,6 +170,7 @@ class LlamaCppInfer(BaseInfer):
                 reasoning_parser=reasoning_name,
                 renderer=renderer,
                 constrain_tool_calls=self.config.constrain_tool_calls,
+                require_tool_call=self.config.require_tool_call,
             )
         elif self.model_config.usecase == ModelUsecase.embed:
             self.serving_embedding = OpenAIServingEmbedding(self.llamacpp, self.model_config.name)

--- a/modelship/infer/llama_cpp/openai/serving_chat.py
+++ b/modelship/infer/llama_cpp/openai/serving_chat.py
@@ -41,6 +41,7 @@ class OpenAIServingChat(OpenAIServing):
         reasoning_parser: str | None = None,
         renderer: LlamaCppToolCallRenderer | None = None,
         constrain_tool_calls: bool = False,
+        require_tool_call: bool = False,
     ):
         self._llama = llama
         self.model_name = model_name
@@ -52,6 +53,7 @@ class OpenAIServingChat(OpenAIServing):
         self.reasoning_parser = reasoning_parser
         self._renderer = renderer
         self._constrain_tool_calls = constrain_tool_calls
+        self._require_tool_call = require_tool_call
         self._logged_reasoning_unconstrained = False
         # The renderer's presence is the sole switch between paths:
         #  - renderer set → drive `create_completion` raw, route every
@@ -232,7 +234,9 @@ class OpenAIServingChat(OpenAIServing):
             max_tokens = request.max_completion_tokens
 
         completion_kwargs = self._build_completion_kwargs(request, prompt)
-        if self._constrain_tool_calls and tool_parser_name and tools:
+        # `require_tool_call` forces a tool call *via* the grammar, so it implies
+        # building one even when `constrain_tool_calls` is off.
+        if (self._constrain_tool_calls or self._require_tool_call) and tool_parser_name and tools:
             if self.reasoning_parser:
                 # Grammar's `content` excludes `<` (the start marker's first char),
                 # which also opens `<think>` — constraining would block the reasoning
@@ -245,7 +249,9 @@ class OpenAIServingChat(OpenAIServing):
                         self.model_name,
                     )
             else:
-                grammar = build_tool_call_grammar(get_parser(tool_parser_name), tools)
+                grammar = build_tool_call_grammar(
+                    get_parser(tool_parser_name), tools, require_tool_call=self._require_tool_call
+                )
                 if grammar is not None:
                     if completion_kwargs.get("grammar") is not None:
                         logger.warning(

--- a/modelship/infer/llama_cpp/tool_grammar.py
+++ b/modelship/infer/llama_cpp/tool_grammar.py
@@ -218,7 +218,7 @@ def _build_gemma_tool_call_gbnf(
                 return "( " + " | ".join(emit_value(s, depth + 1) for s in subs) + " )"
 
         t = schema.get("type")
-        if isinstance(t, list):
+        if isinstance(t, list) and t:
             return "( " + " | ".join(emit_value({**schema, "type": tt}, depth + 1) for tt in t) + " )"
         if t == "string":
             return str_val

--- a/modelship/infer/llama_cpp/tool_grammar.py
+++ b/modelship/infer/llama_cpp/tool_grammar.py
@@ -56,13 +56,6 @@ _GEMMA_FAMILY_PARSERS = frozenset({"function_gemma", "gemma4"})
 # single-command correctness and hardest-stop the 270M runaway; raise to relax.
 _MAX_TOOL_CALLS = 1
 
-# When True the Gemma grammar's root REQUIRES a tool call — the free-text
-# ``content`` escape is dropped, so the model cannot end its turn empty. Tiny
-# models (FunctionGemma 270M) frequently decline to act (finish_reason=stop,
-# no tool); forcing a call converts those into an attempt. Trade-off: it forces
-# a tool even on chit-chat ("thank you"), so gate non-actions upstream (hassil).
-_REQUIRE_TOOL_CALL = True
-
 # Recursion guard for nested object/array schemas — beyond this, value rules
 # collapse to the generic recursive value rule (``gv``), which accepts any
 # string / number / bool / null / array / object the DSL can express.
@@ -82,18 +75,21 @@ def _gbnf_literal(s: str) -> str:
     return json.dumps(s, ensure_ascii=False)
 
 
-def build_tool_call_gbnf(parser: ToolCallParser, tools: list[dict[str, Any]]) -> str | None:
+def build_tool_call_gbnf(
+    parser: ToolCallParser, tools: list[dict[str, Any]], *, require_tool_call: bool = False
+) -> str | None:
     """Assemble the GBNF text for the tool-call grammar, or ``None`` if unsupported.
 
     Split from compilation so the emitted grammar can be inspected/tested as
     text. Returns ``None`` (logged once per parser) for parsers without an
-    emitter and on conversion failure.
+    emitter and on conversion failure. When ``require_tool_call`` is set the
+    root drops its free-text escape, so the model must emit a tool call.
     """
     if not tools:
         return None
 
     if parser.name in _GEMMA_FAMILY_PARSERS:
-        return _build_gemma_tool_call_gbnf(parser, tools)
+        return _build_gemma_tool_call_gbnf(parser, tools, require_tool_call=require_tool_call)
 
     if parser.name not in _JSON_FAMILY_PARSERS:
         if parser.name not in _logged_unconstrained:
@@ -151,17 +147,23 @@ def build_tool_call_gbnf(parser: ToolCallParser, tools: list[dict[str, Any]]) ->
     # Allow optional leading/trailing conversational text and optional whitespace
     # around the JSON envelope, so a chatty prefix can't strand the model in the
     # content branch. `tool-calls` caps at two calls so decoding can't loop forever.
+    # `require_tool_call` drops the free-text branch so a tool call is mandatory.
+    if require_tool_call:
+        root_rule = "root ::= tool-calls\n"
+        content_rule = ""
+    else:
+        root_rule = "root ::= ( content )? tool-calls ( content )? | content\n"
+        content_rule = f"content ::= [^{escaped_char}]+\n"
     prefix = (
-        "root ::= ( content )? tool-calls ( content )? | content\n"
-        "tool-calls ::= tool-call ( tc-ws tool-call )?\n"
-        f"tool-call ::= {start} tc-ws tc-json tc-ws {end}\n"
-        f"content ::= [^{escaped_char}]+\n"
-        "tc-ws ::= [ \\t\\n\\r]*\n"
+        root_rule + "tool-calls ::= tool-call ( tc-ws tool-call )?\n"
+        f"tool-call ::= {start} tc-ws tc-json tc-ws {end}\n" + content_rule + "tc-ws ::= [ \\t\\n\\r]*\n"
     )
     return prefix + inner
 
 
-def _build_gemma_tool_call_gbnf(parser: ToolCallParser, tools: list[dict[str, Any]]) -> str | None:
+def _build_gemma_tool_call_gbnf(
+    parser: ToolCallParser, tools: list[dict[str, Any]], *, require_tool_call: bool = False
+) -> str | None:
     """Hand-build the GBNF for a Gemma-family ``call:FUNC{...}`` DSL body.
 
     ``json_schema_to_gbnf`` only speaks JSON, so the per-tool body is emitted
@@ -277,7 +279,7 @@ def _build_gemma_tool_call_gbnf(parser: ToolCallParser, tools: list[dict[str, An
     start_char = parser.start_marker[0] if parser.start_marker else "<"
     content_excl = f"\\{start_char}" if start_char in "]-^\\" else start_char
 
-    if _REQUIRE_TOOL_CALL:
+    if require_tool_call:
         root_rule = "root ::= tool-calls"
         content_rules: list[str] = []
     else:
@@ -309,15 +311,18 @@ def _build_gemma_tool_call_gbnf(parser: ToolCallParser, tools: list[dict[str, An
     return "\n".join(envelope + tool_rules + generic_rules) + "\n"
 
 
-def build_tool_call_grammar(parser: ToolCallParser, tools: list[dict[str, Any]]) -> LlamaGrammar | None:
+def build_tool_call_grammar(
+    parser: ToolCallParser, tools: list[dict[str, Any]], *, require_tool_call: bool = False
+) -> LlamaGrammar | None:
     """Compile a tool-call-constraining grammar, or ``None`` if unsupported.
 
     ``parser`` supplies the envelope markers; ``tools`` is the OpenAI-shaped list
-    already resolved for the request. Returns ``None`` for parsers without an
+    already resolved for the request. ``require_tool_call`` forces a tool call by
+    dropping the free-text root branch. Returns ``None`` for parsers without an
     emitter and on any conversion/compile failure, so the caller falls back to
     unconstrained decoding rather than erroring.
     """
-    text = build_tool_call_gbnf(parser, tools)
+    text = build_tool_call_gbnf(parser, tools, require_tool_call=require_tool_call)
     if text is None:
         return None
     try:

--- a/modelship/infer/llama_cpp/tool_grammar.py
+++ b/modelship/infer/llama_cpp/tool_grammar.py
@@ -10,8 +10,19 @@ chatty preamble before a tool call are both reachable.
 
 JSON-family parsers (Hermes) wrap each call's ``{"name", "arguments"}`` JSON in
 literal marker tags, so the body is built by reusing llama.cpp's own
-``json_schema_to_gbnf`` and only the envelope is hand-written. Custom-syntax
-families return ``None`` (no emitter yet).
+``json_schema_to_gbnf`` and only the envelope is hand-written.
+
+Gemma-family parsers (FunctionGemma / Gemma 4) use a non-JSON DSL —
+``call:FUNC{key:<delim>val<delim>,n:42}`` — so ``json_schema_to_gbnf`` can't
+express it; that body is hand-built by :func:`_build_gemma_tool_call_gbnf`,
+which maps each tool's parameter schema to value rules (enum alternations,
+delimited strings, bare numbers/bools, arrays, nested objects). The envelope
+caps the number of calls (``_MAX_TOOL_CALLS``) to stop the runaway repetition
+small FunctionGemma checkpoints fall into. Other families return ``None``.
+
+The Gemma grammar is loose by design: it pins the call count, tool name, and
+enum values, but does not enforce ``required`` args, key uniqueness, or key
+ordering.
 """
 
 from __future__ import annotations
@@ -37,8 +48,37 @@ logger = get_logger("infer.llama_cpp.tool_grammar")
 # different envelope shape, not wired here.
 _JSON_FAMILY_PARSERS = frozenset({"hermes"})
 
+# Parsers whose call body is a custom ``call:FUNC{...}`` DSL — handled by the
+# hand-built emitter, not ``json_schema_to_gbnf``.
+_GEMMA_FAMILY_PARSERS = frozenset({"function_gemma", "gemma4"})
+
+# Max enveloped calls the grammar allows per response. Held at 1 to isolate
+# single-command correctness and hardest-stop the 270M runaway; raise to relax.
+_MAX_TOOL_CALLS = 1
+
+# When True the Gemma grammar's root REQUIRES a tool call — the free-text
+# ``content`` escape is dropped, so the model cannot end its turn empty. Tiny
+# models (FunctionGemma 270M) frequently decline to act (finish_reason=stop,
+# no tool); forcing a call converts those into an attempt. Trade-off: it forces
+# a tool even on chit-chat ("thank you"), so gate non-actions upstream (hassil).
+_REQUIRE_TOOL_CALL = True
+
+# Recursion guard for nested object/array schemas — beyond this, value rules
+# collapse to the permissive delimited-string fallback.
+_MAX_SCHEMA_DEPTH = 5
+
 # Parser names already logged as unconstrained, to avoid repeating per request.
 _logged_unconstrained: set[str] = set()
+
+
+def _gbnf_literal(s: str) -> str:
+    """Render ``s`` as a GBNF double-quoted string literal.
+
+    GBNF accepts the same ``\\"`` / ``\\\\`` escapes JSON uses, so ``json.dumps``
+    produces a valid literal; ``ensure_ascii=False`` keeps UTF-8 enum values
+    intact rather than emitting ``\\uXXXX`` escapes.
+    """
+    return json.dumps(s, ensure_ascii=False)
 
 
 def build_tool_call_gbnf(parser: ToolCallParser, tools: list[dict[str, Any]]) -> str | None:
@@ -50,6 +90,9 @@ def build_tool_call_gbnf(parser: ToolCallParser, tools: list[dict[str, Any]]) ->
     """
     if not tools:
         return None
+
+    if parser.name in _GEMMA_FAMILY_PARSERS:
+        return _build_gemma_tool_call_gbnf(parser, tools)
 
     if parser.name not in _JSON_FAMILY_PARSERS:
         if parser.name not in _logged_unconstrained:
@@ -115,6 +158,125 @@ def build_tool_call_gbnf(parser: ToolCallParser, tools: list[dict[str, Any]]) ->
         "tc-ws ::= [ \\t\\n\\r]*\n"
     )
     return prefix + inner
+
+
+def _build_gemma_tool_call_gbnf(parser: ToolCallParser, tools: list[dict[str, Any]]) -> str | None:
+    """Hand-build the GBNF for a Gemma-family ``call:FUNC{...}`` DSL body.
+
+    ``json_schema_to_gbnf`` only speaks JSON, so the per-tool body is emitted
+    directly: a name literal, then a brace-wrapped alternation of ``key:value``
+    pairs whose value rules come from :func:`_emit_value`. Returns ``None`` when
+    no tool carries a usable function name.
+    """
+    delim = parser.string_delim or ""
+    d_lit = _gbnf_literal(delim)
+    # String values exclude the marker/delim lead char ('<' for both families)
+    # so a value can't swallow the closing delim or end marker mid-generation.
+    excl = (delim or parser.start_marker or "<")[0]
+    excl_cls = f"\\{excl}" if excl in "]-^\\" else excl
+    str_val = f"( {d_lit} [^{excl_cls}]* {d_lit} )"
+
+    def emit_enum_value(v: object) -> str:
+        if isinstance(v, bool):
+            return '"true"' if v else '"false"'
+        if isinstance(v, int | float):
+            return _gbnf_literal(str(v))  # bare, unquoted in the wire format
+        if v is None:
+            return '"null"'
+        return f"{d_lit} {_gbnf_literal(str(v))} {d_lit}"
+
+    def emit_value(schema: object, depth: int = 0) -> str:
+        """Return a parenthesized GBNF expression matching one value of ``schema``.
+
+        Always parenthesized so it can sit on either side of a ``|`` without
+        leaking precedence into the enclosing alternation.
+        """
+        if not isinstance(schema, dict) or depth > _MAX_SCHEMA_DEPTH:
+            return str_val
+
+        enum = schema.get("enum")
+        if enum:
+            return "( " + " | ".join(emit_enum_value(v) for v in enum) + " )"
+
+        for combinator in ("anyOf", "oneOf"):
+            subs = schema.get(combinator)
+            if isinstance(subs, list) and subs:
+                return "( " + " | ".join(emit_value(s, depth + 1) for s in subs) + " )"
+
+        t = schema.get("type")
+        if isinstance(t, list):
+            return "( " + " | ".join(emit_value({**schema, "type": tt}, depth + 1) for tt in t) + " )"
+        if t == "string":
+            return str_val
+        if t == "integer":
+            return '( "-"? [0-9]+ )'
+        if t == "number":
+            return '( "-"? [0-9]+ ( "." [0-9]+ )? )'
+        if t == "boolean":
+            return '( "true" | "false" )'
+        if t == "null":
+            return '( "null" )'
+        if t == "array":
+            items = schema.get("items")
+            item = emit_value(items, depth + 1) if isinstance(items, dict) else str_val
+            return f'( "[" ( {item} ( "," {item} )* )? "]" )'
+        if t == "object":
+            props = schema.get("properties")
+            if isinstance(props, dict) and props:
+                pair = (
+                    "( "
+                    + " | ".join(f"{_gbnf_literal(f'{k}:')} {emit_value(v, depth + 1)}" for k, v in props.items())
+                    + " )"
+                )
+                return f'( "{{" ( {pair} ( "," {pair} )* )? "}}" )'
+        return str_val
+
+    tool_rules: list[str] = []
+    n_tools = 0
+    for t in tools:
+        func = t.get("function")
+        if not func or not func.get("name"):
+            continue
+        idx = n_tools
+        n_tools += 1
+        name_lit = _gbnf_literal(func["name"])
+        params = func.get("parameters") or {}
+        props = params.get("properties") if isinstance(params, dict) else None
+        if isinstance(props, dict) and props:
+            pair_branches = " | ".join(f"{_gbnf_literal(f'{k}:')} {emit_value(v)}" for k, v in props.items())
+            tool_rules.append(f"tool-{idx}-pair ::= {pair_branches}")
+            tool_rules.append(f'tool-{idx}-args ::= ( tool-{idx}-pair ( "," tool-{idx}-pair )* )?')
+            tool_rules.append(f'tool-{idx} ::= {name_lit} "{{" tool-{idx}-args "}}"')
+        else:
+            # All-optional / no-property intents collapse to FUNC{}.
+            tool_rules.append(f'tool-{idx} ::= {name_lit} "{{" "}}"')
+
+    if n_tools == 0:
+        return None
+
+    call_choice = " | ".join(f"tool-{i}" for i in range(n_tools))
+    # Calls are concatenated back-to-back (no separator) up to the cap.
+    tool_calls_rhs = "tool-call" + " ( tool-call )?" * (_MAX_TOOL_CALLS - 1)
+
+    start = _gbnf_literal(parser.start_marker)
+    end = _gbnf_literal(parser.end_marker)
+    start_char = parser.start_marker[0] if parser.start_marker else "<"
+    content_excl = f"\\{start_char}" if start_char in "]-^\\" else start_char
+
+    if _REQUIRE_TOOL_CALL:
+        root_rule = "root ::= tool-calls"
+        content_rules: list[str] = []
+    else:
+        root_rule = "root ::= ( content )? tool-calls ( content )? | content"
+        content_rules = [f"content ::= [^{content_excl}]+"]
+    envelope = [
+        root_rule,
+        f"tool-calls ::= {tool_calls_rhs}",
+        f'tool-call ::= {start} "call:" call-choice {end}',
+        f"call-choice ::= {call_choice}",
+        *content_rules,
+    ]
+    return "\n".join(envelope + tool_rules) + "\n"
 
 
 def build_tool_call_grammar(parser: ToolCallParser, tools: list[dict[str, Any]]) -> LlamaGrammar | None:

--- a/modelship/infer/llama_cpp/tool_grammar.py
+++ b/modelship/infer/llama_cpp/tool_grammar.py
@@ -64,7 +64,8 @@ _MAX_TOOL_CALLS = 1
 _REQUIRE_TOOL_CALL = True
 
 # Recursion guard for nested object/array schemas — beyond this, value rules
-# collapse to the permissive delimited-string fallback.
+# collapse to the generic recursive value rule (``gv``), which accepts any
+# string / number / bool / null / array / object the DSL can express.
 _MAX_SCHEMA_DEPTH = 5
 
 # Parser names already logged as unconstrained, to avoid repeating per request.
@@ -176,6 +177,17 @@ def _build_gemma_tool_call_gbnf(parser: ToolCallParser, tools: list[dict[str, An
     excl_cls = f"\\{excl}" if excl in "]-^\\" else excl
     str_val = f"( {d_lit} [^{excl_cls}]* {d_lit} )"
 
+    # Generic recursive value rules, emitted only when referenced (free-form
+    # objects, unconstrained arrays, schemaless props, or past the depth cap).
+    # ``gv`` accepts any value the DSL can express, so the grammar never forces
+    # a delimited string where the model legitimately needs ``{...}`` / ``[...]``.
+    uses_generic = False
+
+    def generic(ref: str) -> str:
+        nonlocal uses_generic
+        uses_generic = True
+        return ref
+
     def emit_enum_value(v: object) -> str:
         if isinstance(v, bool):
             return '"true"' if v else '"false"'
@@ -192,7 +204,7 @@ def _build_gemma_tool_call_gbnf(parser: ToolCallParser, tools: list[dict[str, An
         leaking precedence into the enclosing alternation.
         """
         if not isinstance(schema, dict) or depth > _MAX_SCHEMA_DEPTH:
-            return str_val
+            return generic("gv")
 
         enum = schema.get("enum")
         if enum:
@@ -218,7 +230,7 @@ def _build_gemma_tool_call_gbnf(parser: ToolCallParser, tools: list[dict[str, An
             return '( "null" )'
         if t == "array":
             items = schema.get("items")
-            item = emit_value(items, depth + 1) if isinstance(items, dict) else str_val
+            item = emit_value(items, depth + 1) if isinstance(items, dict) else generic("gv")
             return f'( "[" ( {item} ( "," {item} )* )? "]" )'
         if t == "object":
             props = schema.get("properties")
@@ -229,7 +241,9 @@ def _build_gemma_tool_call_gbnf(parser: ToolCallParser, tools: list[dict[str, An
                     + " )"
                 )
                 return f'( "{{" ( {pair} ( "," {pair} )* )? "}}" )'
-        return str_val
+            # Free-form object (no/empty properties): accept any DSL object.
+            return generic("gv-obj")
+        return generic("gv")
 
     tool_rules: list[str] = []
     n_tools = 0
@@ -276,7 +290,23 @@ def _build_gemma_tool_call_gbnf(parser: ToolCallParser, tools: list[dict[str, An
         f"call-choice ::= {call_choice}",
         *content_rules,
     ]
-    return "\n".join(envelope + tool_rules) + "\n"
+
+    generic_rules: list[str] = []
+    if uses_generic:
+        generic_rules = [
+            "gv ::= gv-str | gv-num | gv-bool | gv-null | gv-arr | gv-obj",
+            f"gv-str ::= {d_lit} [^{excl_cls}]* {d_lit}",
+            'gv-num ::= "-"? [0-9]+ ( "." [0-9]+ )?',
+            'gv-bool ::= "true" | "false"',
+            'gv-null ::= "null"',
+            'gv-arr ::= "[" ( gv ( "," gv )* )? "]"',
+            'gv-obj ::= "{" ( gv-pair ( "," gv-pair )* )? "}"',
+            'gv-pair ::= gv-key ":" gv',
+            # Bare key: anything up to the structural ``:`` / separators / delim lead.
+            f"gv-key ::= [^:,{{}}\\[\\]{excl_cls}]+",
+        ]
+
+    return "\n".join(envelope + tool_rules + generic_rules) + "\n"
 
 
 def build_tool_call_grammar(parser: ToolCallParser, tools: list[dict[str, Any]]) -> LlamaGrammar | None:

--- a/modelship/openai/parsers/tool_calling/parsers/base.py
+++ b/modelship/openai/parsers/tool_calling/parsers/base.py
@@ -53,6 +53,11 @@ class ToolCallParser(ABC):
     # strips every OTHER registered special from chunks itself. Hermes and
     # llama3_json keep the default — their markers are regular text.
     markers_are_specials: bool = False
+    # Delimiter token wrapping string values in custom-syntax (non-JSON) call
+    # bodies — ``<escape>`` for FunctionGemma, ``<|"|>`` for Gemma 4. ``None``
+    # for JSON-family parsers (Hermes/Mistral) whose bodies need no such token.
+    # The GBNF tool-grammar emitter reads it to wrap string-valued arguments.
+    string_delim: str | None = None
 
     @abstractmethod
     def extract_partial_name(self, partial_payload: str) -> str | None:

--- a/tests/test_llama_cpp_chat_trace.py
+++ b/tests/test_llama_cpp_chat_trace.py
@@ -52,6 +52,7 @@ def _serving(text: str) -> OpenAIServingChat:
     chat._llama = _FakeLlama(text)
     chat.reasoning_parser = None
     chat._constrain_tool_calls = False
+    chat._require_tool_call = False
     chat._completion_accepted_params = set(inspect.signature(Llama.create_completion).parameters)
     return chat
 

--- a/tests/test_llama_cpp_constrain_reasoning.py
+++ b/tests/test_llama_cpp_constrain_reasoning.py
@@ -45,7 +45,9 @@ class _CapturingLlama:
         return {"choices": [{"text": "hi"}], "usage": {"prompt_tokens": 3, "completion_tokens": 1}}
 
 
-def _serving(*, reasoning_parser: str | None) -> tuple[OpenAIServingChat, _CapturingLlama]:
+def _serving(
+    *, reasoning_parser: str | None, constrain_tool_calls: bool = True, require_tool_call: bool = False
+) -> tuple[OpenAIServingChat, _CapturingLlama]:
     from llama_cpp import Llama
 
     chat = OpenAIServingChat.__new__(OpenAIServingChat)
@@ -56,7 +58,8 @@ def _serving(*, reasoning_parser: str | None) -> tuple[OpenAIServingChat, _Captu
     chat._llama = llama
     chat.tool_call_parser = "hermes"
     chat.reasoning_parser = reasoning_parser
-    chat._constrain_tool_calls = True
+    chat._constrain_tool_calls = constrain_tool_calls
+    chat._require_tool_call = require_tool_call
     chat._logged_reasoning_unconstrained = False
     chat._completion_accepted_params = set(inspect.signature(Llama.create_completion).parameters)
     return chat, llama
@@ -66,8 +69,8 @@ def _request() -> ChatCompletionRequest:
     return ChatCompletionRequest(model="x", messages=[{"role": "user", "content": "hi"}], tools=TOOLS)
 
 
-async def _run(reasoning_parser: str | None) -> dict:
-    chat, llama = _serving(reasoning_parser=reasoning_parser)
+async def _run(reasoning_parser: str | None, **serving_kwargs) -> dict:
+    chat, llama = _serving(reasoning_parser=reasoning_parser, **serving_kwargs)
     await chat._handle_with_parsers(
         _request(),
         "chat-1",
@@ -89,3 +92,17 @@ async def test_grammar_skipped_when_reasoning_parser_active():
 async def test_grammar_applied_without_reasoning_parser():
     kwargs = await _run(reasoning_parser=None)
     assert kwargs.get("grammar") is not None, "tool-call grammar should constrain a non-reasoning deployment"
+
+
+@pytest.mark.asyncio
+async def test_require_tool_call_builds_grammar_without_constrain():
+    # require_tool_call forces a call via the grammar, so it implies building one
+    # even when constrain_tool_calls is off.
+    kwargs = await _run(reasoning_parser=None, constrain_tool_calls=False, require_tool_call=True)
+    assert kwargs.get("grammar") is not None, "require_tool_call should build the grammar on its own"
+
+
+@pytest.mark.asyncio
+async def test_no_grammar_when_both_flags_off():
+    kwargs = await _run(reasoning_parser=None, constrain_tool_calls=False, require_tool_call=False)
+    assert "grammar" not in kwargs, "no grammar when neither constrain_tool_calls nor require_tool_call is set"

--- a/tests/test_llama_cpp_tool_grammar.py
+++ b/tests/test_llama_cpp_tool_grammar.py
@@ -245,6 +245,21 @@ class TestGemmaToolCallGrammar:
         assert '"on:" ( "true" | "false" )' in text
         assert '"[" (' in text  # array rule for `tags`
 
+    def test_empty_type_list_falls_back_to_generic(self):
+        # `type: []` must not emit an empty group `(  )`, which is invalid GBNF.
+        tools = [
+            {
+                "type": "function",
+                "function": {"name": "F", "parameters": {"type": "object", "properties": {"x": {"type": []}}}},
+            }
+        ]
+        parser = get_parser("function_gemma")
+        text = build_tool_call_gbnf(parser, tools)
+        assert text is not None
+        assert "(  )" not in text
+        assert '"x:" gv' in text
+        assert build_tool_call_grammar(parser, tools) is not None
+
     def test_generic_rules_omitted_when_unneeded(self):
         # The fully-typed GEMMA_TOOLS never needs the generic fallback, so the
         # gv-* rule block must not be emitted.

--- a/tests/test_llama_cpp_tool_grammar.py
+++ b/tests/test_llama_cpp_tool_grammar.py
@@ -4,7 +4,12 @@ import json
 
 from llama_cpp import LlamaGrammar
 
-from modelship.infer.llama_cpp.tool_grammar import _MAX_TOOL_CALLS, build_tool_call_gbnf, build_tool_call_grammar
+from modelship.infer.llama_cpp.tool_grammar import (
+    _MAX_TOOL_CALLS,
+    _REQUIRE_TOOL_CALL,
+    build_tool_call_gbnf,
+    build_tool_call_grammar,
+)
 from modelship.openai.parsers.tool_calling import HermesToolCallParser, get_parser
 
 GEMMA_TOOLS = [
@@ -177,9 +182,14 @@ class TestGemmaToolCallGrammar:
         parser = get_parser("function_gemma")
         text = build_tool_call_gbnf(parser, GEMMA_TOOLS)
         assert text is not None
-        assert "root ::= ( content )? tool-calls ( content )? | content" in text
         assert f'tool-call ::= "{parser.start_marker}" "call:" call-choice "{parser.end_marker}"' in text
-        assert "content ::= [^<]+" in text  # both gemma markers/delims lead with '<'
+        if _REQUIRE_TOOL_CALL:
+            # Forced-call root: no free-text escape, so no `content` rule.
+            assert "root ::= tool-calls" in text
+            assert "content ::=" not in text
+        else:
+            assert "root ::= ( content )? tool-calls ( content )? | content" in text
+            assert "content ::= [^<]+" in text  # both gemma markers/delims lead with '<'
 
     def test_call_cap_is_structural(self):
         # The cap is exactly _MAX_TOOL_CALLS calls, concatenated with no separator.
@@ -221,6 +231,59 @@ class TestGemmaToolCallGrammar:
         assert '"minutes:" ( "-"? [0-9]+ )' in text
         assert '"on:" ( "true" | "false" )' in text
         assert '"[" (' in text  # array rule for `tags`
+
+    def test_generic_rules_omitted_when_unneeded(self):
+        # The fully-typed GEMMA_TOOLS never needs the generic fallback, so the
+        # gv-* rule block must not be emitted.
+        text = build_tool_call_gbnf(get_parser("function_gemma"), GEMMA_TOOLS)
+        assert text is not None
+        assert "gv ::=" not in text
+
+    def test_free_form_object_uses_generic_object_rule(self):
+        # A property typed `object` with no `properties`, a schemaless property,
+        # and an array with no `items` must map to the generic value rules — not
+        # a delimited string, which would reject a legitimate {...} / [...] and
+        # deadlock constrained sampling.
+        tools = [
+            {
+                "type": "function",
+                "function": {
+                    "name": "SetState",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {
+                            "attrs": {"type": "object"},
+                            "anything": {},
+                            "list": {"type": "array"},
+                        },
+                    },
+                },
+            }
+        ]
+        parser = get_parser("function_gemma")
+        text = build_tool_call_gbnf(parser, tools)
+        assert text is not None
+        assert '"attrs:" gv-obj' in text
+        assert '"anything:" gv' in text
+        assert "gv ::= gv-str | gv-num | gv-bool | gv-null | gv-arr | gv-obj" in text
+        # And it compiles + round-trips a nested object and a mixed array.
+        assert build_tool_call_grammar(parser, tools) is not None
+        d = parser.string_delim
+        sample = (
+            parser.start_marker
+            + "call:SetState{attrs:{k:"
+            + d
+            + "v"
+            + d
+            + ",n:5},list:["
+            + d
+            + "a"
+            + d
+            + ",true]}"
+            + parser.end_marker
+        )
+        out = parser.parse(sample)
+        assert json.loads(out.tool_calls[0].function.arguments) == {"attrs": {"k": "v", "n": 5}, "list": ["a", True]}
 
     def test_all_malformed_tools_returns_none(self):
         tools = [{"type": "function", "function": {}}, {"type": "function"}]

--- a/tests/test_llama_cpp_tool_grammar.py
+++ b/tests/test_llama_cpp_tool_grammar.py
@@ -6,7 +6,6 @@ from llama_cpp import LlamaGrammar
 
 from modelship.infer.llama_cpp.tool_grammar import (
     _MAX_TOOL_CALLS,
-    _REQUIRE_TOOL_CALL,
     build_tool_call_gbnf,
     build_tool_call_grammar,
 )
@@ -179,17 +178,31 @@ class TestGemmaToolCallGrammar:
         assert isinstance(g, LlamaGrammar)
 
     def test_envelope_and_markers(self):
+        # Default: free-text answers stay reachable around the tool calls.
         parser = get_parser("function_gemma")
         text = build_tool_call_gbnf(parser, GEMMA_TOOLS)
         assert text is not None
         assert f'tool-call ::= "{parser.start_marker}" "call:" call-choice "{parser.end_marker}"' in text
-        if _REQUIRE_TOOL_CALL:
-            # Forced-call root: no free-text escape, so no `content` rule.
-            assert "root ::= tool-calls" in text
-            assert "content ::=" not in text
-        else:
-            assert "root ::= ( content )? tool-calls ( content )? | content" in text
-            assert "content ::= [^<]+" in text  # both gemma markers/delims lead with '<'
+        assert "root ::= ( content )? tool-calls ( content )? | content" in text
+        assert "content ::= [^<]+" in text  # both gemma markers/delims lead with '<'
+
+    def test_require_tool_call_drops_free_text_escape(self):
+        # Forced-call root: no `content` branch, so the model must emit a call.
+        parser = get_parser("function_gemma")
+        text = build_tool_call_gbnf(parser, GEMMA_TOOLS, require_tool_call=True)
+        assert text is not None
+        assert "root ::= tool-calls\n" in text
+        assert "content ::=" not in text
+        assert build_tool_call_grammar(parser, GEMMA_TOOLS, require_tool_call=True) is not None
+
+    def test_require_tool_call_drops_free_text_escape_hermes(self):
+        # The flag is parser-agnostic — the JSON-family envelope honors it too.
+        parser = HermesToolCallParser()
+        text = build_tool_call_gbnf(parser, TOOLS, require_tool_call=True)
+        assert text is not None
+        assert "root ::= tool-calls\n" in text
+        assert "content ::=" not in text
+        assert build_tool_call_grammar(parser, TOOLS, require_tool_call=True) is not None
 
     def test_call_cap_is_structural(self):
         # The cap is exactly _MAX_TOOL_CALLS calls, concatenated with no separator.

--- a/tests/test_llama_cpp_tool_grammar.py
+++ b/tests/test_llama_cpp_tool_grammar.py
@@ -4,8 +4,44 @@ import json
 
 from llama_cpp import LlamaGrammar
 
-from modelship.infer.llama_cpp.tool_grammar import build_tool_call_gbnf, build_tool_call_grammar
+from modelship.infer.llama_cpp.tool_grammar import _MAX_TOOL_CALLS, build_tool_call_gbnf, build_tool_call_grammar
 from modelship.openai.parsers.tool_calling import HermesToolCallParser, get_parser
+
+GEMMA_TOOLS = [
+    {
+        "type": "function",
+        "function": {
+            "name": "HassTurnOn",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "name": {"type": "string"},
+                    "area": {"enum": ["Living Room", "Small Bedroom"]},
+                },
+                "required": ["name"],
+            },
+        },
+    },
+    {
+        # All-optional / no-property intent: must collapse to FUNC{}.
+        "type": "function",
+        "function": {"name": "HassGetState", "parameters": {"type": "object", "properties": {}}},
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "SetTimer",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "minutes": {"type": "integer"},
+                    "on": {"type": "boolean"},
+                    "tags": {"type": "array", "items": {"type": "string"}},
+                },
+            },
+        },
+    },
+]
 
 TOOLS = [
     {
@@ -54,10 +90,6 @@ class TestBuildToolCallGrammar:
     def test_empty_tools_returns_none(self):
         assert build_tool_call_grammar(HermesToolCallParser(), []) is None
         assert build_tool_call_gbnf(HermesToolCallParser(), []) is None
-
-    def test_function_gemma_returns_none(self):
-        # Custom-syntax family has no emitter yet.
-        assert build_tool_call_grammar(get_parser("function_gemma"), TOOLS) is None
 
     def test_qwen3_coder_returns_none(self):
         # Shares Hermes markers but an XML body — must not be treated as JSON-family.
@@ -128,3 +160,111 @@ class TestGrammarShapedOutputRoundTrips:
         )
         out = parser.parse(sample)
         assert [c.function.name for c in out.tool_calls] == ["HassTurnOn", "HassTurnOff"]
+
+
+class TestGemmaToolCallGrammar:
+    """The hand-built emitter for the FunctionGemma / Gemma 4 ``call:FUNC{...}`` DSL."""
+
+    def test_function_gemma_returns_grammar(self):
+        g = build_tool_call_grammar(get_parser("function_gemma"), GEMMA_TOOLS)
+        assert isinstance(g, LlamaGrammar)
+
+    def test_gemma4_returns_grammar(self):
+        g = build_tool_call_grammar(get_parser("gemma4"), GEMMA_TOOLS)
+        assert isinstance(g, LlamaGrammar)
+
+    def test_envelope_and_markers(self):
+        parser = get_parser("function_gemma")
+        text = build_tool_call_gbnf(parser, GEMMA_TOOLS)
+        assert text is not None
+        assert "root ::= ( content )? tool-calls ( content )? | content" in text
+        assert f'tool-call ::= "{parser.start_marker}" "call:" call-choice "{parser.end_marker}"' in text
+        assert "content ::= [^<]+" in text  # both gemma markers/delims lead with '<'
+
+    def test_call_cap_is_structural(self):
+        # The cap is exactly _MAX_TOOL_CALLS calls, concatenated with no separator.
+        text = build_tool_call_gbnf(get_parser("function_gemma"), GEMMA_TOOLS)
+        assert text is not None
+        expected = "tool-calls ::= " + "tool-call" + " ( tool-call )?" * (_MAX_TOOL_CALLS - 1)
+        assert expected in text
+
+    def test_every_tool_name_is_a_literal(self):
+        text = build_tool_call_gbnf(get_parser("function_gemma"), GEMMA_TOOLS)
+        assert text is not None
+        for name in ("HassTurnOn", "HassGetState", "SetTimer"):
+            assert f'"{name}"' in text
+        # All three tools are selectable.
+        assert "call-choice ::= tool-0 | tool-1 | tool-2" in text
+
+    def test_enum_values_are_escaped_literals(self):
+        # FunctionGemma wraps string values in the <escape> delimiter.
+        text = build_tool_call_gbnf(get_parser("function_gemma"), GEMMA_TOOLS)
+        assert text is not None
+        assert '"<escape>" "Living Room" "<escape>"' in text
+        assert '"<escape>" "Small Bedroom" "<escape>"' in text
+
+    def test_gemma4_uses_its_own_delimiter(self):
+        # Gemma 4 uses <|"|> rather than <escape>; it appears as an escaped literal.
+        text = build_tool_call_gbnf(get_parser("gemma4"), GEMMA_TOOLS)
+        assert text is not None
+        assert '"<|\\"|>" "Living Room" "<|\\"|>"' in text
+        assert "<escape>" not in text
+
+    def test_empty_property_tool_collapses_to_empty_braces(self):
+        text = build_tool_call_gbnf(get_parser("function_gemma"), GEMMA_TOOLS)
+        assert text is not None
+        assert 'tool-1 ::= "HassGetState" "{" "}"' in text
+
+    def test_number_bool_array_value_rules(self):
+        text = build_tool_call_gbnf(get_parser("function_gemma"), GEMMA_TOOLS)
+        assert text is not None
+        assert '"minutes:" ( "-"? [0-9]+ )' in text
+        assert '"on:" ( "true" | "false" )' in text
+        assert '"[" (' in text  # array rule for `tags`
+
+    def test_all_malformed_tools_returns_none(self):
+        tools = [{"type": "function", "function": {}}, {"type": "function"}]
+        assert build_tool_call_gbnf(get_parser("function_gemma"), tools) is None
+        assert build_tool_call_grammar(get_parser("function_gemma"), tools) is None
+
+    def test_empty_tools_returns_none(self):
+        assert build_tool_call_gbnf(get_parser("function_gemma"), []) is None
+
+
+class TestGemmaGrammarParserAgreement:
+    """Canonical strings the grammar can emit must parse back to the right call.
+
+    Guards the emitter and the parser against drifting apart — the grammar
+    constrains generation, the parser consumes it, and nothing checks they
+    agree except this.
+    """
+
+    def test_string_arg_roundtrips(self):
+        parser = get_parser("function_gemma")
+        sample = f"{parser.start_marker}call:HassTurnOn{{name:{parser.string_delim}small_bedroom_light{parser.string_delim}}}{parser.end_marker}"
+        out = parser.parse(sample)
+        assert len(out.tool_calls) == 1
+        call = out.tool_calls[0]
+        assert call.function.name == "HassTurnOn"
+        assert json.loads(call.function.arguments) == {"name": "small_bedroom_light"}
+
+    def test_enum_arg_roundtrips(self):
+        parser = get_parser("function_gemma")
+        d = parser.string_delim
+        sample = f"{parser.start_marker}call:HassTurnOn{{name:{d}x{d},area:{d}Living Room{d}}}{parser.end_marker}"
+        out = parser.parse(sample)
+        assert json.loads(out.tool_calls[0].function.arguments) == {"name": "x", "area": "Living Room"}
+
+    def test_empty_args_roundtrips(self):
+        parser = get_parser("function_gemma")
+        sample = f"{parser.start_marker}call:HassGetState{{}}{parser.end_marker}"
+        out = parser.parse(sample)
+        assert out.tool_calls[0].function.name == "HassGetState"
+        assert json.loads(out.tool_calls[0].function.arguments) == {}
+
+    def test_number_bool_array_roundtrips(self):
+        parser = get_parser("function_gemma")
+        d = parser.string_delim
+        sample = f"{parser.start_marker}call:SetTimer{{minutes:42,on:true,tags:[{d}a{d},{d}b{d}]}}{parser.end_marker}"
+        out = parser.parse(sample)
+        assert json.loads(out.tool_calls[0].function.arguments) == {"minutes": 42, "on": True, "tags": ["a", "b"]}


### PR DESCRIPTION
The function_gemma and gemma4 parsers previously ran unconstrained, so small FunctionGemma checkpoints (270M) could loop, repeating tool calls.

Add a hand-built GBNF emitter for the custom call:FUNC{...} DSL (which json_schema_to_gbnf can't express). The grammar caps the call count, pins the tool name to the available set, and constrains argument values to each tool's JSON schema (enum alternations, delimited strings, bare numbers/bools, arrays, nested objects). Free-text answers stay reachable.

constrain_tool_calls already routed through to build_tool_call_grammar, so this is purely the emitter plus tests and an example config. The grammar is loose by design: it does not enforce required args, key uniqueness, or ordering.

