### PR TITLE
refactor: split deploy coordinator into mutex and replica-routing actors

### DIFF
--- a/modelship/deploy/serve_utils.py
+++ b/modelship/deploy/serve_utils.py
@@ -56,15 +56,15 @@ def delete_apps_quietly(app_names) -> None:
             logger.exception("Failed to delete deployment: %s", name)
 
 
-def remove_apps(app_names: list[str], coordinator, gateway_name: str) -> None:
-    """Drop the given deployment apps from the coordinator's ownership registry
+def remove_apps(app_names: list[str], replica_coordinator, gateway_name: str) -> None:
+    """Drop the given deployment apps from the replica coordinator's ownership registry
     (which bumps the gateway generation so every replica's watch loop stops routing
     to them), then delete them from Ray Serve (`serve.delete` drains in-flight
     requests first)."""
     if not app_names:
         return
     try:
-        ray.get([coordinator.unregister_deployment.remote(gateway_name, a) for a in app_names])
+        ray.get([replica_coordinator.unregister_deployment.remote(gateway_name, a) for a in app_names])
     except Exception:
         logger.exception("Failed to drop deployments from registry: %s", app_names)
     delete_apps_quietly(app_names)
@@ -228,11 +228,11 @@ def start_gateway(gateway_name: str, serve_logging_config: LoggingConfig) -> Non
     )
 
 
-def seed_expected_models(coordinator, gateway_name: str, yml_conf: ModelshipConfig) -> None:
-    # Record the full desired set on the coordinator (the gateway's readiness
-    # baseline) — already-deployed models also count toward "ready". Bumping the
-    # generation makes every replica adopt it via its watch loop.
+def seed_expected_models(replica_coordinator, gateway_name: str, yml_conf: ModelshipConfig) -> None:
+    # Record the full desired set on the replica coordinator (the gateway's
+    # readiness baseline) — already-deployed models also count toward "ready".
+    # Bumping the generation makes every replica adopt it via its watch loop.
     try:
-        ray.get(coordinator.set_expected.remote(gateway_name, [c.name for c in yml_conf.models]))
+        ray.get(replica_coordinator.set_expected.remote(gateway_name, [c.name for c in yml_conf.models]))
     except Exception:
         logger.exception("Failed to seed expected model list on coordinator (non-fatal).")

--- a/modelship/deploy/strategy.py
+++ b/modelship/deploy/strategy.py
@@ -100,6 +100,7 @@ def compute_deploy_plan(
 class DeployContext:
     plugin_wheels: dict[str, Path]
     coordinator: Any
+    replica_coordinator: Any
     probe: Any
     operator_id: str
     gateway_name: str
@@ -149,11 +150,11 @@ def try_reserve_and_deploy(config: ModelshipModelConfig, ctx: DeployContext) -> 
             route_prefix=None,
         )
         logger.info("Model ready: %s (deployment: %s)", config.name, deployment_name)
-        # Record ownership in the coordinator — the single source of truth. This
-        # bumps the gateway's generation, so every gateway replica's watch loop
+        # Record ownership in the replica coordinator — the single source of truth.
+        # This bumps the gateway's generation, so every gateway replica's watch loop
         # picks the new deployment up (the driver never pushes to replicas directly).
         try:
-            ray.get(ctx.coordinator.register_deployment.remote(ctx.gateway_name, deployment_name, config.name))
+            ray.get(ctx.replica_coordinator.register_deployment.remote(ctx.gateway_name, deployment_name, config.name))
         except Exception:
             logger.exception("Failed to record %s in deploy registry", deployment_name)
         return "deployed", None

--- a/modelship/infer/deploy_coordinator.py
+++ b/modelship/infer/deploy_coordinator.py
@@ -10,7 +10,7 @@ atomic check, so operators never race.
 
 Design:
 
-- `ModelshipDeployCoordinator` is a detached, named Ray actor. The first
+- `DeployCoordinator` is a detached, named Ray actor. The first
   operator to start creates it; subsequent operators look it up by name.
 - Operators reserve via `try_reserve(operator_id, probe, num_gpus, num_cpus)`.
   Granted only when the lock is unheld AND the cluster has the requested
@@ -22,10 +22,14 @@ Design:
   dies — the coordinator sees `RayActorError` and force-releases the lock.
 - Graceful shutdown uses `release(operator_id)` from the operator's
   try/finally, cancelling the liveness watcher cleanly.
+
+The durable per-gateway routing registry that gateway replicas long-poll lives on
+a separate actor, `ReplicaCoordinator` (see `replica_coordinator.py`) — it shares
+this module's namespace but is otherwise independent, so gateway watch traffic
+never contends with this mutex's event loop.
 """
 
 import asyncio
-import contextlib
 import time
 
 import ray
@@ -33,28 +37,19 @@ from ray import exceptions as ray_exceptions
 
 from modelship.logging import get_logger
 from modelship.metrics import (
-    COORDINATOR_GENERATION,
     DEPLOY_LOCK_HELD,
     DEPLOY_RESERVATIONS_TOTAL,
     OPERATOR_FORCE_RELEASE_TOTAL,
 )
-from modelship.state import MemoryStateStore, get_state_store
 
 logger = get_logger("deploy_coordinator")
 
 COORDINATOR_ACTOR_NAME = "modelship-deploy-coordinator"
 COORDINATOR_NAMESPACE = "modelship"
 
-_STATE_KEY = "coordinator/state"
-
 _LIVENESS_POLL_INTERVAL_S = 5.0
 _LIVENESS_CALL_TIMEOUT_S = 3.0
 _LIVENESS_TIMEOUT_STRIKES = 3
-
-# How long a gateway replica's wait_for_change blocks before returning the
-# current generation unchanged. Bounds how long a missed wake / coordinator
-# restart can leave a replica un-reconciled (it re-pulls on every return).
-_WATCH_TIMEOUT_S = 30.0
 
 
 @ray.remote(num_cpus=0)
