### PR TITLE
feat: enforce required arguments in Gemma tool-call GBNF grammar

### DIFF
--- a/modelship/infer/llama_cpp/tool_grammar.py
+++ b/modelship/infer/llama_cpp/tool_grammar.py
@@ -269,17 +269,24 @@ def _build_gemma_tool_call_gbnf(
             # alternation let the model repeat a key (e.g. ``name`` twice) -> corrupt call.
             # Enforces top-level ``required`` fields by restricting branches to only valid
             # ordered subsets that include all top-level required properties.
-            req_keys = set(params.get("required") or [])
+            req_val = params.get("required")
+            if isinstance(req_val, str):
+                req_keys = {req_val}
+            elif isinstance(req_val, list):
+                req_keys = set(req_val)
+            else:
+                req_keys = set()
+
             req_set = {j for j, (k, _) in enumerate(prop_items) if k in req_keys}
             first_req = min(req_set) if req_set else None
 
             branch_js = range(first_req + 1) if first_req is not None else range(m)
 
-            def later(n: int, current_idx: int, current_req_set: set[int]) -> str:
-                return f'"," tool-{current_idx}-p{n}' if n in current_req_set else f'( "," tool-{current_idx}-p{n} )?'
+            def later(n: int) -> str:
+                return f'"," tool-{idx}-p{n}' if n in req_set else f'( "," tool-{idx}-p{n} )?'  # noqa: B023
 
             branches = " | ".join(
-                " ".join([f"tool-{idx}-p{j}"] + [later(n, idx, req_set) for n in range(j + 1, m)]) for j in branch_js
+                " ".join([f"tool-{idx}-p{j}"] + [later(n) for n in range(j + 1, m)]) for j in branch_js
             )
             args_rhs = f"( {branches} )?" if first_req is None else f"( {branches} )"
             tool_rules.append(f"tool-{idx}-args ::= {args_rhs}")

--- a/modelship/infer/llama_cpp/tool_grammar.py
+++ b/modelship/infer/llama_cpp/tool_grammar.py
@@ -273,7 +273,7 @@ def _build_gemma_tool_call_gbnf(
             if isinstance(req_val, str):
                 req_keys = {req_val}
             elif isinstance(req_val, list):
-                req_keys = set(req_val)
+                req_keys = {k for k in req_val if isinstance(k, str)}
             else:
                 req_keys = set()
 

--- a/modelship/infer/llama_cpp/tool_grammar.py
+++ b/modelship/infer/llama_cpp/tool_grammar.py
@@ -21,8 +21,8 @@ caps the number of calls (``_MAX_TOOL_CALLS``) to stop the runaway repetition
 small FunctionGemma checkpoints fall into. Other families return ``None``.
 
 The Gemma grammar is loose by design: it pins the call count, tool name, and
-enum values, but does not enforce ``required`` args, key uniqueness, or key
-ordering.
+enum values. Key uniqueness, ordering, and ``required`` arguments are enforced
+at the top level, and only nested-object shape remains loose.
 """
 
 from __future__ import annotations
@@ -267,11 +267,22 @@ def _build_gemma_tool_call_gbnf(
             # with correct commas (first present property is bare, every later one carries a
             # leading comma). Enforces key *uniqueness* — a free ``pair ( "," pair )*``
             # alternation let the model repeat a key (e.g. ``name`` twice) -> corrupt call.
+            # Enforces top-level ``required`` fields by restricting branches to only valid
+            # ordered subsets that include all top-level required properties.
+            req_keys = set(params.get("required") or [])
+            req_set = {j for j, (k, _) in enumerate(prop_items) if k in req_keys}
+            first_req = min(req_set) if req_set else None
+
+            branch_js = range(first_req + 1) if first_req is not None else range(m)
+
+            def later(n: int, current_idx: int, current_req_set: set[int]) -> str:
+                return f'"," tool-{current_idx}-p{n}' if n in current_req_set else f'( "," tool-{current_idx}-p{n} )?'
+
             branches = " | ".join(
-                " ".join([f"tool-{idx}-p{j}"] + [f'( "," tool-{idx}-p{n} )?' for n in range(j + 1, m)])
-                for j in range(m)
+                " ".join([f"tool-{idx}-p{j}"] + [later(n, idx, req_set) for n in range(j + 1, m)]) for j in branch_js
             )
-            tool_rules.append(f"tool-{idx}-args ::= ( {branches} )?")
+            args_rhs = f"( {branches} )?" if first_req is None else f"( {branches} )"
+            tool_rules.append(f"tool-{idx}-args ::= {args_rhs}")
             tool_rules.append(f'tool-{idx} ::= {name_lit} "{{" tool-{idx}-args "}}"')
         else:
             # All-optional / no-property intents collapse to FUNC{}.

--- a/tests/test_llama_cpp_tool_grammar.py
+++ b/tests/test_llama_cpp_tool_grammar.py
@@ -321,6 +321,88 @@ class TestGemmaToolCallGrammar:
     def test_empty_tools_returns_none(self):
         assert build_tool_call_gbnf(get_parser("function_gemma"), []) is None
 
+    def test_required_arg_is_mandatory(self):
+        # 1. Required arg is mandatory: with a tool `{name:string, area:enum}`,
+        #    `required:["name"]`, assert the emitted `tool-0-args` rule equals the expected
+        #    string (no outer `?`, p0 in every branch). Assert `build_tool_call_grammar` compiles.
+        tools = [
+            {
+                "type": "function",
+                "function": {
+                    "name": "HassTurnOn",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {
+                            "name": {"type": "string"},
+                            "area": {"enum": ["Living Room", "Small Bedroom"]},
+                        },
+                        "required": ["name"],
+                    },
+                },
+            }
+        ]
+        parser = get_parser("function_gemma")
+        text = build_tool_call_gbnf(parser, tools)
+        assert text is not None
+        assert 'tool-0-args ::= ( tool-0-p0 ( "," tool-0-p1 )? | tool-0-p1 )' not in text
+        assert 'tool-0-args ::= ( tool-0-p0 ( "," tool-0-p1 )? )' in text
+        assert 'tool-0-args ::= ( tool-0-p0 ( "," tool-0-p1 )? )?' not in text
+        assert build_tool_call_grammar(parser, tools) is not None
+
+    def test_no_required_regression(self):
+        # 2. No-required regression: a tool with the same props but no `required` still
+        #    emits `tool-0-args ::= ( ... )?` (outer optional present) — byte-identical to pre-change output.
+        tools = [
+            {
+                "type": "function",
+                "function": {
+                    "name": "HassTurnOn",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {
+                            "name": {"type": "string"},
+                            "area": {"enum": ["Living Room", "Small Bedroom"]},
+                        },
+                    },
+                },
+            }
+        ]
+        parser = get_parser("function_gemma")
+        text = build_tool_call_gbnf(parser, tools)
+        assert text is not None
+        assert 'tool-0-args ::= ( tool-0-p0 ( "," tool-0-p1 )? | tool-0-p1 )?' in text
+
+    def test_multiple_required_order_preserved(self):
+        # 3. Multiple required, order preserved: `[opt a, req b, opt c, req d]` produces the
+        #    branch set from the worked examples (assert key substrings: `"," tool-0-p1` mandatory,
+        #    `( "," tool-0-p2 )?` optional, `"," tool-0-p3` mandatory).
+        tools = [
+            {
+                "type": "function",
+                "function": {
+                    "name": "MultiReq",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {
+                            "a": {"type": "string"},
+                            "b": {"type": "string"},
+                            "c": {"type": "string"},
+                            "d": {"type": "string"},
+                        },
+                        "required": ["b", "d"],
+                    },
+                },
+            }
+        ]
+        parser = get_parser("function_gemma")
+        text = build_tool_call_gbnf(parser, tools)
+        assert text is not None
+        expected_rule = (
+            'tool-0-args ::= ( tool-0-p0 "," tool-0-p1 ( "," tool-0-p2 )? "," tool-0-p3 | '
+            'tool-0-p1 ( "," tool-0-p2 )? "," tool-0-p3 )'
+        )
+        assert expected_rule in text
+
 
 class TestGemmaGrammarParserAgreement:
     """Canonical strings the grammar can emit must parse back to the right call.
@@ -359,3 +441,15 @@ class TestGemmaGrammarParserAgreement:
         sample = f"{parser.start_marker}call:SetTimer{{minutes:42,on:true,tags:[{d}a{d},{d}b{d}]}}{parser.end_marker}"
         out = parser.parse(sample)
         assert json.loads(out.tool_calls[0].function.arguments) == {"minutes": 42, "on": True, "tags": ["a", "b"]}
+
+    def test_required_arg_parser_agreement(self):
+        # 4. Parser agreement: the minimal grammar-emittable call for `HassTurnOn` is
+        #    `...call:HassTurnOn{name:<escape>x<escape>}...` and round-trips via
+        #    `parser.parse(...)` to `{"name": "x"}` (mirrors `test_enum_arg_roundtrips`).
+        parser = get_parser("function_gemma")
+        d = parser.string_delim
+        sample = f"{parser.start_marker}call:HassTurnOn{{name:{d}x{d}}}{parser.end_marker}"
+        out = parser.parse(sample)
+        assert len(out.tool_calls) == 1
+        assert out.tool_calls[0].function.name == "HassTurnOn"
+        assert json.loads(out.tool_calls[0].function.arguments) == {"name": "x"}


### PR DESCRIPTION
Restrict top-level parameters in FunctionGemma and Gemma4 GBNF tool-call grammars to only valid ordered subsets containing all declared required fields, and omit the optional GBNF trailing ? modifier on required properties. This ensures small models like Home Assistant's Hass* tools include all targeting fields before emitting, preventing immediate downstream rejection of under-targeted calls.

Also add corresponding unit test coverage for mandatory arguments, order preservation, and parser round-trip agreement.


