### PR TITLE
fix: vllm embed init, transcription/translation request construction,…

### DIFF
--- a/modelship/infer/vllm/vllm_infer.py
+++ b/modelship/infer/vllm/vllm_infer.py
@@ -10,6 +10,7 @@ from starlette.requests import Request
 from starlette.responses import Response
 from vllm.config.model import ModelDType
 from vllm.engine.arg_utils import AsyncEngineArgs
+from vllm.entrypoints.chat_utils import ChatTemplateConfig
 from vllm.entrypoints.openai.chat_completion.protocol import (
     ChatCompletionRequest as VllmChatCompletionRequest,
 )
@@ -334,8 +335,7 @@ class VllmInfer(BaseInfer):
                     ],
                 ),
                 request_logger=RequestLogger(max_log_len=None),
-                chat_template=None,
-                chat_template_content_format="auto",
+                chat_template_config=ChatTemplateConfig(chat_template=None, chat_template_content_format="auto"),
             )
             if self.model_config.usecase is ModelUsecase.embed
             and any(task in self.supported_tasks for task in ["embed", "embedding"])
@@ -723,7 +723,10 @@ class VllmInfer(BaseInfer):
     ) -> ErrorResponse | TranscriptionResponse | TranscriptionResponseVerbose | AsyncGenerator[str, None]:
         if self.serving_transcription is None:
             return await super().create_transcription(audio_data, request, raw_request)
-        vllm_request = VllmTranscriptionRequest(**request.model_dump())
+        # `file` is a required field on vLLM's own request schema but unused by
+        # create_transcription (audio_data is passed separately) — model_construct
+        # skips validation instead of raising on the field modelship never populates.
+        vllm_request = VllmTranscriptionRequest.model_construct(**request.model_dump())
         vllm_request.timestamp_granularities = []
         try:
             result = await self.serving_transcription.create_transcription(
@@ -746,7 +749,10 @@ class VllmInfer(BaseInfer):
     ) -> ErrorResponse | TranslationResponse | TranslationResponseVerbose | AsyncGenerator[str, None]:
         if self.serving_translation is None:
             return await super().create_translation(audio_data, request, raw_request)
-        vllm_request = VllmTranslationRequest(**request.model_dump())
+        # `file` is a required field on vLLM's own request schema but unused by
+        # create_translation (audio_data is passed separately) — model_construct
+        # skips validation instead of raising on the field modelship never populates.
+        vllm_request = VllmTranslationRequest.model_construct(**request.model_dump())
         try:
             result = await self.serving_translation.create_translation(
                 audio_data, vllm_request, cast("Request", raw_request)

--- a/modelship/openai/api.py
+++ b/modelship/openai/api.py
@@ -142,7 +142,16 @@ def _error_response(result: ErrorResponse) -> JSONResponse:
 def _validation_error_from_cause(cause: BaseException) -> ErrorResponse:
     # OpenAI-style 400 for client-side validation failures (e.g. vLLM's
     # VLLMValidationError on context overflow, which subclasses ValueError).
-    base = cause.args[0] if cause.args else str(cause)
+    # A pydantic ValidationError's .args is only () locally; once it crosses the
+    # Ray pickle boundary it becomes (model_title, [line_errors], ...) — args[0]
+    # would be a bare model name like "TranscriptionRequest", not a useful
+    # message, so always render those through str() instead.
+    if isinstance(cause, ValidationError):
+        base = str(cause)
+    elif cause.args:
+        base = cause.args[0]
+    else:
+        base = str(cause)
     return create_error_response(
         message=base,
         err_type="invalid_request_error",

--- a/modelship/openai/protocol/responses/adapter.py
+++ b/modelship/openai/protocol/responses/adapter.py
@@ -24,7 +24,7 @@ from __future__ import annotations
 
 from typing import Any, Literal
 
-from modelship.openai.protocol.chat import ChatCompletionRequest
+from modelship.openai.protocol.chat import ChatCompletionRequest, StreamOptions
 from modelship.openai.protocol.responses.schemas import (
     ResponseInputTokensDetails,
     ResponseObject,
@@ -49,7 +49,7 @@ class UnsupportedResponsesFeatureError(ValueError):
 
 
 def responses_request_to_chat(request: ResponsesRequest) -> ChatCompletionRequest:
-    """Translate a ``ResponsesRequest`` into a non-streaming ``ChatCompletionRequest``.
+    """Translate a ``ResponsesRequest`` into a ``ChatCompletionRequest``.
 
     Raises :class:`UnsupportedResponsesFeatureError` for stateful/background/hosted-tool
     features that the stateless Phase A adapter cannot fulfill.
@@ -67,8 +67,14 @@ def responses_request_to_chat(request: ResponsesRequest) -> ChatCompletionReques
     kwargs: dict[str, Any] = {
         "model": request.model,
         "messages": messages,
-        "stream": False,
+        "stream": bool(request.stream),
     }
+    if request.stream:
+        # Responses always reports usage on the final event; the streaming
+        # translator only gets a usage-bearing chunk out of the chat pipeline
+        # when this is set (see engine_ops.stream_chat_completion). ChatCompletionRequest
+        # rejects stream_options when stream=False, so this must stay conditional.
+        kwargs["stream_options"] = StreamOptions(include_usage=True)
     if request.max_output_tokens is not None:
         kwargs["max_completion_tokens"] = request.max_output_tokens
     if request.temperature is not None:


### PR DESCRIPTION
… and Responses streaming usage

- ServingEmbedding init passed vLLM's now-removed flat chat_template kwargs; PoolingServingBase requires a ChatTemplateConfig object, so every embed deploy failed fatally at actor init and was silently evicted.
- create_transcription/create_translation built vLLM's request objects via full validation after modelship stripped the (unpicklable) file field, so every request raised on the missing required field. Use model_construct like the gateway side already does, since nothing downstream reads it.
- _validation_error_from_cause used a pydantic ValidationError's args[0] as the message; that's empty locally but becomes the model class name once the exception crosses the Ray pickle boundary. Always str() it instead.
- responses_request_to_chat never set stream_options.include_usage, so streaming /v1/responses never got a usage-bearing chunk out of the chat pipeline and response.completed.usage stayed None.

