### PR TITLE
feat: expose llama-server prompt-cache tuning flags

### DIFF
--- a/docs/model-configuration.md
+++ b/docs/model-configuration.md
@@ -304,9 +304,12 @@ The `llama_server` loader runs GGUF models by launching a [`llama-server`](https
 | `parallel` | int | `1` | Concurrent request slots (`--parallel`). When `max_ongoing_requests` isn't set explicitly, it defaults to this value so overflow queues in Ray Serve rather than inside llama-server |
 | `chat_template` | string | — | Built-in template name (e.g. `chatml`) or a path to a Jinja file. Omit to use the GGUF's embedded chat template |
 | `mmproj` | string | — | Multimodal projector file/repo ref (e.g. a CLIP model) for vision models — see [Vision](#vision-gguf) below |
+| `cache_reuse` | int | `0` | Min chunk size (tokens) for fuzzy KV-cache reuse via position-shifting (`--cache-reuse`). `0` means exact-prefix reuse only (llama-server's default); raise it to also reuse cached chunks after a mid-prompt divergence — e.g. a changed system-prompt header, or a swapped RAG document, where the surrounding context is unchanged |
+| `context_shift` | bool | `false` | Evict the oldest tokens and keep generating when a slot's context fills, instead of erroring (`--context-shift`) |
+| `cache_ram_mib` | int | `None` (llama-server's own default: `8192`) | In-RAM prompt-cache cap in MiB (`-cram`/`--cache-ram`). `-1` means no limit, `0` disables the cache |
 | `extra_args` | list[string] | `[]` | Escape hatch: extra flags appended verbatim to the `llama-server` launch command |
 
-> **Note:** there is no persistent on-disk prompt cache. llama-server manages request-level prefix caching internally and automatically within its slots, but has no equivalent to modelship's restart-persistent disk cache.
+> **Note on caching:** llama-server caches prompts in RAM by default (`--cache-prompt`, always on; an 8 GiB idle-slot cache via `--cache-ram`) — exact-prefix reuse works out of the box for ordinary append-only chat with no configuration needed. `cache_reuse`, `context_shift`, and `cache_ram_mib` above tune that further. There is still no persistent **on-disk** prompt cache — llama-server's caching is in-memory only and does not survive a process restart, unlike modelship's restart-persistent disk cache for other loaders.
 
 The fool-proof minimum — preflight fills in `n_ctx`, `n_gpu_layers`, and `threads`:
 

--- a/modelship/infer/infer_config.py
+++ b/modelship/infer/infer_config.py
@@ -122,6 +122,18 @@ class LlamaServerConfig(BaseModel):
     chat_template: str | None = None
     # Path to the multimodal projector file (e.g. clip-model-f16.gguf)
     mmproj: str | None = None
+    # Min chunk size for fuzzy KV-cache reuse via position-shifting
+    # (--cache-reuse). 0 (llama-server's default) means exact-prefix reuse
+    # only; raising it also reuses cached chunks after a mid-prompt
+    # divergence (e.g. a changed system-prompt header, a swapped RAG chunk).
+    cache_reuse: int = Field(default=0, ge=0)
+    # Evict the oldest tokens and keep generating when a slot's context
+    # fills, instead of erroring (--context-shift). Off by default, matching
+    # llama-server's own default.
+    context_shift: bool = False
+    # In-RAM prompt-cache cap in MiB (-cram). None keeps llama-server's own
+    # default (8192); -1 means no limit, 0 disables the cache.
+    cache_ram_mib: int | None = Field(default=None, ge=-1)
     # Escape hatch for launch flags not otherwise surfaced, appended verbatim.
     extra_args: list[str] = Field(default_factory=list)
 

--- a/modelship/infer/llama_server/llama_server_infer.py
+++ b/modelship/infer/llama_server/llama_server_infer.py
@@ -255,6 +255,12 @@ class LlamaServerInfer(BaseInfer):
             args += ["--mmproj", self.config.mmproj]
         if self.model_config.usecase == ModelUsecase.embed:
             args += ["--embedding"]
+        if self.config.cache_reuse > 0:
+            args += ["--cache-reuse", str(self.config.cache_reuse)]
+        if self.config.context_shift:
+            args += ["--context-shift"]
+        if self.config.cache_ram_mib is not None:
+            args += ["--cache-ram", str(self.config.cache_ram_mib)]
         args += list(self.config.extra_args)
 
         logger.info("llama-server launch args for '%s': %s", self.model_config.name, _redact(args))

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -24,6 +24,9 @@ class TestLlamaServerConfig:
         assert config.threads is None
         assert config.parallel == 1
         assert config.chat_template is None
+        assert config.cache_reuse == 0
+        assert config.context_shift is False
+        assert config.cache_ram_mib is None
         assert config.extra_args == []
 
     def test_custom_values(self):
@@ -34,6 +37,9 @@ class TestLlamaServerConfig:
             threads=8,
             parallel=4,
             chat_template="chatml",
+            cache_reuse=256,
+            context_shift=True,
+            cache_ram_mib=4096,
             extra_args=["--flash-attn"],
         )
         assert config.n_ctx == 4096
@@ -42,6 +48,9 @@ class TestLlamaServerConfig:
         assert config.threads == 8
         assert config.parallel == 4
         assert config.chat_template == "chatml"
+        assert config.cache_reuse == 256
+        assert config.context_shift is True
+        assert config.cache_ram_mib == 4096
         assert config.extra_args == ["--flash-attn"]
 
     def _num_gpus_model(self, num_gpus: float) -> ModelshipModelConfig:

--- a/tests/test_llama_server_infer.py
+++ b/tests/test_llama_server_infer.py
@@ -171,6 +171,50 @@ class TestSubprocessLifecycle:
             infer_set.shutdown()
 
     @pytest.mark.asyncio
+    async def test_cache_flags_absent_at_defaults(self, tmp_path, monkeypatch):
+        binary = _write_fake_executable(tmp_path, _FAKE_HEALTHY_SERVER)
+        monkeypatch.setenv("MSHIP_LLAMA_SERVER_BIN", binary)
+
+        infer = LlamaServerInfer(_make_config())
+        await infer.start()
+        try:
+            args = list(infer._proc.args)
+            assert "--cache-reuse" not in args
+            assert "--context-shift" not in args
+            assert "--cache-ram" not in args
+        finally:
+            infer.shutdown()
+
+    @pytest.mark.asyncio
+    async def test_cache_flags_appear_when_set(self, tmp_path, monkeypatch):
+        binary = _write_fake_executable(tmp_path, _FAKE_HEALTHY_SERVER)
+        monkeypatch.setenv("MSHIP_LLAMA_SERVER_BIN", binary)
+
+        infer = LlamaServerInfer(_make_config(cache_reuse=256, context_shift=True, cache_ram_mib=4096))
+        await infer.start()
+        try:
+            args = list(infer._proc.args)
+            assert args[args.index("--cache-reuse") + 1] == "256"
+            assert "--context-shift" in args
+            assert args[args.index("--cache-ram") + 1] == "4096"
+        finally:
+            infer.shutdown()
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("cache_ram_mib", [0, -1])
+    async def test_cache_ram_flag_appears_for_zero_and_no_limit(self, tmp_path, monkeypatch, cache_ram_mib):
+        binary = _write_fake_executable(tmp_path, _FAKE_HEALTHY_SERVER)
+        monkeypatch.setenv("MSHIP_LLAMA_SERVER_BIN", binary)
+
+        infer = LlamaServerInfer(_make_config(cache_ram_mib=cache_ram_mib))
+        await infer.start()
+        try:
+            args = list(infer._proc.args)
+            assert args[args.index("--cache-ram") + 1] == str(cache_ram_mib)
+        finally:
+            infer.shutdown()
+
+    @pytest.mark.asyncio
     async def test_immediate_crash_retries_then_raises(self, tmp_path, monkeypatch):
         binary = _write_fake_executable(tmp_path, _FAKE_CRASHING_SERVER)
         monkeypatch.setenv("MSHIP_LLAMA_SERVER_BIN", binary)


### PR DESCRIPTION
Add cache_reuse, context_shift, and cache_ram_mib to LlamaServerConfig, wired through to llama-server's --cache-reuse, --context-shift, and --cache-ram launch flags. Defaults match llama-server's own defaults, so existing deploys are unaffected.