@@ -72,7 +67,7 @@ class OperatorProbe:
 
 
 @ray.remote(num_cpus=0)
-class ModelshipDeployCoordinator:
+class DeployCoordinator:
     """Cluster-wide mutex + resource-aware admission gate for model deploys."""
 
     def __init__(self):
@@ -81,104 +76,12 @@ class ModelshipDeployCoordinator:
         self._held_since: float = 0.0
         self._watcher_task: asyncio.Task | None = None
         self._fatal_errors: dict[str, str] = {}
-        # Durable ownership registry: gateway_name -> {deployment_name -> model_name}.
-        # The driver writes it on (un)deploy; gateway replicas reconcile their
-        # routing tables from it (see get_routing / wait_for_change), so the driver
-        # never pushes to individual replicas.
-        # _registry and _expected are durable (loaded below, written through on
-        # every change); _generation/_change are ephemeral wakeup state. On a
-        # resurrected coordinator the generation restarts at 0, which the gateway's
-        # wait_for_change already treats as "changed" so replicas re-pull and
-        # reconcile from the reloaded registry.
-        self._store = get_state_store()
-        if isinstance(getattr(self._store, "inner", self._store), MemoryStateStore):
-            # A memory store dies with the actor: a restarted coordinator reloads an
-            # empty registry, and the next deploy (gen advances) re-enables removals
-            # against it — dropping still-healthy models from gateway routing. Fine
-            # single-node; for multi-node/HA set MSHIP_STATE_STORE to file:// or redis://.
-            logger.warning(
-                "Deploy coordinator is backed by a non-durable memory state store; its routing "
-                "registry will be lost on coordinator restart. Set MSHIP_STATE_STORE to file:// "
-                "or redis:// for multi-node/HA."
-            )
-        saved = self._store.get(_STATE_KEY)
-        saved = saved if isinstance(saved, dict) else {}
-        self._registry: dict[str, dict[str, str]] = saved.get("registry") or {}
-        # Per-gateway change notification driving the gateway watch loop: a
-        # monotonic generation bumped on every routing/expected change, plus an
-        # asyncio.Event woken on each bump so a long-polling replica returns at
-        # once. _expected is the desired model set used for gateway readiness.
-        self._generation: dict[str, int] = {}
-        self._expected: dict[str, list[str]] = saved.get("expected") or {}
-        self._change: dict[str, asyncio.Event] = {}
 
     def report_fatal_error(self, deployment_name: str, reason: str) -> None:
         self._fatal_errors[deployment_name] = reason
 
     def pop_fatal_error(self, deployment_name: str) -> str | None:
         return self._fatal_errors.pop(deployment_name, None)
