### PR TITLE
feat: enforce schema order and uniqueness in Gemma tool call GBNF gra…

### DIFF
--- a/modelship/infer/llama_cpp/tool_grammar.py
+++ b/modelship/infer/llama_cpp/tool_grammar.py
@@ -290,20 +290,21 @@ def _build_gemma_tool_call_gbnf(
     content_excl = f"\\{start_char}" if start_char in "]-^\\" else start_char
 
     if require_tool_call:
-        root_rule = "root ::= tool-calls"
+        root_rule = "root ::= ws tool-calls ws"
         content_rules: list[str] = []
     else:
         # A turn is *either* tool calls or free text — never text wrapped around a call.
         # The old ``( content )? tool-calls ( content )?`` let a small model spill malformed
         # DSL as leading/trailing content (e.g. ``capturePlayercall:HassMediaNext{}``), which
         # then got captured into chat history and poisoned later turns.
-        root_rule = "root ::= tool-calls | content"
+        root_rule = "root ::= ws tool-calls ws | content"
         content_rules = [f"content ::= [^{content_excl}]+"]
     envelope = [
         root_rule,
         f"tool-calls ::= {tool_calls_rhs}",
         f'tool-call ::= {start} "call:" call-choice {end}',
         f"call-choice ::= {call_choice}",
+        "ws ::= [ \\t\\n\\r]*",
         *content_rules,
     ]
 

--- a/modelship/infer/llama_cpp/tool_grammar.py
+++ b/modelship/infer/llama_cpp/tool_grammar.py
@@ -259,9 +259,19 @@ def _build_gemma_tool_call_gbnf(
         params = func.get("parameters") or {}
         props = params.get("properties") if isinstance(params, dict) else None
         if isinstance(props, dict) and props:
-            pair_branches = " | ".join(f"{_gbnf_literal(f'{k}:')} {emit_value(v)}" for k, v in props.items())
-            tool_rules.append(f"tool-{idx}-pair ::= {pair_branches}")
-            tool_rules.append(f'tool-{idx}-args ::= ( tool-{idx}-pair ( "," tool-{idx}-pair )* )?')
+            prop_items = list(props.items())
+            for j, (k, v) in enumerate(prop_items):
+                tool_rules.append(f"tool-{idx}-p{j} ::= {_gbnf_literal(f'{k}:')} {emit_value(v)}")
+            m = len(prop_items)
+            # Ordered-optional args: each property appears at most once, in schema order,
+            # with correct commas (first present property is bare, every later one carries a
+            # leading comma). Enforces key *uniqueness* — a free ``pair ( "," pair )*``
+            # alternation let the model repeat a key (e.g. ``name`` twice) -> corrupt call.
+            branches = " | ".join(
+                " ".join([f"tool-{idx}-p{j}"] + [f'( "," tool-{idx}-p{n} )?' for n in range(j + 1, m)])
+                for j in range(m)
+            )
+            tool_rules.append(f"tool-{idx}-args ::= ( {branches} )?")
             tool_rules.append(f'tool-{idx} ::= {name_lit} "{{" tool-{idx}-args "}}"')
         else:
             # All-optional / no-property intents collapse to FUNC{}.
@@ -283,7 +293,11 @@ def _build_gemma_tool_call_gbnf(
         root_rule = "root ::= tool-calls"
         content_rules: list[str] = []
     else:
-        root_rule = "root ::= ( content )? tool-calls ( content )? | content"
+        # A turn is *either* tool calls or free text — never text wrapped around a call.
+        # The old ``( content )? tool-calls ( content )?`` let a small model spill malformed
+        # DSL as leading/trailing content (e.g. ``capturePlayercall:HassMediaNext{}``), which
+        # then got captured into chat history and poisoned later turns.
+        root_rule = "root ::= tool-calls | content"
         content_rules = [f"content ::= [^{content_excl}]+"]
     envelope = [
         root_rule,

--- a/tests/test_llama_cpp_tool_grammar.py
+++ b/tests/test_llama_cpp_tool_grammar.py
@@ -183,7 +183,7 @@ class TestGemmaToolCallGrammar:
         text = build_tool_call_gbnf(parser, GEMMA_TOOLS)
         assert text is not None
         assert f'tool-call ::= "{parser.start_marker}" "call:" call-choice "{parser.end_marker}"' in text
-        assert "root ::= ( content )? tool-calls ( content )? | content" in text
+        assert "root ::= tool-calls | content" in text
         assert "content ::= [^<]+" in text  # both gemma markers/delims lead with '<'
 
     def test_require_tool_call_drops_free_text_escape(self):

--- a/tests/test_llama_cpp_tool_grammar.py
+++ b/tests/test_llama_cpp_tool_grammar.py
@@ -183,7 +183,7 @@ class TestGemmaToolCallGrammar:
         text = build_tool_call_gbnf(parser, GEMMA_TOOLS)
         assert text is not None
         assert f'tool-call ::= "{parser.start_marker}" "call:" call-choice "{parser.end_marker}"' in text
-        assert "root ::= tool-calls | content" in text
+        assert "root ::= ws tool-calls ws | content" in text
         assert "content ::= [^<]+" in text  # both gemma markers/delims lead with '<'
 
     def test_require_tool_call_drops_free_text_escape(self):
@@ -191,7 +191,7 @@ class TestGemmaToolCallGrammar:
         parser = get_parser("function_gemma")
         text = build_tool_call_gbnf(parser, GEMMA_TOOLS, require_tool_call=True)
         assert text is not None
-        assert "root ::= tool-calls\n" in text
+        assert "root ::= ws tool-calls ws\n" in text
         assert "content ::=" not in text
         assert build_tool_call_grammar(parser, GEMMA_TOOLS, require_tool_call=True) is not None
 


### PR DESCRIPTION
…mmar

Refine Gemma/Gemma4 GBNF tool call grammar to generate ordered-optional parameters in schema order. This prevents small models from repeating keys (e.g., repeating name twice) and corrupting the function call.

Also restrict the turn root rule to be either tool calls or free text instead of wrapping tool calls in conversational text, preventing small models from spilling malformed DSL as leading/trailing content.

