### PR TITLE
refactor: consolidate the /v1/responses streaming and non-stream life…

### DIFF
--- a/modelship/infer/base_infer.py
+++ b/modelship/infer/base_infer.py
@@ -2,7 +2,7 @@ import asyncio
 import contextlib
 import struct
 from abc import ABC, abstractmethod
-from collections.abc import AsyncGenerator, Coroutine
+from collections.abc import AsyncGenerator, AsyncIterator, Callable, Coroutine
 from typing import Any, TypeVar
 
 from modelship.infer.infer_config import ModelshipModelConfig, RawRequestProxy
@@ -10,6 +10,7 @@ from modelship.logging import get_logger
 from modelship.openai.protocol import (
     ChatCompletionRequest,
     ChatCompletionResponse,
+    ChatCompletionStreamResponse,
     EmbeddingRequest,
     ErrorInfo,
     ErrorResponse,
@@ -28,6 +29,7 @@ from modelship.openai.protocol import (
     TranslationResponse,
     TranslationResponseVerbose,
 )
+from modelship.openai.protocol.responses.streaming import ResponsesStreamTranslator
 
 logger = get_logger("infer")
 
@@ -165,6 +167,47 @@ class BaseInfer(ABC):
                 with contextlib.suppress(asyncio.CancelledError):
                     await next_item
             await work.aclose()
+
+    async def _stream_responses(
+        self,
+        request: ResponsesRequest,
+        chunks: AsyncIterator[ChatCompletionStreamResponse],
+        *,
+        request_id: str,
+        client_error: Callable[[Exception], str | None] = lambda _exc: None,
+    ) -> AsyncGenerator[str, None]:
+        """Drive a Responses SSE event stream from a loader's typed chat chunks.
+
+        Shared by every loader's `create_response`: each supplies its own native
+        chunk source (already wrapped in `run_cancellable_stream`) and this owns
+        the `ResponsesStreamTranslator` lifecycle — start, one `process()` per
+        chunk, then `finish()` on a clean end or `fail()` on an error.
+        `ClientDisconnectedError` (raised by `run_cancellable_stream` once the
+        client is gone) ends the stream silently, matching every other endpoint.
+        Any other exception is passed to `client_error`, which returns a
+        client-safe message to report via `fail()`, or `None` to log a full
+        stack trace and report a generic "Internal error during generation".
+        """
+        translator = ResponsesStreamTranslator(request)
+        for event in translator.start():
+            yield event
+        try:
+            async for chunk in chunks:
+                for event in translator.process(chunk):
+                    yield event
+        except ClientDisconnectedError:
+            logger.info("responses request %s aborted: client disconnected", request_id)
+            return
+        except Exception as exc:
+            message = client_error(exc)
+            if message is None:
+                logger.exception("responses request %s failed mid-stream", request_id)
+                message = "Internal error during generation"
+            for event in translator.fail(message):
+                yield event
+            return
+        for event in translator.finish():
+            yield event
 
     async def on_generation_aborted(self) -> None:
         """Hook for loaders whose engine needs cleanup beyond task cancellation

--- a/modelship/infer/base_infer.py
+++ b/modelship/infer/base_infer.py
@@ -2,7 +2,7 @@ import asyncio
 import contextlib
 import struct
 from abc import ABC, abstractmethod
-from collections.abc import AsyncGenerator, AsyncIterator, Callable, Coroutine
+from collections.abc import AsyncGenerator, Callable, Coroutine
 from typing import Any, TypeVar
 
 from modelship.infer.infer_config import ModelshipModelConfig, RawRequestProxy
@@ -171,7 +171,7 @@ class BaseInfer(ABC):
     async def _stream_responses(
         self,
         request: ResponsesRequest,
-        chunks: AsyncIterator[ChatCompletionStreamResponse],
+        chunks: AsyncGenerator[ChatCompletionStreamResponse, None],
         *,
         request_id: str,
         client_error: Callable[[Exception], str | None] = lambda _exc: None,
@@ -187,27 +187,39 @@ class BaseInfer(ABC):
         Any other exception is passed to `client_error`, which returns a
         client-safe message to report via `fail()`, or `None` to log a full
         stack trace and report a generic "Internal error during generation".
+
+        The `finally` block's `chunks.aclose()` is what guarantees `chunks` (and
+        transitively the native engine/subprocess stream it wraps) is torn down
+        even when neither of the `except` branches runs — e.g. the consumer
+        (Starlette/Ray Serve) closes *this* generator early while it's suspended
+        at one of the `yield`s below. `async for` does not propagate that closure
+        into the generator being iterated the way `yield from` would for a
+        synchronous generator, so without this `chunks` would otherwise be left
+        suspended forever, leaking its disconnect-poll task and underlying stream.
         """
         translator = ResponsesStreamTranslator(request)
-        for event in translator.start():
-            yield event
         try:
-            async for chunk in chunks:
-                for event in translator.process(chunk):
-                    yield event
-        except ClientDisconnectedError:
-            logger.info("responses request %s aborted: client disconnected", request_id)
-            return
-        except Exception as exc:
-            message = client_error(exc)
-            if message is None:
-                logger.exception("responses request %s failed mid-stream", request_id)
-                message = "Internal error during generation"
-            for event in translator.fail(message):
+            for event in translator.start():
                 yield event
-            return
-        for event in translator.finish():
-            yield event
+            try:
+                async for chunk in chunks:
+                    for event in translator.process(chunk):
+                        yield event
+            except ClientDisconnectedError:
+                logger.info("responses request %s aborted: client disconnected", request_id)
+                return
+            except Exception as exc:
+                message = client_error(exc)
+                if message is None:
+                    logger.exception("responses request %s failed mid-stream", request_id)
+                    message = "Internal error during generation"
+                for event in translator.fail(message):
+                    yield event
+                return
+            for event in translator.finish():
+                yield event
+        finally:
+            await chunks.aclose()
 
     async def on_generation_aborted(self) -> None:
         """Hook for loaders whose engine needs cleanup beyond task cancellation

--- a/modelship/infer/llama_server/llama_server_infer.py
+++ b/modelship/infer/llama_server/llama_server_infer.py
@@ -21,9 +21,10 @@ from modelship.openai.chat_utils import (
     ParsedChatOutput,
     UnsupportedContentError,
     build_from_parsed,
-    build_responses_items_from_parsed,
+    build_response_from_parsed,
     encode_chat_sse_chunk,
     normalize_chat_messages,
+    responses_validation_error,
 )
 from modelship.openai.protocol import (
     ChatCompletionLogProbs,
@@ -47,12 +48,8 @@ from modelship.openai.protocol import (
 )
 from modelship.openai.protocol.responses.adapter import (
     UnsupportedResponsesFeatureError,
-    _status_for,
-    _usage_from_chat,
-    build_response_object,
     responses_request_to_chat,
 )
-from modelship.openai.protocol.responses.streaming import ResponsesStreamTranslator
 from modelship.preflight import discover_hardware, merge_with_user_overrides, run_preflight
 from modelship.utils import base_request_id, random_uuid
 
@@ -467,7 +464,7 @@ class LlamaServerInfer(BaseInfer):
         except UnsupportedResponsesFeatureError as e:
             return create_error_response(e)
         except ValidationError as e:
-            return _responses_validation_error(e)
+            return responses_validation_error(e)
 
         request_id = f"resp-{base_request_id(raw_request)}"
         supports_image = bool(self.config.mmproj)
@@ -483,7 +480,7 @@ class LlamaServerInfer(BaseInfer):
         payload = _build_payload(chat_request, messages, model_name=self.model_config.name)
 
         if request.stream:
-            return self._stream_response(payload, request, request_id, raw_request)
+            return self._create_response_stream(payload, request, request_id, raw_request)
 
         try:
             return await self.run_cancellable(self._send_response(payload, request, request_id), raw_request)
@@ -568,45 +565,18 @@ class LlamaServerInfer(BaseInfer):
             if trace:
                 logger.log(TRACE, "chat response %s (stream): %r", request_id, "".join(buffered))
 
-    async def _stream_response(
+    async def _create_response_stream(
         self, payload: dict[str, Any], request: ResponsesRequest, request_id: str, raw_request: RawRequestProxy
     ) -> AsyncGenerator[str, None]:
-        """Race the llama-server SSE stream against the client's disconnect signal —
-        the Responses counterpart of `_stream_chat_completion`."""
-        stream = self._stream_response_body(payload, request, request_id)
-        try:
-            async for chunk in self.run_cancellable_stream(stream, raw_request):
-                yield chunk
-        except ClientDisconnectedError:
-            logger.info("responses request %s aborted: client disconnected", request_id)
-            return
-
-    async def _stream_response_body(
-        self, payload: dict[str, Any], request: ResponsesRequest, request_id: str
-    ) -> AsyncGenerator[str, None]:
-        """Native streaming Responses path: feeds `ResponsesStreamTranslator` directly
+        """Native streaming Responses path: feeds `BaseInfer._stream_responses` directly
         from `_raw_stream_chunks`'s typed chunks, same source `_stream_chat_completion_body`
-        uses — no chat SSE text round trip like the (unused-by-this-loader) `BaseInfer` default."""
+        uses — no chat SSE text round trip."""
         assert self._client is not None
-        translator = ResponsesStreamTranslator(request)
-        for event in translator.start():
-            yield event
-        try:
-            async for chunk in _raw_stream_chunks(
-                self._client, payload, model_name=self.model_config.name, request_id=request_id
-            ):
-                for event in translator.process(chunk):
-                    yield event
-        except _LlamaServerStreamError as e:
-            for event in translator.fail(str(e)):
-                yield event
-            return
-        except httpx.HTTPError as e:
-            logger.warning("responses request %s failed mid-stream: %s", request_id, e)
-            for event in translator.fail(f"llama-server request failed: {e}"):
-                yield event
-            return
-        for event in translator.finish():
+        stream = _raw_stream_chunks(self._client, payload, model_name=self.model_config.name, request_id=request_id)
+        chunks = self.run_cancellable_stream(stream, raw_request)
+        async for event in self._stream_responses(
+            request, chunks, request_id=request_id, client_error=_llama_stream_error
+        ):
             yield event
 
 
@@ -614,13 +584,6 @@ class LlamaServerInfer(BaseInfer):
 # Request / response projection — never relay llama-server's JSON verbatim,
 # it's `extra="allow"`-shaped and would leak extension fields (e.g. `timings`).
 # ---------------------------------------------------------------------------
-
-
-def _responses_validation_error(exc: ValidationError) -> ErrorResponse:
-    # Pydantic ValidationErrors surfaced by responses_request_to_chat (e.g. a
-    # bad reasoning.effort value) — same 400 shape as every other rejection here.
-    base = exc.args[0] if exc.args else str(exc)
-    return create_error_response(message=base, err_type="invalid_request_error")
 
 
 def _redact(args: list[str]) -> list[str]:
@@ -739,13 +702,12 @@ def _project_chat_response(data: dict, *, model_name: str, request_id: str) -> C
 
 def _project_response(data: dict, request: ResponsesRequest, *, model_name: str) -> ResponseObject:
     choices, finish_reasons, _logprobs_list = _parsed_choices_from_data(data)
-    status, incomplete = _status_for(finish_reasons[0] if finish_reasons else None)
-    return build_response_object(
+    parsed = choices[0] if choices else ParsedChatOutput(content=None, reasoning=None)
+    return build_response_from_parsed(
+        parsed,
         request,
-        status=status,
-        output=build_responses_items_from_parsed(choices[0]) if choices else [],
-        usage=_usage_from_chat(_project_usage(data.get("usage"))),
-        incomplete=incomplete,
+        usage=_project_usage(data.get("usage")),
+        finish_reason=finish_reasons[0] if finish_reasons else None,
         model=model_name,
     )
 
@@ -803,12 +765,24 @@ class _LlamaServerStreamError(Exception):
     """
 
 
+def _llama_stream_error(exc: Exception) -> str | None:
+    """`client_error` mapper for `BaseInfer._stream_responses`: both of
+    `_raw_stream_chunks`'s failure modes are client-safe to relay verbatim;
+    anything else falls through to the generic "Internal error during generation"
+    message."""
+    if isinstance(exc, _LlamaServerStreamError):
+        return str(exc)
+    if isinstance(exc, httpx.HTTPError):
+        return f"llama-server request failed: {exc}"
+    return None
+
+
 async def _raw_stream_chunks(
     client: httpx.AsyncClient, payload: dict[str, Any], *, model_name: str, request_id: str
 ) -> AsyncGenerator[ChatCompletionStreamResponse, None]:
     """Open the llama-server SSE stream and yield typed chunks.
 
-    Shared by `_stream_chat_completion_body` (chat) and `_stream_response_body`
+    Shared by `_stream_chat_completion_body` (chat) and `_create_response_stream`
     (Responses) — both need the same parsed chunks, just encoded differently.
     Raises `_LlamaServerStreamError` for a failure after the connection opens
     (HTTP error status, inline `error` field); `httpx.HTTPError` propagates

--- a/modelship/infer/vllm/vllm_infer.py
+++ b/modelship/infer/vllm/vllm_infer.py
@@ -67,9 +67,10 @@ from modelship.metrics import _ENABLED as _METRICS_ENABLED
 from modelship.openai.chat_utils import (
     UnsupportedContentError,
     build_from_parsed,
-    build_responses_items_from_parsed,
+    build_response_from_parsed,
     encode_chat_sse_chunk,
     normalize_chat_messages,
+    responses_validation_error,
 )
 from modelship.openai.protocol import (
     ChatCompletionRequest,
@@ -90,12 +91,8 @@ from modelship.openai.protocol import (
 )
 from modelship.openai.protocol.responses.adapter import (
     UnsupportedResponsesFeatureError,
-    _status_for,
-    _usage_from_chat,
-    build_response_object,
     responses_request_to_chat,
 )
-from modelship.openai.protocol.responses.streaming import ResponsesStreamTranslator
 from modelship.preflight import discover_hardware, merge_with_user_overrides, run_preflight
 from modelship.utils import base_request_id
 
@@ -118,11 +115,14 @@ def _validation_error(exc: VLLMValidationError) -> ErrorResponse:
     )
 
 
-def _responses_validation_error(exc: ValidationError) -> ErrorResponse:
-    # Same shape as _validation_error, for pydantic ValidationErrors surfaced by
-    # responses_request_to_chat (e.g. a bad reasoning.effort value).
-    base = exc.args[0] if exc.args else str(exc)
-    return create_error_response(message=base, err_type="invalid_request_error", status_code=HTTPStatus.BAD_REQUEST)
+def _vllm_stream_error(exc: Exception) -> str | None:
+    """`client_error` mapper for `BaseInfer._stream_responses`: a mid-stream
+    `VLLMValidationError` is client-safe to relay verbatim; anything else falls
+    through to the generic "Internal error during generation" message."""
+    if isinstance(exc, VLLMValidationError):
+        base = exc.args[0] if exc.args else str(exc)
+        return str(base)
+    return None
 
 
 class VllmInfer(BaseInfer):
@@ -549,7 +549,7 @@ class VllmInfer(BaseInfer):
         except UnsupportedResponsesFeatureError as e:
             return create_error_response(e)
         except ValidationError as e:
-            return _responses_validation_error(e)
+            return responses_validation_error(e)
 
         try:
             chat_request.messages = normalize_chat_messages(
@@ -643,19 +643,15 @@ class VllmInfer(BaseInfer):
         prompt_tokens = len(final_res.prompt_token_ids)
         completion_tokens = sum(len(output.token_ids) for output in final_res.outputs)
 
-        status, incomplete = _status_for(finish_reasons[0])
-        return build_response_object(
+        return build_response_from_parsed(
+            choices[0],
             request,
-            status=status,
-            output=build_responses_items_from_parsed(choices[0]),
-            usage=_usage_from_chat(
-                UsageInfo(
-                    prompt_tokens=prompt_tokens,
-                    completion_tokens=completion_tokens,
-                    total_tokens=prompt_tokens + completion_tokens,
-                )
+            usage=UsageInfo(
+                prompt_tokens=prompt_tokens,
+                completion_tokens=completion_tokens,
+                total_tokens=prompt_tokens + completion_tokens,
             ),
-            incomplete=incomplete,
+            finish_reason=finish_reasons[0],
             model=self.model_config.name,
         )
 
@@ -667,9 +663,9 @@ class VllmInfer(BaseInfer):
         sampling_params: SamplingParams,
         raw_request: RawRequestProxy,
     ) -> AsyncGenerator[str, None]:
-        """Native streaming Responses path: feeds `ResponsesStreamTranslator` directly
+        """Native streaming Responses path: feeds `BaseInfer._stream_responses` directly
         from `engine_ops.stream_chat_completion`'s typed chunks — no chat SSE text
-        round trip like the (unused-by-this-loader) `BaseInfer` default."""
+        round trip."""
         request_id = f"resp-{base_request_id(raw_request)}"
         tokenizer = self.openai_serving_render.renderer.tokenizer
         assert tokenizer is not None, "vllm renderer has no tokenizer (skip_tokenizer_init=True is unsupported here)"
@@ -687,27 +683,10 @@ class VllmInfer(BaseInfer):
             want_logprobs=False,
             num_output_top_logprobs=None,
         )
-        translator = ResponsesStreamTranslator(request)
-        for event in translator.start():
-            yield event
-        try:
-            async for chunk in self.run_cancellable_stream(stream, raw_request):
-                for event in translator.process(chunk):
-                    yield event
-        except ClientDisconnectedError:
-            logger.info("responses request %s aborted: client disconnected", request_id)
-            return
-        except VLLMValidationError as exc:
-            base = exc.args[0] if exc.args else str(exc)
-            for event in translator.fail(str(base)):
-                yield event
-            return
-        except Exception:
-            logger.exception("responses request %s failed mid-stream", request_id)
-            for event in translator.fail("Internal error during generation"):
-                yield event
-            return
-        for event in translator.finish():
+        chunks = self.run_cancellable_stream(stream, raw_request)
+        async for event in self._stream_responses(
+            request, chunks, request_id=request_id, client_error=_vllm_stream_error
+        ):
             yield event
 
     async def create_embedding(

--- a/modelship/openai/api.py
+++ b/modelship/openai/api.py
@@ -53,10 +53,6 @@ from modelship.openai.protocol import (
     TranslationResponse,
     create_error_response,
 )
-from modelship.openai.protocol.responses import (
-    UnsupportedResponsesFeatureError,
-    responses_request_to_chat,
-)
 from modelship.utils import random_uuid
 
 logger = get_logger("api")
@@ -549,19 +545,6 @@ class ModelshipAPI:
         req_id = random_uuid()
         self._set_request_id(req_id)
         model = request.model or ""
-        try:
-            # Fail fast on unsupported features before touching Ray. The loader
-            # re-derives its own ChatCompletionRequest from `request` — this call's
-            # result is discarded, it's here purely for the early validation.
-            responses_request_to_chat(request)
-        except UnsupportedResponsesFeatureError as e:
-            return _error_response(create_error_response(e))
-        except ValidationError as e:
-            # Translating into ChatCompletionRequest can surface invalid params
-            # (e.g. a bad reasoning.effort value) as a pydantic ValidationError,
-            # which is not a ValueError — return a 400 rather than a generic 500.
-            return _error_response(_validation_error_from_cause(e))
-
         handle = self._get_handle(request.model)
         watcher = RequestWatcher(raw_request, req_id, model=model, endpoint="create_response")
         headers = dict(raw_request.headers)

--- a/modelship/openai/chat_utils.py
+++ b/modelship/openai/chat_utils.py
@@ -4,15 +4,22 @@ import time
 from dataclasses import dataclass, field
 from typing import Any
 
+from pydantic import ValidationError
+
 from modelship.logging import get_logger
 from modelship.openai.protocol import (
     ChatCompletionResponse,
     ChatCompletionResponseChoice,
     ChatCompletionStreamResponse,
     ChatMessage,
+    ErrorResponse,
+    ResponseObject,
+    ResponsesRequest,
     ToolCall,
     UsageInfo,
 )
+from modelship.openai.protocol.error import create_error_response
+from modelship.openai.protocol.responses.adapter import _status_for, _usage_from_chat, build_response_object
 from modelship.openai.protocol.responses.schemas import (
     ResponseFunctionToolCall,
     ResponseOutputItem,
@@ -306,3 +313,36 @@ def build_responses_items_from_parsed(parsed: ParsedChatOutput) -> list[Response
             )
         )
     return output
+
+
+def build_response_from_parsed(
+    parsed: ParsedChatOutput,
+    request: ResponsesRequest,
+    *,
+    usage: UsageInfo,
+    finish_reason: str | None,
+    model: str,
+) -> ResponseObject:
+    """Build a non-streaming ``ResponseObject`` from one loader's parsed chat output.
+
+    Shared by every loader's non-streaming `create_response`: each shapes its own
+    `ParsedChatOutput` from its native response format, then hands it here for the
+    status/usage/envelope assembly (`build_response_object` + `_status_for` +
+    `_usage_from_chat`) that used to be duplicated per loader.
+    """
+    status, incomplete = _status_for(finish_reason)
+    return build_response_object(
+        request,
+        status=status,
+        output=build_responses_items_from_parsed(parsed),
+        usage=_usage_from_chat(usage),
+        incomplete=incomplete,
+        model=model,
+    )
+
+
+def responses_validation_error(exc: ValidationError) -> ErrorResponse:
+    """400 for a pydantic ``ValidationError`` surfaced by ``responses_request_to_chat``
+    (e.g. a bad ``reasoning.effort`` value) — same shape as every other rejection."""
+    base = exc.args[0] if exc.args else str(exc)
+    return create_error_response(message=base, err_type="invalid_request_error")

--- a/modelship/openai/chat_utils.py
+++ b/modelship/openai/chat_utils.py
@@ -343,6 +343,9 @@ def build_response_from_parsed(
 
 def responses_validation_error(exc: ValidationError) -> ErrorResponse:
     """400 for a pydantic ``ValidationError`` surfaced by ``responses_request_to_chat``
-    (e.g. a bad ``reasoning.effort`` value) — same shape as every other rejection."""
-    base = exc.args[0] if exc.args else str(exc)
-    return create_error_response(message=base, err_type="invalid_request_error")
+    (e.g. a bad ``reasoning.effort`` value) — same shape as every other rejection.
+
+    ``ValidationError.args`` is always empty (pydantic never populates it), so
+    ``str(exc)`` — its full per-field error report — is the message to use.
+    """
+    return create_error_response(message=str(exc), err_type="invalid_request_error")

--- a/tests/test_responses_api.py
+++ b/tests/test_responses_api.py
@@ -1,10 +1,12 @@
 """Route-level tests for /v1/responses.
 
-Since Stage D, the route does no chat<->Responses translation itself (that
-now lives on `BaseInfer.create_response`, either the default Phase A shim or
-a loader's native override) — it only fails fast on unsupported features
-before touching Ray, then hands the original `ResponsesRequest` straight to
-`handle.respond` and threads the result through the shared `_handle_response`.
+The route does no chat<->Responses translation and no pre-validation of its
+own: it hands the original `ResponsesRequest` straight to `handle.respond`
+and threads the result through the shared `_handle_response`, exactly like
+`create_chat_completion`'s route. Feature-support validation (e.g. rejecting
+`previous_response_id`) happens inside the deployment's `create_response` —
+a rejection surfaces here as an ordinary leading `ErrorResponse` from the
+handle, the same path any other loader-side error takes.
 """
 
 import json
@@ -13,7 +15,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from modelship.openai.api import ModelshipAPI
-from modelship.openai.protocol import ResponsesRequest
+from modelship.openai.protocol import ResponsesRequest, create_error_response
 from modelship.openai.protocol.responses import ResponseObject, ResponseOutputMessage, ResponseOutputText, ResponseUsage
 
 _ModelshipAPI = ModelshipAPI.func_or_class
@@ -89,6 +91,19 @@ class TestResponsesRoute:
 
     @pytest.mark.asyncio
     async def test_previous_response_id_rejected_400(self, api):
+        # The deployment rejects unsupported features (its create_response calls
+        # responses_request_to_chat internally); the route just relays whatever
+        # ErrorResponse comes back as the first item from the handle, same as any
+        # other loader-side rejection.
+        handle = MagicMock()
+
+        async def gen():
+            yield create_error_response("previous_response_id is not supported")
+
+        handle.respond.options.return_value.remote.return_value = gen()
+        api.models = {"m": {"m-a1b2c": handle}}
+        api._round_robin = {"m": 0}
+
         request = ResponsesRequest(model="m", input="hi", previous_response_id="resp_1")
         result = await api.create_response(request, _raw_request())
         assert result.status_code == 400
@@ -97,9 +112,18 @@ class TestResponsesRoute:
 
     @pytest.mark.asyncio
     async def test_invalid_param_returns_400_not_500(self, api):
-        # An invalid reasoning.effort fails when constructing the
+        # An invalid reasoning.effort fails when the deployment constructs the
         # ChatCompletionRequest (pydantic ValidationError, not a ValueError);
-        # the route must convert it to a 400, not let it 500.
+        # that must surface as a 400 ErrorResponse, not a 500.
+        handle = MagicMock()
+
+        async def gen():
+            yield create_error_response("bad reasoning.effort value", err_type="invalid_request_error")
+
+        handle.respond.options.return_value.remote.return_value = gen()
+        api.models = {"m": {"m-a1b2c": handle}}
+        api._round_robin = {"m": 0}
+
         request = ResponsesRequest(model="m", input="hi", reasoning={"effort": "turbo"})
         result = await api.create_response(request, _raw_request())
         assert result.status_code == 400


### PR DESCRIPTION
…cycle

vLLM and llama_server each hand-drove ResponsesStreamTranslator and duplicated validation-error shaping and non-stream envelope assembly. Move both into shared helpers (BaseInfer._stream_responses, chat_utils.build_response_from_parsed/responses_validation_error) so each loader only supplies its native chunk source. Also drop the gateway's responses_request_to_chat call that ran purely for early validation and discarded the result, since the loader re-derives it anyway.