-
-    # --- Routing registry + change notification (drives the gateway watch loop) ---
-    # These are async so every registry / generation / Event mutation runs on the
-    # actor's single event loop, serialised with wait_for_change and race-free.
-
-    def _bump(self, gateway_name: str) -> None:
-        """Advance the gateway's generation and wake any current waiters. The old
-        Event is set (releasing replicas blocked on it) then replaced with a fresh
-        unset Event for the next round."""
-        self._generation[gateway_name] = self._generation.get(gateway_name, 0) + 1
-        COORDINATOR_GENERATION.set(self._generation[gateway_name], tags={"gateway": gateway_name})
-        old = self._change.get(gateway_name)
-        if old is not None:
-            old.set()
-        self._change[gateway_name] = asyncio.Event()
-
-    def _persist(self) -> None:
-        """Write the durable routing state through the StateStore. A no-op for the
-        memory store; for redis/file this is what survives coordinator death."""
-        self._store.set(_STATE_KEY, {"registry": self._registry, "expected": self._expected})
-
-    async def register_deployment(self, gateway_name: str, deployment_name: str, model_name: str) -> None:
-        self._registry.setdefault(gateway_name, {})[deployment_name] = model_name
-        self._persist()
-        self._bump(gateway_name)
-
-    async def unregister_deployment(self, gateway_name: str, deployment_name: str) -> None:
-        gw = self._registry.get(gateway_name)
-        if gw is not None:
-            gw.pop(deployment_name, None)
-            if not gw:
-                del self._registry[gateway_name]
-        self._persist()
-        self._bump(gateway_name)
-
-    async def set_expected(self, gateway_name: str, names: list[str]) -> None:
-        """Record the desired model set for readiness; bumps so replicas adopt it."""
-        self._expected[gateway_name] = list(names)
-        self._persist()
-        self._bump(gateway_name)
-
-    async def get_routing(self, gateway_name: str) -> dict:
-        """Snapshot a replica pulls after a change: the app->model map, the
-        expected-model set, and the current generation."""
-        return {
-            "models": dict(self._registry.get(gateway_name, {})),
-            "expected": list(self._expected.get(gateway_name, [])),
-            "generation": self._generation.get(gateway_name, 0),
-        }
-
-    async def wait_for_change(self, gateway_name: str, since_gen: int, timeout: float = _WATCH_TIMEOUT_S) -> int:
-        """Long-poll for a routing change. Returns the current generation at once
-        if it differs from since_gen (covers both a forward bump and a coordinator
-        restart that reset it to 0); otherwise waits for the next bump up to
-        timeout, then returns the current generation regardless."""
-        current = self._generation.get(gateway_name, 0)
-        if current != since_gen:
-            return current
-        event = self._change.setdefault(gateway_name, asyncio.Event())
-        with contextlib.suppress(TimeoutError):
-            await asyncio.wait_for(event.wait(), timeout)
-        return self._generation.get(gateway_name, 0)
 
     async def try_reserve(
         self,
@@ -290,7 +193,7 @@ def get_or_create_coordinator():
     except ValueError:
         pass
     try:
-        return ModelshipDeployCoordinator.options(
+        return DeployCoordinator.options(
             name=COORDINATOR_ACTOR_NAME,
             namespace=COORDINATOR_NAMESPACE,
             lifetime="detached",

--- a/modelship/infer/replica_coordinator.py
+++ b/modelship/infer/replica_coordinator.py
@@ -62,13 +62,15 @@ class ReplicaCoordinator:
             )
         saved = self._store.get(_STATE_KEY)
         saved = saved if isinstance(saved, dict) else {}
-        self._registry: dict[str, dict[str, str]] = saved.get("registry") or {}
+        registry = saved.get("registry")
+        self._registry: dict[str, dict[str, str]] = registry if isinstance(registry, dict) else {}
         # Per-gateway change notification driving the gateway watch loop: a
         # monotonic generation bumped on every routing/expected change, plus an
         # asyncio.Event woken on each bump so a long-polling replica returns at
         # once. _expected is the desired model set used for gateway readiness.
         self._generation: dict[str, int] = {}
-        self._expected: dict[str, list[str]] = saved.get("expected") or {}
+        expected = saved.get("expected")
+        self._expected: dict[str, list[str]] = expected if isinstance(expected, dict) else {}
         self._change: dict[str, asyncio.Event] = {}
 
     # These are async so every registry / generation / Event mutation runs on the

--- a/modelship/infer/replica_coordinator.py
+++ b/modelship/infer/replica_coordinator.py
@@ -1,0 +1,151 @@
+"""Cluster-wide routing registry shared by every gateway replica.
+
+`ReplicaCoordinator` is a detached, named Ray actor holding the durable mapping of
+model deployments each gateway owns. `mship_deploy.py` writes to it as models are
+(un)deployed; every gateway replica long-polls `wait_for_change` and reconciles its
+own routing table from `get_routing` — the driver never pushes to individual
+replicas.
+
+The registry is persisted through `get_state_store()` (file/redis for multi-node
+HA) so a resurrected actor reloads live ownership instead of starting empty. The
+per-gateway generation counter and its wakeup `asyncio.Event` are ephemeral: on
+restart the generation resets to 0, which `wait_for_change` already treats as
+"changed" so replicas re-pull and reconcile from the reloaded registry.
+"""
+
+import asyncio
+import contextlib
+
+import ray
+
+from modelship.infer.deploy_coordinator import COORDINATOR_NAMESPACE
+from modelship.logging import get_logger
+from modelship.metrics import COORDINATOR_GENERATION
+from modelship.state import MemoryStateStore, get_state_store
+
+logger = get_logger("replica_coordinator")
+
+REPLICA_COORDINATOR_ACTOR_NAME = "modelship-replica-coordinator"
+
+_STATE_KEY = "coordinator/state"
+
+# How long a gateway replica's wait_for_change blocks before returning the
+# current generation unchanged. Bounds how long a missed wake / coordinator
+# restart can leave a replica un-reconciled (it re-pulls on every return).
+_WATCH_TIMEOUT_S = 30.0
+
+
+@ray.remote(num_cpus=0)
+class ReplicaCoordinator:
+    """Durable per-gateway routing registry with long-poll change notification."""
+
+    def __init__(self):
+        # Durable ownership registry: gateway_name -> {deployment_name -> model_name}.
+        # The driver writes it on (un)deploy; gateway replicas reconcile their
+        # routing tables from it (see get_routing / wait_for_change), so the driver
+        # never pushes to individual replicas.
+        # _registry and _expected are durable (loaded below, written through on
+        # every change); _generation/_change are ephemeral wakeup state. On a
+        # resurrected coordinator the generation restarts at 0, which the gateway's
+        # wait_for_change already treats as "changed" so replicas re-pull and
+        # reconcile from the reloaded registry.
+        self._store = get_state_store()
+        if isinstance(getattr(self._store, "inner", self._store), MemoryStateStore):
+            # A memory store dies with the actor: a restarted coordinator reloads an
+            # empty registry, and the next deploy (gen advances) re-enables removals
+            # against it — dropping still-healthy models from gateway routing. Fine
+            # single-node; for multi-node/HA set MSHIP_STATE_STORE to file:// or redis://.
+            logger.warning(
+                "Replica coordinator is backed by a non-durable memory state store; its routing "
+                "registry will be lost on coordinator restart. Set MSHIP_STATE_STORE to file:// "
+                "or redis:// for multi-node/HA."
+            )
+        saved = self._store.get(_STATE_KEY)
+        saved = saved if isinstance(saved, dict) else {}
+        self._registry: dict[str, dict[str, str]] = saved.get("registry") or {}
+        # Per-gateway change notification driving the gateway watch loop: a
+        # monotonic generation bumped on every routing/expected change, plus an
+        # asyncio.Event woken on each bump so a long-polling replica returns at
+        # once. _expected is the desired model set used for gateway readiness.
+        self._generation: dict[str, int] = {}
+        self._expected: dict[str, list[str]] = saved.get("expected") or {}
+        self._change: dict[str, asyncio.Event] = {}
+
+    # These are async so every registry / generation / Event mutation runs on the
+    # actor's single event loop, serialised with wait_for_change and race-free.
+
+    def _bump(self, gateway_name: str) -> None:
+        """Advance the gateway's generation and wake any current waiters. The old
+        Event is set (releasing replicas blocked on it) then replaced with a fresh
+        unset Event for the next round."""
+        self._generation[gateway_name] = self._generation.get(gateway_name, 0) + 1
+        COORDINATOR_GENERATION.set(self._generation[gateway_name], tags={"gateway": gateway_name})
+        old = self._change.get(gateway_name)
+        if old is not None:
+            old.set()
+        self._change[gateway_name] = asyncio.Event()
+
+    def _persist(self) -> None:
+        """Write the durable routing state through the StateStore. A no-op for the
+        memory store; for redis/file this is what survives coordinator death."""
+        self._store.set(_STATE_KEY, {"registry": self._registry, "expected": self._expected})
+
+    async def register_deployment(self, gateway_name: str, deployment_name: str, model_name: str) -> None:
+        self._registry.setdefault(gateway_name, {})[deployment_name] = model_name
+        self._persist()
+        self._bump(gateway_name)
+
+    async def unregister_deployment(self, gateway_name: str, deployment_name: str) -> None:
+        gw = self._registry.get(gateway_name)
+        if gw is not None:
+            gw.pop(deployment_name, None)
+            if not gw:
+                del self._registry[gateway_name]
+        self._persist()
+        self._bump(gateway_name)
+
+    async def set_expected(self, gateway_name: str, names: list[str]) -> None:
+        """Record the desired model set for readiness; bumps so replicas adopt it."""
+        self._expected[gateway_name] = list(names)
+        self._persist()
+        self._bump(gateway_name)
+
+    async def get_routing(self, gateway_name: str) -> dict:
+        """Snapshot a replica pulls after a change: the app->model map, the
+        expected-model set, and the current generation."""
+        return {
+            "models": dict(self._registry.get(gateway_name, {})),
+            "expected": list(self._expected.get(gateway_name, [])),
+            "generation": self._generation.get(gateway_name, 0),
+        }
+
+    async def wait_for_change(self, gateway_name: str, since_gen: int, timeout: float = _WATCH_TIMEOUT_S) -> int:
+        """Long-poll for a routing change. Returns the current generation at once
+        if it differs from since_gen (covers both a forward bump and a coordinator
+        restart that reset it to 0); otherwise waits for the next bump up to
+        timeout, then returns the current generation regardless."""
+        current = self._generation.get(gateway_name, 0)
+        if current != since_gen:
+            return current
+        event = self._change.setdefault(gateway_name, asyncio.Event())
+        with contextlib.suppress(TimeoutError):
+            await asyncio.wait_for(event.wait(), timeout)
+        return self._generation.get(gateway_name, 0)
+
+
+def get_or_create_replica_coordinator():
+    """Return the cluster-wide replica-routing coordinator handle, creating it if absent."""
+    try:
+        return ray.get_actor(REPLICA_COORDINATOR_ACTOR_NAME, namespace=COORDINATOR_NAMESPACE)
+    except ValueError:
+        pass
+    try:
+        return ReplicaCoordinator.options(
+            name=REPLICA_COORDINATOR_ACTOR_NAME,
+            namespace=COORDINATOR_NAMESPACE,
+            lifetime="detached",
+            num_cpus=0,
+            max_restarts=-1,
+        ).remote()
+    except ValueError:
+        return ray.get_actor(REPLICA_COORDINATOR_ACTOR_NAME, namespace=COORDINATOR_NAMESPACE)

--- a/modelship/openai/api.py
+++ b/modelship/openai/api.py
@@ -17,7 +17,7 @@ from ray.serve.handle import DeploymentHandle, DeploymentResponseGenerator
 from starlette.middleware.base import BaseHTTPMiddleware
 from starlette.types import ASGIApp
 
-from modelship.infer import deploy_coordinator
+from modelship.infer import replica_coordinator
 from modelship.infer.infer_config import RequestWatcher
 from modelship.logging import configure_logging, get_logger
 from modelship.metrics import (
@@ -179,7 +179,7 @@ class ModelshipAPI:
         # every replica — including restarted / autoscaled ones — converges.
         self._gen = 0  # last coordinator generation this replica reconciled to
         self._watch_task: asyncio.Task | None = None
-        self._coordinator = None  # cached coordinator handle
+        self._replica_coord = None  # cached replica-coordinator handle
         # Timing state — the first sync with a non-empty expected set stamps a start;
         # each model's first appearance records the gap since the previous arrival as
         # an approximate load duration.
@@ -281,18 +281,18 @@ class ModelshipAPI:
         GATEWAY_ROUTING_GENERATION.set(new_gen)
 
     def _coord(self):
-        if self._coordinator is None:
-            self._coordinator = deploy_coordinator.get_or_create_coordinator()
-        return self._coordinator
+        if self._replica_coord is None:
+            self._replica_coord = replica_coordinator.get_or_create_replica_coordinator()
+        return self._replica_coord
 
     async def _coord_async(self):
-        """Resolve (and cache) the coordinator handle without blocking the event loop.
-        Cached fast path is a no-op; only after a reset (coordinator restart) does this
-        do work, and get_or_create's synchronous ray.get_actor can stall on a
+        """Resolve (and cache) the replica-coordinator handle without blocking the event
+        loop. Cached fast path is a no-op; only after a reset (coordinator restart) does
+        this do work, and get_or_create's synchronous ray.get_actor can stall on a
         recovering GCS — so hop it to a thread to keep concurrent requests flowing."""
-        if self._coordinator is None:
-            self._coordinator = await asyncio.to_thread(deploy_coordinator.get_or_create_coordinator)
-        return self._coordinator
+        if self._replica_coord is None:
+            self._replica_coord = await asyncio.to_thread(replica_coordinator.get_or_create_replica_coordinator)
+        return self._replica_coord
 
     def _ensure_watching(self) -> None:
         """First-request hook: do one synchronous sync so this request isn't blocked
@@ -312,7 +312,7 @@ class ModelshipAPI:
         try:
             snapshot = cast(dict, ray.get(self._coord().get_routing.remote(self._gateway_name)))
         except Exception:
-            self._coordinator = None  # re-resolve next time in case the handle went stale
+            self._replica_coord = None  # re-resolve next time in case the handle went stale
             logger.debug("gateway: initial routing sync deferred; coordinator unavailable", exc_info=True)
             return False
         try:
@@ -338,7 +338,7 @@ class ModelshipAPI:
             except asyncio.CancelledError:
                 return
             except Exception:
-                self._coordinator = None
+                self._replica_coord = None
                 GATEWAY_WATCH_ERRORS_TOTAL.inc()
                 logger.debug("gateway: watch iteration failed; retrying", exc_info=True)
                 await asyncio.sleep(_WATCH_RETRY_S)

--- a/mship_deploy.py
+++ b/mship_deploy.py
@@ -60,6 +60,7 @@ from modelship.deploy.serve_utils import (  # noqa: E402
 )
 from modelship.deploy.strategy import DeployContext, compute_deploy_plan, run_deploy_loop  # noqa: E402
 from modelship.infer.deploy_coordinator import OperatorProbe, get_or_create_coordinator  # noqa: E402
+from modelship.infer.replica_coordinator import get_or_create_replica_coordinator  # noqa: E402
 from modelship.logging import configure_logging, get_lib_log_config, get_logger  # noqa: E402
 from modelship.metrics import DEPLOY_DURATION_SECONDS, DEPLOY_MODELS_CHANGED_TOTAL  # noqa: E402
 from modelship.state import get_state_store  # noqa: E402
@@ -125,9 +126,11 @@ def main(argv: list[str] | None = None) -> None:
 
     plugin_wheels = resolve_all_plugin_wheels(yml_conf)
 
-    # The detached coordinator holds the cross-operator deploy lock and the durable
-    # ownership registry (used for the deploy lock + gateway-restart self-heal).
+    # The detached coordinator holds the cross-operator deploy lock; the detached
+    # replica coordinator holds the durable ownership registry (used for
+    # gateway-restart self-heal).
     coordinator = get_or_create_coordinator()
+    replica_coord = get_or_create_replica_coordinator()
     # Scope reconcile-removal to deployments this gateway's effective set managed
     # BEFORE this run, so a fresh/empty effective config (e.g. migration over
     # pre-existing live models) removes nothing.
@@ -168,7 +171,7 @@ def main(argv: list[str] | None = None) -> None:
         # AFTER the gateway is up so /health and /readyz answer during downloads.
         resolve_all_model_sources(yml_conf)
 
-        seed_expected_models(coordinator, gateway_name, yml_conf)
+        seed_expected_models(replica_coord, gateway_name, yml_conf)
 
         # Purge registry entries for previously-effective deployments that are no
         # longer desired and have no live Serve app (e.g. resurrected from the
@@ -178,7 +181,7 @@ def main(argv: list[str] | None = None) -> None:
         if plan.registry_only_drop:
             try:
                 ray.get(
-                    [coordinator.unregister_deployment.remote(gateway_name, name) for name in plan.registry_only_drop]
+                    [replica_coord.unregister_deployment.remote(gateway_name, name) for name in plan.registry_only_drop]
                 )
             except Exception:
                 logger.exception("Failed to drop stale registry entries: %s", plan.registry_only_drop)
@@ -187,7 +190,7 @@ def main(argv: list[str] | None = None) -> None:
         # freed resources are available for the deploy loop. Used when the
         # cluster can't fit old + new at the same time.
         if args.replace_strategy == "stop_start":
-            remove_apps(apps_to_remove, coordinator, gateway_name)
+            remove_apps(apps_to_remove, replica_coord, gateway_name)
             apps_to_remove = []
 
         # The probe is driver-owned so Ray force-releases the coordinator lock if
@@ -199,6 +202,7 @@ def main(argv: list[str] | None = None) -> None:
         ctx = DeployContext(
             plugin_wheels=plugin_wheels,
             coordinator=coordinator,
+            replica_coordinator=replica_coord,
             probe=probe,
             operator_id=operator_id,
             gateway_name=gateway_name,
@@ -218,7 +222,7 @@ def main(argv: list[str] | None = None) -> None:
         # round-robins across both old and new handles for the same model,
         # so no requests are lost.
         if apps_to_remove:
-            remove_apps(apps_to_remove, coordinator, gateway_name)
+            remove_apps(apps_to_remove, replica_coord, gateway_name)
 
         # Persist the achieved effective config (desired minus permanently-failed
         # models) so a re-assert after cluster loss restores exactly this set and

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -216,7 +216,7 @@ class TestWatchReconcile:
             "generation": 3,
         }
         with (
-            patch("modelship.infer.deploy_coordinator.get_or_create_coordinator", return_value=MagicMock()),
+            patch("modelship.infer.replica_coordinator.get_or_create_replica_coordinator", return_value=MagicMock()),
             patch("modelship.openai.api.ray.get", return_value=snapshot),
             patch("modelship.openai.api.serve.get_app_handle", return_value=MagicMock()),
         ):
@@ -228,7 +228,7 @@ class TestWatchReconcile:
 
     def test_sync_tolerates_unavailable_coordinator(self, api):
         api._watch_task = None
-        with patch("modelship.infer.deploy_coordinator.get_or_create_coordinator", side_effect=RuntimeError):
+        with patch("modelship.infer.replica_coordinator.get_or_create_replica_coordinator", side_effect=RuntimeError):
             assert api._sync_routing_blocking() is False
         assert api.models == {}
 
@@ -239,7 +239,7 @@ class TestWatchReconcile:
         api._watch_task = None
         snapshot = {"models": {"qwen-aaaaaaaaaa": "qwen"}, "expected": ["qwen"], "generation": 2}
         with (
-            patch("modelship.infer.deploy_coordinator.get_or_create_coordinator", return_value=MagicMock()),
+            patch("modelship.infer.replica_coordinator.get_or_create_replica_coordinator", return_value=MagicMock()),
             patch("modelship.openai.api.ray.get", return_value=snapshot),
             patch("modelship.openai.api.serve.get_app_handle", side_effect=RuntimeError("controller lag")),
         ):
@@ -252,18 +252,20 @@ class TestWatchReconcile:
         # cleared so the next _coord() re-resolves instead of retrying a corpse.
         stale = MagicMock()
         stale.get_routing.remote.side_effect = RuntimeError("actor dead")
-        api._coordinator = stale
+        api._replica_coord = stale
         with patch("modelship.openai.api.ray.get", side_effect=RuntimeError("actor dead")):
             assert api._sync_routing_blocking() is False
-        assert api._coordinator is None
+        assert api._replica_coord is None
 
     @pytest.mark.asyncio
     async def test_coord_async_resolves_off_thread_and_caches(self, api):
         # The watch loop resolves the coordinator via asyncio.to_thread (so the sync
         # ray.get_actor never blocks the event loop) and caches the handle.
-        api._coordinator = None
+        api._replica_coord = None
         sentinel = MagicMock()
-        with patch("modelship.infer.deploy_coordinator.get_or_create_coordinator", return_value=sentinel) as goc:
+        with patch(
+            "modelship.infer.replica_coordinator.get_or_create_replica_coordinator", return_value=sentinel
+        ) as goc:
             assert await api._coord_async() is sentinel
             assert await api._coord_async() is sentinel
         goc.assert_called_once()  # second call served from cache, no re-resolve
@@ -274,10 +276,10 @@ class TestWatchReconcile:
         _apply(api, {"qwen-aaaaaaaaaa": "qwen"}, gen=4)
         empty = {"models": {}, "expected": [], "generation": 0}
         with (
-            patch("modelship.infer.deploy_coordinator.get_or_create_coordinator", return_value=MagicMock()),
+            patch("modelship.infer.replica_coordinator.get_or_create_replica_coordinator", return_value=MagicMock()),
             patch("modelship.openai.api.ray.get", return_value=empty),
         ):
-            api._coordinator = None
+            api._replica_coord = None
             assert api._sync_routing_blocking() is True
         assert "qwen" in api.models
 

--- a/tests/test_deploy_coordinator.py
+++ b/tests/test_deploy_coordinator.py
@@ -1,136 +1,21 @@
-"""Tests for the deploy coordinator's routing registry + watch API (the source of
-truth gateway replicas reconcile from). Exercises the undecorated class directly,
-in-process, without a Ray cluster."""
+"""Tests for the deploy coordinator's cross-operator mutex actor factory.
 
-import asyncio
+The routing-registry concern lives on a separate actor (see
+tests/test_replica_coordinator.py); this file only covers what's left on
+DeployCoordinator. The reserve/release/liveness paths currently have no unit
+coverage."""
+
 from unittest.mock import MagicMock, patch
 
-import pytest
-
 from modelship.infer import deploy_coordinator
-from modelship.infer.deploy_coordinator import ModelshipDeployCoordinator
-from modelship.state import MemoryStateStore
-
-# The plain class behind @ray.remote — its async methods are ordinary coroutines.
-_Coord = ModelshipDeployCoordinator.__ray_metadata__.modified_class
 
 
-@pytest.fixture
-def coord():
-    return _Coord()
-
-
-class TestRoutingRegistry:
-    @pytest.mark.asyncio
-    async def test_register_records_and_bumps_generation(self, coord):
-        assert (await coord.get_routing("gw"))["generation"] == 0
-        await coord.register_deployment("gw", "qwen-aaaa", "qwen")
-        routing = await coord.get_routing("gw")
-        assert routing["models"] == {"qwen-aaaa": "qwen"}
-        assert routing["generation"] == 1
-
-    @pytest.mark.asyncio
-    async def test_unregister_removes_and_bumps(self, coord):
-        await coord.register_deployment("gw", "qwen-aaaa", "qwen")
-        await coord.unregister_deployment("gw", "qwen-aaaa")
-        routing = await coord.get_routing("gw")
-        assert routing["models"] == {}
-        assert routing["generation"] == 2
-
-    @pytest.mark.asyncio
-    async def test_set_expected_records_and_bumps(self, coord):
-        await coord.set_expected("gw", ["qwen", "kokoro"])
-        routing = await coord.get_routing("gw")
-        assert routing["expected"] == ["qwen", "kokoro"]
-        assert routing["generation"] == 1
-
-    @pytest.mark.asyncio
-    async def test_generation_is_per_gateway(self, coord):
-        await coord.register_deployment("gw-a", "x-1", "x")
-        assert (await coord.get_routing("gw-a"))["generation"] == 1
-        assert (await coord.get_routing("gw-b"))["generation"] == 0
-
-
-class TestWaitForChange:
-    @pytest.mark.asyncio
-    async def test_returns_immediately_when_already_advanced(self, coord):
-        await coord.register_deployment("gw", "x-1", "x")  # gen -> 1
-        # A caller still at gen 0 must not block — the set already moved.
-        gen = await asyncio.wait_for(coord.wait_for_change("gw", 0), timeout=1)
-        assert gen == 1
-
-    @pytest.mark.asyncio
-    async def test_blocks_then_wakes_on_change(self, coord):
-        async def mutate():
-            await asyncio.sleep(0.05)
-            await coord.register_deployment("gw", "x-1", "x")
-
-        task = asyncio.create_task(mutate())
-        gen = await asyncio.wait_for(coord.wait_for_change("gw", 0), timeout=2)
-        await task
-        assert gen == 1
-
-    @pytest.mark.asyncio
-    async def test_times_out_returning_same_generation(self, coord):
-        gen = await coord.wait_for_change("gw", 0, timeout=0.05)
-        assert gen == 0
-
-    @pytest.mark.asyncio
-    async def test_restart_lower_generation_returns_immediately(self, coord):
-        # Replica last saw gen 5; a restarted coordinator is back at gen 0. Returning
-        # at once (0 != 5) lets the replica re-sync instead of blocking forever.
-        gen = await asyncio.wait_for(coord.wait_for_change("gw", 5), timeout=1)
-        assert gen == 0
-
-    @pytest.mark.asyncio
-    async def test_consecutive_cycles_advance(self, coord):
-        await coord.register_deployment("gw", "x-1", "x")
-        g1 = await asyncio.wait_for(coord.wait_for_change("gw", 0), timeout=1)
-        assert g1 == 1
-        # Subscribe at g1; a second change wakes us with the next generation.
-        waiter = asyncio.create_task(asyncio.wait_for(coord.wait_for_change("gw", g1), timeout=2))
-        await asyncio.sleep(0.05)
-        await coord.set_expected("gw", ["x"])
-        assert await waiter == 2
-
-
-class TestDurableState:
-    """Registry + expected are written through a StateStore so a resurrected
-    coordinator (max_restarts) reloads them instead of coming back empty."""
-
-    @pytest.mark.asyncio
-    async def test_reloads_registry_and_expected_from_shared_store(self):
-        store = MemoryStateStore()  # stand-in for a redis:// store across restarts
-        with patch.object(deploy_coordinator, "get_state_store", return_value=store):
-            first = _Coord()
-            await first.register_deployment("gw", "qwen-aaaa", "qwen")
-            await first.set_expected("gw", ["qwen", "kokoro"])
-
-            # A brand-new coordinator backed by the same store = a resurrected actor.
-            second = _Coord()
-        routing = await second.get_routing("gw")
-        assert routing["models"] == {"qwen-aaaa": "qwen"}
-        assert routing["expected"] == ["qwen", "kokoro"]
-        # Generation is ephemeral — restart resets it to 0 (the gateway treats that
-        # as "changed" and re-pulls).
-        assert routing["generation"] == 0
-
-    @pytest.mark.asyncio
-    async def test_unregister_persists_removal(self):
-        store = MemoryStateStore()
-        with patch.object(deploy_coordinator, "get_state_store", return_value=store):
-            first = _Coord()
-            await first.register_deployment("gw", "qwen-aaaa", "qwen")
-            await first.unregister_deployment("gw", "qwen-aaaa")
-            second = _Coord()
-        assert (await second.get_routing("gw"))["models"] == {}
-
-    def test_get_or_create_sets_max_restarts(self):
-        # Resurrection only helps because the actor auto-restarts; assert the option.
-        with (
-            patch.object(deploy_coordinator.ray, "get_actor", side_effect=ValueError("absent")),
-            patch.object(deploy_coordinator.ModelshipDeployCoordinator, "options") as options,
-        ):
-            options.return_value.remote.return_value = MagicMock()
-            deploy_coordinator.get_or_create_coordinator()
-        assert options.call_args.kwargs["max_restarts"] == -1
+def test_get_or_create_sets_max_restarts():
+    # Resurrection only helps because the actor auto-restarts; assert the option.
+    with (
+        patch.object(deploy_coordinator.ray, "get_actor", side_effect=ValueError("absent")),
+        patch.object(deploy_coordinator.DeployCoordinator, "options") as options,
+    ):
+        options.return_value.remote.return_value = MagicMock()
+        deploy_coordinator.get_or_create_coordinator()
+    assert options.call_args.kwargs["max_restarts"] == -1

--- a/tests/test_mship_deploy.py
+++ b/tests/test_mship_deploy.py
@@ -381,35 +381,36 @@ class TestReservationTotals:
 
 class TestRemoveApps:
     def test_noop_on_empty_list(self):
-        coordinator = MagicMock()
+        replica_coordinator = MagicMock()
         with patch("modelship.deploy.serve_utils.serve.delete") as mock_delete:
-            mship_deploy.remove_apps([], coordinator, "gw")
-        coordinator.unregister_deployment.remote.assert_not_called()
+            mship_deploy.remove_apps([], replica_coordinator, "gw")
+        replica_coordinator.unregister_deployment.remote.assert_not_called()
         mock_delete.assert_not_called()
 
     def test_unregisters_then_deletes(self):
-        coordinator = MagicMock()
+        replica_coordinator = MagicMock()
         apps = ["qwen-aaaaaaaaaa", "kokoro-bbbbbbbbbb"]
         with (
             patch("modelship.deploy.serve_utils.ray.get") as mock_get,
             patch("modelship.deploy.serve_utils.serve.delete") as mock_delete,
         ):
-            mship_deploy.remove_apps(apps, coordinator, "gw")
+            mship_deploy.remove_apps(apps, replica_coordinator, "gw")
 
-        # Each app is dropped from the coordinator registry (which bumps the gateway
-        # generation so replicas stop routing) before serve.delete tears it down.
-        coordinator.unregister_deployment.remote.assert_any_call("gw", "qwen-aaaaaaaaaa")
-        coordinator.unregister_deployment.remote.assert_any_call("gw", "kokoro-bbbbbbbbbb")
+        # Each app is dropped from the replica coordinator's registry (which bumps
+        # the gateway generation so replicas stop routing) before serve.delete tears
+        # it down.
+        replica_coordinator.unregister_deployment.remote.assert_any_call("gw", "qwen-aaaaaaaaaa")
+        replica_coordinator.unregister_deployment.remote.assert_any_call("gw", "kokoro-bbbbbbbbbb")
         mock_get.assert_called_once()  # batched ray.get over the unregister calls
         assert mock_delete.call_args_list == [(("qwen-aaaaaaaaaa",),), (("kokoro-bbbbbbbbbb",),)]
 
     def test_continues_on_serve_delete_error(self):
-        coordinator = MagicMock()
+        replica_coordinator = MagicMock()
         with (
             patch("modelship.deploy.serve_utils.ray.get"),
             patch("modelship.deploy.serve_utils.serve.delete", side_effect=[Exception("gone"), None]) as mock_delete,
         ):
-            mship_deploy.remove_apps(["a-1234567890", "b-1234567890"], coordinator, "gw")
+            mship_deploy.remove_apps(["a-1234567890", "b-1234567890"], replica_coordinator, "gw")
         # Both deletes attempted even though the first raised.
         assert mock_delete.call_count == 2
 

--- a/tests/test_replica_coordinator.py
+++ b/tests/test_replica_coordinator.py
@@ -1,0 +1,136 @@
+"""Tests for the replica coordinator's routing registry + watch API (the source of
+truth gateway replicas reconcile from). Exercises the undecorated class directly,
+in-process, without a Ray cluster."""
+
+import asyncio
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from modelship.infer import replica_coordinator
+from modelship.infer.replica_coordinator import ReplicaCoordinator
+from modelship.state import MemoryStateStore
+
+# The plain class behind @ray.remote — its async methods are ordinary coroutines.
+_Coord = ReplicaCoordinator.__ray_metadata__.modified_class
+
+
+@pytest.fixture
+def coord():
+    return _Coord()
+
+
+class TestRoutingRegistry:
+    @pytest.mark.asyncio
+    async def test_register_records_and_bumps_generation(self, coord):
+        assert (await coord.get_routing("gw"))["generation"] == 0
+        await coord.register_deployment("gw", "qwen-aaaa", "qwen")
+        routing = await coord.get_routing("gw")
+        assert routing["models"] == {"qwen-aaaa": "qwen"}
+        assert routing["generation"] == 1
+
+    @pytest.mark.asyncio
+    async def test_unregister_removes_and_bumps(self, coord):
+        await coord.register_deployment("gw", "qwen-aaaa", "qwen")
+        await coord.unregister_deployment("gw", "qwen-aaaa")
+        routing = await coord.get_routing("gw")
+        assert routing["models"] == {}
+        assert routing["generation"] == 2
+
+    @pytest.mark.asyncio
+    async def test_set_expected_records_and_bumps(self, coord):
+        await coord.set_expected("gw", ["qwen", "kokoro"])
+        routing = await coord.get_routing("gw")
+        assert routing["expected"] == ["qwen", "kokoro"]
+        assert routing["generation"] == 1
+
+    @pytest.mark.asyncio
+    async def test_generation_is_per_gateway(self, coord):
+        await coord.register_deployment("gw-a", "x-1", "x")
+        assert (await coord.get_routing("gw-a"))["generation"] == 1
+        assert (await coord.get_routing("gw-b"))["generation"] == 0
+
+
+class TestWaitForChange:
+    @pytest.mark.asyncio
+    async def test_returns_immediately_when_already_advanced(self, coord):
+        await coord.register_deployment("gw", "x-1", "x")  # gen -> 1
+        # A caller still at gen 0 must not block — the set already moved.
+        gen = await asyncio.wait_for(coord.wait_for_change("gw", 0), timeout=1)
+        assert gen == 1
+
+    @pytest.mark.asyncio
+    async def test_blocks_then_wakes_on_change(self, coord):
+        async def mutate():
+            await asyncio.sleep(0.05)
+            await coord.register_deployment("gw", "x-1", "x")
+
+        task = asyncio.create_task(mutate())
+        gen = await asyncio.wait_for(coord.wait_for_change("gw", 0), timeout=2)
+        await task
+        assert gen == 1
+
+    @pytest.mark.asyncio
+    async def test_times_out_returning_same_generation(self, coord):
+        gen = await coord.wait_for_change("gw", 0, timeout=0.05)
+        assert gen == 0
+
+    @pytest.mark.asyncio
+    async def test_restart_lower_generation_returns_immediately(self, coord):
+        # Replica last saw gen 5; a restarted coordinator is back at gen 0. Returning
+        # at once (0 != 5) lets the replica re-sync instead of blocking forever.
+        gen = await asyncio.wait_for(coord.wait_for_change("gw", 5), timeout=1)
+        assert gen == 0
+
+    @pytest.mark.asyncio
+    async def test_consecutive_cycles_advance(self, coord):
+        await coord.register_deployment("gw", "x-1", "x")
+        g1 = await asyncio.wait_for(coord.wait_for_change("gw", 0), timeout=1)
+        assert g1 == 1
+        # Subscribe at g1; a second change wakes us with the next generation.
+        waiter = asyncio.create_task(asyncio.wait_for(coord.wait_for_change("gw", g1), timeout=2))
+        await asyncio.sleep(0.05)
+        await coord.set_expected("gw", ["x"])
+        assert await waiter == 2
+
+
+class TestDurableState:
+    """Registry + expected are written through a StateStore so a resurrected
+    coordinator (max_restarts) reloads them instead of coming back empty."""
+
+    @pytest.mark.asyncio
+    async def test_reloads_registry_and_expected_from_shared_store(self):
+        store = MemoryStateStore()  # stand-in for a redis:// store across restarts
+        with patch.object(replica_coordinator, "get_state_store", return_value=store):
+            first = _Coord()
+            await first.register_deployment("gw", "qwen-aaaa", "qwen")
+            await first.set_expected("gw", ["qwen", "kokoro"])
+
+            # A brand-new coordinator backed by the same store = a resurrected actor.
+            second = _Coord()
+        routing = await second.get_routing("gw")
+        assert routing["models"] == {"qwen-aaaa": "qwen"}
+        assert routing["expected"] == ["qwen", "kokoro"]
+        # Generation is ephemeral — restart resets it to 0 (the gateway treats that
+        # as "changed" and re-pulls).
+        assert routing["generation"] == 0
+
+    @pytest.mark.asyncio
+    async def test_unregister_persists_removal(self):
+        store = MemoryStateStore()
+        with patch.object(replica_coordinator, "get_state_store", return_value=store):
+            first = _Coord()
+            await first.register_deployment("gw", "qwen-aaaa", "qwen")
+            await first.unregister_deployment("gw", "qwen-aaaa")
+            second = _Coord()
+        assert (await second.get_routing("gw"))["models"] == {}
+
+    def test_get_or_create_sets_max_restarts(self):
+        # Resurrection only helps because the actor auto-restarts; assert the option.
+        with (
+            patch.object(replica_coordinator.ray, "get_actor", side_effect=ValueError("absent")),
+            patch.object(replica_coordinator.ReplicaCoordinator, "options") as options,
+        ):
+            options.return_value.remote.return_value = MagicMock()
+            replica_coordinator.get_or_create_replica_coordinator()
+        assert options.call_args.kwargs["max_restarts"] == -1


### PR DESCRIPTION
Gateway watch-loop traffic (per-replica long-poll) shared an actor and event loop with the low-frequency cross-operator deploy mutex. Splits the routing registry (register/unregister/set_expected/get_routing/ wait_for_change + StateStore persistence) into a new ReplicaCoordinator actor, so gateway replica count no longer contends with deploy locking. No behavior change; DeployCoordinator keeps the mutex/liveness concern.
