### PR TITLE
refactor: prefix all third-party vLLM imports with Vllm/vllm_

### DIFF
--- a/modelship/infer/vllm/capabilities.py
+++ b/modelship/infer/vllm/capabilities.py
@@ -2,7 +2,7 @@
 
 from dataclasses import dataclass
 
-from vllm.config.model import ModelConfig
+from vllm.config.model import ModelConfig as VllmModelConfig
 
 
 @dataclass(frozen=True)
@@ -13,7 +13,7 @@ class VllmCapabilities:
     supports_audio: bool = False  # audio chat input not wired through the vLLM serving_chat path
 
     @classmethod
-    def detect(cls, model_config: ModelConfig) -> "VllmCapabilities":
+    def detect(cls, model_config: VllmModelConfig) -> "VllmCapabilities":
         # vLLM's own ModelConfig inspects the loaded HF config and registry to
         # decide whether the architecture is multimodal — far more reliable than
         # sniffing model names or task strings.

--- a/modelship/infer/vllm/engine_ops.py
+++ b/modelship/infer/vllm/engine_ops.py
@@ -187,7 +187,7 @@ def generate(
 def project_tool_calls(vllm_tool_calls: list[VllmFunctionCall] | None) -> list[ToolCall]:
     """Project a parser's vLLM-shaped tool calls onto modelship's OpenAI `ToolCall`.
 
-    `vllm.parser.VllmParser.parse()`'s `FunctionCall` has the same `id`/`name`/`arguments`
+    `vllm.parser.Parser.parse()`'s `FunctionCall` has the same `id`/`name`/`arguments`
     shape as modelship's own; `id` is only set when the tool_call_id_type config
     minted one (e.g. kimi_k2), so most calls need one generated here.
     """

--- a/modelship/infer/vllm/engine_ops.py
+++ b/modelship/infer/vllm/engine_ops.py
@@ -10,7 +10,7 @@ from collections.abc import AsyncGenerator, Mapping, Sequence
 from typing import Any
 
 from vllm.entrypoints.openai.chat_completion.protocol import (
-    ChatCompletionNamedToolChoiceParam,
+    ChatCompletionNamedToolChoiceParam as VllmChatCompletionNamedToolChoiceParam,
 )
 from vllm.entrypoints.openai.chat_completion.protocol import (
     ChatCompletionRequest as VllmChatCompletionRequest,
@@ -19,16 +19,17 @@ from vllm.entrypoints.openai.engine.protocol import DeltaMessage as VllmDeltaMes
 from vllm.entrypoints.openai.engine.protocol import DeltaToolCall as VllmDeltaToolCall
 from vllm.entrypoints.openai.engine.protocol import ErrorResponse as VllmErrorResponse
 from vllm.entrypoints.openai.engine.protocol import FunctionCall as VllmFunctionCall
-from vllm.entrypoints.serve.render.serving import OpenAIServingRender
-from vllm.entrypoints.serve.utils.api_utils import get_max_tokens
-from vllm.inputs import EngineInput
-from vllm.logprobs import Logprob
-from vllm.outputs import RequestOutput
-from vllm.parser import Parser
-from vllm.renderers.inputs.preprocess import extract_prompt_components, extract_prompt_len
-from vllm.sampling_params import SamplingParams
-from vllm.tokenizers import TokenizerLike
-from vllm.v1.engine.async_llm import AsyncLLM
+from vllm.entrypoints.serve.render.serving import OpenAIServingRender as VllmOpenAIServingRender
+from vllm.entrypoints.serve.utils.api_utils import get_max_tokens as vllm_get_max_tokens
+from vllm.inputs import EngineInput as VllmEngineInput
+from vllm.logprobs import Logprob as VllmLogprob
+from vllm.outputs import RequestOutput as VllmRequestOutput
+from vllm.parser import Parser as VllmParser
+from vllm.renderers.inputs.preprocess import extract_prompt_components as vllm_extract_prompt_components
+from vllm.renderers.inputs.preprocess import extract_prompt_len as vllm_extract_prompt_len
+from vllm.sampling_params import SamplingParams as VllmSamplingParams
+from vllm.tokenizers import TokenizerLike as VllmTokenizerLike
+from vllm.v1.engine.async_llm import AsyncLLM as VllmAsyncLLM
 
 from modelship.openai.chat_utils import ParsedChatOutput
 from modelship.openai.protocol import (
@@ -68,10 +69,10 @@ def build_vllm_request(
 
 
 async def render_and_params(
-    render: OpenAIServingRender,
+    render: VllmOpenAIServingRender,
     vllm_req: VllmChatCompletionRequest,
-) -> tuple[EngineInput, SamplingParams] | VllmErrorResponse:
-    """Render the chat template and derive `SamplingParams`, in that order.
+) -> tuple[VllmEngineInput, VllmSamplingParams] | VllmErrorResponse:
+    """Render the chat template and derive `VllmSamplingParams`, in that order.
 
     `render_chat` mutates `vllm_req` in place as a side effect of rendering
     (`ToolParser.adjust_request` sets `structured_outputs` /
@@ -88,10 +89,10 @@ async def render_and_params(
         raise RuntimeError(f"expected exactly 1 rendered engine prompt for a chat request, got {len(engine_inputs)}")
     engine_input = engine_inputs[0]
 
-    max_tokens = get_max_tokens(
+    max_tokens = vllm_get_max_tokens(
         render.model_config.max_model_len,
         vllm_req.max_completion_tokens if vllm_req.max_completion_tokens is not None else vllm_req.max_tokens,
-        extract_prompt_len(render.model_config, engine_input),
+        vllm_extract_prompt_len(render.model_config, engine_input),
         render.default_sampling_params,
         render.override_max_tokens,
         truncate_prompt_tokens=vllm_req.truncate_prompt_tokens,
@@ -100,21 +101,21 @@ async def render_and_params(
     return engine_input, sampling_params
 
 
-def extract_prompt_token_ids(render: OpenAIServingRender, engine_input: EngineInput) -> list[int]:
+def extract_prompt_token_ids(render: VllmOpenAIServingRender, engine_input: VllmEngineInput) -> list[int]:
     """Extract the rendered prompt's token IDs, needed for `derive_reasoning_ended`."""
-    return list(extract_prompt_components(render.model_config, engine_input).token_ids or [])
+    return list(vllm_extract_prompt_components(render.model_config, engine_input).token_ids or [])
 
 
 def make_parsers(
-    render: OpenAIServingRender,
-    tokenizer: TokenizerLike,
+    render: VllmOpenAIServingRender,
+    tokenizer: VllmTokenizerLike,
     vllm_req: VllmChatCompletionRequest,
     chat_template_kwargs: dict[str, Any] | None,
     n: int,
-) -> list[Parser | None]:
+) -> list[VllmParser | None]:
     """Instantiate one parser per choice.
 
-    Parsers carry per-choice streaming state (`Parser._stream_state`), so a
+    Parsers carry per-choice streaming state (`VllmParser._stream_state`), so a
     request with `n > 1` needs `n` independent instances — sharing one across
     choices corrupts state on every choice after the first. `render.parser`
     is the same class `render_chat` already resolved internally via
@@ -131,7 +132,7 @@ def make_parsers(
 
 def derive_reasoning_ended(
     vllm_req: VllmChatCompletionRequest,
-    parser: Parser | None,
+    parser: VllmParser | None,
     prompt_token_ids: list[int],
 ) -> bool | None:
     """Replicates the reasoning_ended precedence in vLLM's own chat completion serving.
@@ -155,19 +156,19 @@ def derive_reasoning_ended(
 
 
 def generate(
-    engine: AsyncLLM,
-    engine_input: EngineInput,
-    sampling_params: SamplingParams,
+    engine: VllmAsyncLLM,
+    engine_input: VllmEngineInput,
+    sampling_params: VllmSamplingParams,
     request_id: str,
     *,
     reasoning_ended: bool | None,
-    parser: Parser | None,
+    parser: VllmParser | None,
     chat_template_kwargs: dict[str, Any] | None,
     trace_headers: Mapping[str, str] | None = None,
     priority: int = 0,
     data_parallel_rank: int | None = None,
-) -> AsyncGenerator[RequestOutput, None]:
-    """Thin wrapper over `AsyncLLM.generate` — the only place this loader touches the engine directly."""
+) -> AsyncGenerator[VllmRequestOutput, None]:
+    """Thin wrapper over `VllmAsyncLLM.generate` — the only place this loader touches the engine directly."""
     reasoning_parser_kwargs = None
     if parser is not None and parser.reasoning_parser is not None:
         reasoning_parser_kwargs = {"chat_template_kwargs": chat_template_kwargs}
@@ -186,7 +187,7 @@ def generate(
 def project_tool_calls(vllm_tool_calls: list[VllmFunctionCall] | None) -> list[ToolCall]:
     """Project a parser's vLLM-shaped tool calls onto modelship's OpenAI `ToolCall`.
 
-    `vllm.parser.Parser.parse()`'s `FunctionCall` has the same `id`/`name`/`arguments`
+    `vllm.parser.VllmParser.parse()`'s `FunctionCall` has the same `id`/`name`/`arguments`
     shape as modelship's own; `id` is only set when the tool_call_id_type config
     minted one (e.g. kimi_k2), so most calls need one generated here.
     """
@@ -204,7 +205,7 @@ def project_delta_tool_calls(vllm_tool_calls: list[VllmDeltaToolCall]) -> list[D
 
     Unlike `project_tool_calls`, nothing is synthesized here: only the first
     delta for a given tool call carries `id`/`type`/`function.name` (per
-    `Parser.parse_delta`'s own streaming protocol) — later deltas for the same
+    `VllmParser.parse_delta`'s own streaming protocol) — later deltas for the same
     `index` carry only incremental `function.arguments`, which must pass
     through as-is for the client to accumulate correctly.
     """
@@ -225,8 +226,8 @@ def project_delta_tool_calls(vllm_tool_calls: list[VllmDeltaToolCall]) -> list[D
 
 def build_chat_logprobs(
     token_ids: Sequence[int],
-    top_logprobs: Sequence[dict[int, Logprob] | None],
-    tokenizer: TokenizerLike,
+    top_logprobs: Sequence[dict[int, VllmLogprob] | None],
+    tokenizer: VllmTokenizerLike,
     num_output_top_logprobs: int | None,
 ) -> ChatCompletionLogProbs:
     """Project a choice's per-token logprobs onto modelship's OpenAI logprobs shape.
@@ -270,24 +271,24 @@ def build_chat_logprobs(
 
 
 async def consume_final_output(
-    engine: AsyncLLM,
-    engine_input: EngineInput,
-    sampling_params: SamplingParams,
+    engine: VllmAsyncLLM,
+    engine_input: VllmEngineInput,
+    sampling_params: VllmSamplingParams,
     request_id: str,
     *,
     reasoning_ended: bool | None,
-    parser: Parser | None,
+    parser: VllmParser | None,
     chat_template_kwargs: dict[str, Any] | None,
-) -> RequestOutput:
-    """Drive `generate()` to completion and return the final `RequestOutput`.
+) -> VllmRequestOutput:
+    """Drive `generate()` to completion and return the final `VllmRequestOutput`.
 
     Non-streaming only needs the last output (it carries every choice's full
     text). Cancelling the task awaiting this coroutine (e.g. on client
-    disconnect) propagates into the `async for` below and into `AsyncLLM.generate`'s
+    disconnect) propagates into the `async for` below and into `VllmAsyncLLM.generate`'s
     own `except (CancelledError, GeneratorExit): abort(...)` — no separate abort
     call is needed here.
     """
-    final: RequestOutput | None = None
+    final: VllmRequestOutput | None = None
     async for res in generate(
         engine,
         engine_input,
@@ -317,26 +318,26 @@ def _finish_reason_for_choice(
     """
     if not has_tool_calls:
         return engine_finish_reason or "stop"
-    if isinstance(vllm_req.tool_choice, ChatCompletionNamedToolChoiceParam):
+    if isinstance(vllm_req.tool_choice, VllmChatCompletionNamedToolChoiceParam):
         return engine_finish_reason or "stop"
     return "tool_calls"
 
 
 def build_choices(
-    final_res: RequestOutput,
+    final_res: VllmRequestOutput,
     vllm_req: VllmChatCompletionRequest,
-    parser: Parser | None,
-    tokenizer: TokenizerLike,
+    parser: VllmParser | None,
+    tokenizer: VllmTokenizerLike,
     *,
     enable_auto_tools: bool,
     want_logprobs: bool,
     num_output_top_logprobs: int | None,
 ) -> tuple[list[ParsedChatOutput], list[str | None], list[ChatCompletionLogProbs | None]]:
-    """Parse every choice in a finished `RequestOutput` into modelship's response DTOs.
+    """Parse every choice in a finished `VllmRequestOutput` into modelship's response DTOs.
 
     Non-streaming reuses one shared `parser` instance across every choice —
     `.parse()` is stateless per full-text call, unlike the streaming path's
-    per-choice `Parser._stream_state` (see `make_parsers`).
+    per-choice `VllmParser._stream_state` (see `make_parsers`).
     """
     choices: list[ParsedChatOutput] = []
     finish_reasons: list[str | None] = []
@@ -368,21 +369,21 @@ def build_choices(
 
 
 async def stream_chat_completion(
-    engine: AsyncLLM,
-    render: OpenAIServingRender,
+    engine: VllmAsyncLLM,
+    render: VllmOpenAIServingRender,
     vllm_req: VllmChatCompletionRequest,
-    engine_input: EngineInput,
-    sampling_params: SamplingParams,
+    engine_input: VllmEngineInput,
+    sampling_params: VllmSamplingParams,
     request_id: str,
     model_name: str,
-    tokenizer: TokenizerLike,
+    tokenizer: VllmTokenizerLike,
     *,
     enable_auto_tools: bool,
     want_logprobs: bool,
     num_output_top_logprobs: int | None,
 ) -> AsyncGenerator[ChatCompletionStreamResponse, None]:
     """Drive one streaming chat completion end to end: per-choice parsers,
-    per-delta parsing via `Parser.parse_delta`, and the OpenAI streaming
+    per-delta parsing via `VllmParser.parse_delta`, and the OpenAI streaming
     chunk lifecycle (role chunk, content/tool/reasoning deltas, finish
     chunk, optional usage chunk) — the streaming counterpart of `build_choices`.
 
@@ -457,7 +458,7 @@ async def stream_chat_completion(
             previous_num_tokens[i] += len(output.token_ids)
 
             if vllm_delta is None:
-                # Parser swallowed a control token (e.g. a `<think>` marker) with
+                # VllmParser swallowed a control token (e.g. a `<think>` marker) with
                 # nothing yet emittable — skip unless this is the final delta,
                 # which still needs a (possibly empty) delta to carry finish_reason.
                 if output.finish_reason is None:

--- a/modelship/infer/vllm/parsing/detect.py
+++ b/modelship/infer/vllm/parsing/detect.py
@@ -86,9 +86,9 @@ def resolve_tool_parser(cfg: ModelshipModelConfig, template: str | None) -> str 
         logger.info("Tool-call resolution skipped for '%s' (explicit opt-out).", cfg.name)
         return None
 
-    from vllm.tool_parsers import ToolParserManager
+    from vllm.tool_parsers import ToolParserManager as VllmToolParserManager
 
-    registered = set(ToolParserManager.list_registered())
+    registered = set(VllmToolParserManager.list_registered())
 
     explicit = cfg.vllm_engine_kwargs.tool_call_parser
     if explicit is not None:
@@ -132,9 +132,9 @@ def resolve_reasoning_parser(cfg: ModelshipModelConfig, template: str | None) ->
         logger.info("Reasoning resolution skipped for '%s' (explicit opt-out).", cfg.name)
         return None
 
-    from vllm.reasoning import ReasoningParserManager
+    from vllm.reasoning import ReasoningParserManager as VllmReasoningParserManager
 
-    registered = set(ReasoningParserManager.list_registered())
+    registered = set(VllmReasoningParserManager.list_registered())
 
     explicit = cfg.vllm_engine_kwargs.reasoning_parser
     if explicit is not None:

--- a/modelship/infer/vllm/vllm_infer.py
+++ b/modelship/infer/vllm/vllm_infer.py
@@ -249,7 +249,7 @@ class VllmInfer(BaseInfer):
         logger.info("vllm capabilities for '%s': %s", self.model_config.name, self._caps)
 
         await self.init_serving_chat()
-        self.serving_embedding = await self.init_serving_embeding()
+        self.serving_embedding = await self.init_serving_embedding()
         self.serving_transcription = await self.init_serving_transcription()
         self.serving_translation = await self.init_serving_translation()
 
@@ -330,8 +330,8 @@ class VllmInfer(BaseInfer):
             reasoning_parser=reasoning_parser_name,
         )
 
-    async def init_serving_embeding(self) -> VllmServingEmbedding | None:
-        logger.info("init_serving_embeding: %s, %s", self.supported_tasks, self.model_config.usecase)
+    async def init_serving_embedding(self) -> VllmServingEmbedding | None:
+        logger.info("init_serving_embedding: %s, %s", self.supported_tasks, self.model_config.usecase)
         return (
             VllmServingEmbedding(
                 engine_client=self.engine,

--- a/modelship/infer/vllm/vllm_infer.py
+++ b/modelship/infer/vllm/vllm_infer.py
@@ -8,23 +8,23 @@ from fastapi import UploadFile
 from pydantic import ValidationError
 from starlette.requests import Request
 from starlette.responses import Response
-from vllm.config.model import ModelDType
-from vllm.engine.arg_utils import AsyncEngineArgs
-from vllm.entrypoints.chat_utils import ChatTemplateConfig
+from vllm.config.model import ModelDType as VllmModelDType
+from vllm.engine.arg_utils import AsyncEngineArgs as VllmAsyncEngineArgs
+from vllm.entrypoints.chat_utils import ChatTemplateConfig as VllmChatTemplateConfig
 from vllm.entrypoints.openai.chat_completion.protocol import (
     ChatCompletionRequest as VllmChatCompletionRequest,
 )
 from vllm.entrypoints.openai.engine.protocol import (
     ErrorResponse as VllmErrorResponse,
 )
-from vllm.entrypoints.openai.models.protocol import BaseModelPath
-from vllm.entrypoints.openai.models.serving import OpenAIServingModels
+from vllm.entrypoints.openai.models.protocol import BaseModelPath as VllmBaseModelPath
+from vllm.entrypoints.openai.models.serving import OpenAIServingModels as VllmOpenAIServingModels
 from vllm.entrypoints.pooling.embed.protocol import (
     EmbeddingCompletionRequest as VllmEmbeddingCompletionRequest,
 )
-from vllm.entrypoints.pooling.embed.serving import ServingEmbedding
-from vllm.entrypoints.serve.render.serving import OpenAIServingRender
-from vllm.entrypoints.serve.utils.request_logger import RequestLogger
+from vllm.entrypoints.pooling.embed.serving import ServingEmbedding as VllmServingEmbedding
+from vllm.entrypoints.serve.render.serving import OpenAIServingRender as VllmOpenAIServingRender
+from vllm.entrypoints.serve.utils.request_logger import RequestLogger as VllmRequestLogger
 from vllm.entrypoints.speech_to_text.transcription.protocol import (
     TranscriptionRequest as VllmTranscriptionRequest,
 )
@@ -34,7 +34,9 @@ from vllm.entrypoints.speech_to_text.transcription.protocol import (
 from vllm.entrypoints.speech_to_text.transcription.protocol import (
     TranscriptionResponseVerbose as VllmTranscriptionResponseVerbose,
 )
-from vllm.entrypoints.speech_to_text.transcription.serving import OpenAIServingTranscription
+from vllm.entrypoints.speech_to_text.transcription.serving import (
+    OpenAIServingTranscription as VllmOpenAIServingTranscription,
+)
 from vllm.entrypoints.speech_to_text.translation.protocol import (
     TranslationRequest as VllmTranslationRequest,
 )
@@ -44,12 +46,14 @@ from vllm.entrypoints.speech_to_text.translation.protocol import (
 from vllm.entrypoints.speech_to_text.translation.protocol import (
     TranslationResponseVerbose as VllmTranslationResponseVerbose,
 )
-from vllm.entrypoints.speech_to_text.translation.serving import OpenAIServingTranslation
-from vllm.exceptions import VLLMValidationError
-from vllm.inputs import EngineInput
-from vllm.sampling_params import SamplingParams
-from vllm.usage.usage_lib import UsageContext
-from vllm.v1.engine.async_llm import AsyncLLM
+from vllm.entrypoints.speech_to_text.translation.serving import (
+    OpenAIServingTranslation as VllmOpenAIServingTranslation,
+)
+from vllm.exceptions import VLLMValidationError as VllmValidationError
+from vllm.inputs import EngineInput as VllmEngineInput
+from vllm.sampling_params import SamplingParams as VllmSamplingParams
+from vllm.usage.usage_lib import UsageContext as VllmUsageContext
+from vllm.v1.engine.async_llm import AsyncLLM as VllmAsyncLLM
 
 from modelship.infer.base_infer import MINIMAL_WAV, BaseInfer, ClientDisconnectedError
 from modelship.infer.infer_config import (
@@ -103,8 +107,8 @@ def _encode_error(error: ErrorResponse) -> str:
     return f"data: {json.dumps(error.model_dump(mode='json'))}\n\n"
 
 
-def _validation_error(exc: VLLMValidationError) -> ErrorResponse:
-    # VLLMValidationError.__str__ appends "(parameter=..., value=...)"; keep the
+def _validation_error(exc: VllmValidationError) -> ErrorResponse:
+    # VllmValidationError.__str__ appends "(parameter=..., value=...)"; keep the
     # original message and surface the offending field via the OpenAI `param` slot.
     base = exc.args[0] if exc.args else str(exc)
     return create_error_response(
@@ -117,9 +121,9 @@ def _validation_error(exc: VLLMValidationError) -> ErrorResponse:
 
 def _vllm_stream_error(exc: Exception) -> str | None:
     """`client_error` mapper for `BaseInfer._stream_responses`: a mid-stream
-    `VLLMValidationError` is client-safe to relay verbatim; anything else falls
+    `VllmValidationError` is client-safe to relay verbatim; anything else falls
     through to the generic "Internal error during generation" message."""
-    if isinstance(exc, VLLMValidationError):
+    if isinstance(exc, VllmValidationError):
         base = exc.args[0] if exc.args else str(exc)
         return str(base)
     return None
@@ -182,12 +186,12 @@ class VllmInfer(BaseInfer):
         if self.vllm_engine_kwargs.mm_processor_kwargs is not None:
             mm_kwargs["mm_processor_kwargs"] = self.vllm_engine_kwargs.mm_processor_kwargs
 
-        engine_args = AsyncEngineArgs(
+        engine_args = VllmAsyncEngineArgs(
             model=self.vllm_engine_kwargs.model,
             tensor_parallel_size=self.vllm_engine_kwargs.tensor_parallel_size,
             pipeline_parallel_size=self.vllm_engine_kwargs.pipeline_parallel_size,
             max_model_len=cast("int", self.vllm_engine_kwargs.max_model_len),
-            dtype=cast("ModelDType", self.vllm_engine_kwargs.dtype),
+            dtype=cast("VllmModelDType", self.vllm_engine_kwargs.dtype),
             tokenizer=self.vllm_engine_kwargs.tokenizer,
             trust_remote_code=self.vllm_engine_kwargs.trust_remote_code,
             gpu_memory_utilization=cast("float", self.vllm_engine_kwargs.gpu_memory_utilization),
@@ -205,16 +209,16 @@ class VllmInfer(BaseInfer):
             **mm_kwargs,
         )
 
-        usage_context = UsageContext.OPENAI_API_SERVER
+        usage_context = VllmUsageContext.OPENAI_API_SERVER
         vllm_config = engine_args.create_engine_config(usage_context=usage_context)
 
         stat_loggers: list | None = None
         if _METRICS_ENABLED:
-            from vllm.v1.metrics.ray_wrappers import RayPrometheusStatLogger
+            from vllm.v1.metrics.ray_wrappers import RayPrometheusStatLogger as VllmRayPrometheusStatLogger
 
-            stat_loggers = [RayPrometheusStatLogger]
+            stat_loggers = [VllmRayPrometheusStatLogger]
 
-        self.engine = AsyncLLM.from_vllm_config(
+        self.engine = VllmAsyncLLM.from_vllm_config(
             vllm_config=vllm_config,
             usage_context=usage_context,
             stat_loggers=stat_loggers,
@@ -301,9 +305,9 @@ class VllmInfer(BaseInfer):
         if not (self.model_config.usecase is ModelUsecase.generate and "generate" in self.supported_tasks):
             return
 
-        models = OpenAIServingModels(
+        models = VllmOpenAIServingModels(
             engine_client=self.engine,
-            base_model_paths=[BaseModelPath(name=self.model_config.name, model_path=self.vllm_engine_kwargs.model)],
+            base_model_paths=[VllmBaseModelPath(name=self.model_config.name, model_path=self.vllm_engine_kwargs.model)],
         )
 
         # get_chat_template isn't in vLLM's TokenizerLike protocol (it's a plain
@@ -314,11 +318,11 @@ class VllmInfer(BaseInfer):
         reasoning_parser_name = resolve_reasoning_parser(self.model_config, template) or ""
 
         self._enable_auto_tools = enable_tools
-        self.openai_serving_render = OpenAIServingRender(
+        self.openai_serving_render = VllmOpenAIServingRender(
             model_config=self.engine.model_config,
             renderer=self.engine.renderer,
             model_registry=models.registry,
-            request_logger=RequestLogger(max_log_len=None),
+            request_logger=VllmRequestLogger(max_log_len=None),
             chat_template=None,
             chat_template_content_format=self.vllm_engine_kwargs.chat_template_content_format,
             enable_auto_tools=enable_tools,
@@ -326,55 +330,55 @@ class VllmInfer(BaseInfer):
             reasoning_parser=reasoning_parser_name,
         )
 
-    async def init_serving_embeding(self) -> ServingEmbedding | None:
+    async def init_serving_embeding(self) -> VllmServingEmbedding | None:
         logger.info("init_serving_embeding: %s, %s", self.supported_tasks, self.model_config.usecase)
         return (
-            ServingEmbedding(
+            VllmServingEmbedding(
                 engine_client=self.engine,
-                models=OpenAIServingModels(
+                models=VllmOpenAIServingModels(
                     engine_client=self.engine,
                     base_model_paths=[
-                        BaseModelPath(name=self.model_config.name, model_path=self.vllm_engine_kwargs.model)
+                        VllmBaseModelPath(name=self.model_config.name, model_path=self.vllm_engine_kwargs.model)
                     ],
                 ),
-                request_logger=RequestLogger(max_log_len=None),
-                chat_template_config=ChatTemplateConfig(chat_template=None, chat_template_content_format="auto"),
+                request_logger=VllmRequestLogger(max_log_len=None),
+                chat_template_config=VllmChatTemplateConfig(chat_template=None, chat_template_content_format="auto"),
             )
             if self.model_config.usecase is ModelUsecase.embed
             and any(task in self.supported_tasks for task in ["embed", "embedding"])
             else None
         )
 
-    async def init_serving_transcription(self) -> OpenAIServingTranscription | None:
+    async def init_serving_transcription(self) -> VllmOpenAIServingTranscription | None:
         logger.info("init_serving_transcription: %s, %s", self.supported_tasks, self.model_config.usecase)
         return (
-            OpenAIServingTranscription(
+            VllmOpenAIServingTranscription(
                 engine_client=self.engine,
-                models=OpenAIServingModels(
+                models=VllmOpenAIServingModels(
                     engine_client=self.engine,
                     base_model_paths=[
-                        BaseModelPath(name=self.model_config.name, model_path=self.vllm_engine_kwargs.model)
+                        VllmBaseModelPath(name=self.model_config.name, model_path=self.vllm_engine_kwargs.model)
                     ],
                 ),
-                request_logger=RequestLogger(max_log_len=None),
+                request_logger=VllmRequestLogger(max_log_len=None),
             )
             if (self.model_config.usecase in [ModelUsecase.transcription, ModelUsecase.translation])
             and "transcription" in self.supported_tasks
             else None
         )
 
-    async def init_serving_translation(self) -> OpenAIServingTranslation | None:
+    async def init_serving_translation(self) -> VllmOpenAIServingTranslation | None:
         logger.info("init_serving_translation: %s, %s", self.supported_tasks, self.model_config.usecase)
         return (
-            OpenAIServingTranslation(
+            VllmOpenAIServingTranslation(
                 engine_client=self.engine,
-                models=OpenAIServingModels(
+                models=VllmOpenAIServingModels(
                     engine_client=self.engine,
                     base_model_paths=[
-                        BaseModelPath(name=self.model_config.name, model_path=self.vllm_engine_kwargs.model)
+                        VllmBaseModelPath(name=self.model_config.name, model_path=self.vllm_engine_kwargs.model)
                     ],
                 ),
-                request_logger=RequestLogger(max_log_len=None),
+                request_logger=VllmRequestLogger(max_log_len=None),
             )
             if (self.model_config.usecase in [ModelUsecase.transcription, ModelUsecase.translation])
             and "transcription" in self.supported_tasks
@@ -411,7 +415,7 @@ class VllmInfer(BaseInfer):
         request_id = f"chatcmpl-{base_request_id(raw_request)}"
         try:
             render_result = await engine_ops.render_and_params(self.openai_serving_render, vllm_request)
-        except VLLMValidationError as exc:
+        except VllmValidationError as exc:
             yield _encode_error(_validation_error(exc))
             yield "data: [DONE]\n\n"
             return
@@ -449,7 +453,7 @@ class VllmInfer(BaseInfer):
         except ClientDisconnectedError:
             logger.info("chat request %s aborted: client disconnected", request_id)
             return
-        except VLLMValidationError as exc:
+        except VllmValidationError as exc:
             yield _encode_error(_validation_error(exc))
             yield "data: [DONE]\n\n"
             return
@@ -474,7 +478,7 @@ class VllmInfer(BaseInfer):
         """Non-stream chat path via `engine_ops`, bypassing `OpenAIServingChat`."""
         try:
             render_result = await engine_ops.render_and_params(self.openai_serving_render, vllm_request)
-        except VLLMValidationError as exc:
+        except VllmValidationError as exc:
             return _validation_error(exc)
         if isinstance(render_result, VllmErrorResponse):
             return ErrorResponse.model_validate(render_result.model_dump())
@@ -507,7 +511,7 @@ class VllmInfer(BaseInfer):
             )
         except ClientDisconnectedError:
             return create_error_response("Client disconnected")
-        except VLLMValidationError as exc:
+        except VllmValidationError as exc:
             return _validation_error(exc)
 
         choices, finish_reasons, logprobs_list = engine_ops.build_choices(
@@ -577,7 +581,7 @@ class VllmInfer(BaseInfer):
         returned as a plain `ErrorResponse` instead of a mid-stream `response.failed`."""
         try:
             render_result = await engine_ops.render_and_params(self.openai_serving_render, vllm_request)
-        except VLLMValidationError as exc:
+        except VllmValidationError as exc:
             return _validation_error(exc)
         if isinstance(render_result, VllmErrorResponse):
             return ErrorResponse.model_validate(render_result.model_dump())
@@ -594,7 +598,7 @@ class VllmInfer(BaseInfer):
         `ParsedChatOutput` instead of round-tripping through a `ChatCompletionResponse`."""
         try:
             render_result = await engine_ops.render_and_params(self.openai_serving_render, vllm_request)
-        except VLLMValidationError as exc:
+        except VllmValidationError as exc:
             return _validation_error(exc)
         if isinstance(render_result, VllmErrorResponse):
             return ErrorResponse.model_validate(render_result.model_dump())
@@ -625,7 +629,7 @@ class VllmInfer(BaseInfer):
             )
         except ClientDisconnectedError:
             return create_error_response("Client disconnected")
-        except VLLMValidationError as exc:
+        except VllmValidationError as exc:
             return _validation_error(exc)
 
         choices, finish_reasons, _logprobs_list = engine_ops.build_choices(
@@ -659,8 +663,8 @@ class VllmInfer(BaseInfer):
         self,
         request: ResponsesRequest,
         vllm_request: VllmChatCompletionRequest,
-        engine_input: EngineInput,
-        sampling_params: SamplingParams,
+        engine_input: VllmEngineInput,
+        sampling_params: VllmSamplingParams,
         raw_request: RawRequestProxy,
     ) -> AsyncGenerator[str, None]:
         """Native streaming Responses path: feeds `BaseInfer._stream_responses` directly
@@ -697,7 +701,7 @@ class VllmInfer(BaseInfer):
         vllm_request = VllmEmbeddingCompletionRequest(**request.model_dump())
         try:
             result = await self.serving_embedding(vllm_request, cast("Request", raw_request))
-        except VLLMValidationError as exc:
+        except VllmValidationError as exc:
             return _validation_error(exc)
         if isinstance(result, VllmErrorResponse):
             return ErrorResponse.model_validate(result.model_dump())
@@ -717,7 +721,7 @@ class VllmInfer(BaseInfer):
             result = await self.serving_transcription.create_transcription(
                 audio_data, vllm_request, cast("Request", raw_request)
             )
-        except VLLMValidationError as exc:
+        except VllmValidationError as exc:
             return _validation_error(exc)
         if isinstance(result, VllmErrorResponse):
             return ErrorResponse.model_validate(result.model_dump())
@@ -742,7 +746,7 @@ class VllmInfer(BaseInfer):
             result = await self.serving_translation.create_translation(
                 audio_data, vllm_request, cast("Request", raw_request)
             )
-        except VLLMValidationError as exc:
+        except VllmValidationError as exc:
             return _validation_error(exc)
         if isinstance(result, VllmErrorResponse):
             return ErrorResponse.model_validate(result.model_dump())

--- a/tests/test_vllm_engine_ops.py
+++ b/tests/test_vllm_engine_ops.py
@@ -21,9 +21,9 @@ import pytest
 from vllm.entrypoints.openai.chat_completion.protocol import (
     ChatCompletionRequest as VllmChatCompletionRequest,
 )
-from vllm.entrypoints.serve.render.serving import OpenAIServingRender
-from vllm.parser import Parser
-from vllm.tokenizers import TokenizerLike
+from vllm.entrypoints.serve.render.serving import OpenAIServingRender as VllmOpenAIServingRender
+from vllm.parser import Parser as VllmParser
+from vllm.tokenizers import TokenizerLike as VllmTokenizerLike
 
 from modelship.infer.vllm import engine_ops
 from modelship.openai.protocol import ChatCompletionRequest
@@ -74,7 +74,7 @@ class TestDeriveReasoningEnded:
 
     def test_reasoning_parser_present_defers_to_is_reasoning_end(self):
         vllm_req = _vllm_req()
-        parser = Mock(spec=Parser)
+        parser = Mock(spec=VllmParser)
         parser.reasoning_parser = Mock()
         parser.is_reasoning_end.return_value = True
         result = engine_ops.derive_reasoning_ended(vllm_req, parser=parser, prompt_token_ids=[1, 2, 3])
@@ -83,7 +83,7 @@ class TestDeriveReasoningEnded:
 
     def test_no_reasoning_parser_and_no_grammar_flag_is_none(self):
         vllm_req = _vllm_req()
-        parser = Mock(spec=Parser)
+        parser = Mock(spec=VllmParser)
         parser.reasoning_parser = None
         assert engine_ops.derive_reasoning_ended(vllm_req, parser=parser, prompt_token_ids=[]) is None
 
@@ -94,13 +94,13 @@ class TestDeriveReasoningEnded:
 
 class TestMakeParsers:
     def test_no_parser_class_returns_n_nones(self):
-        render = Mock(spec=OpenAIServingRender)
+        render = Mock(spec=VllmOpenAIServingRender)
         render.parser = None
         result = engine_ops.make_parsers(render, tokenizer=Mock(), vllm_req=_vllm_req(), chat_template_kwargs=None, n=3)
         assert result == [None, None, None]
 
     def test_instantiates_one_independent_parser_per_choice(self):
-        render = Mock(spec=OpenAIServingRender)
+        render = Mock(spec=VllmOpenAIServingRender)
         parser_cls = Mock()
         instances = [Mock(), Mock(), Mock()]
         parser_cls.side_effect = instances
@@ -127,9 +127,9 @@ class TestSignaturesGuardVllmBump:
     """
 
     def test_async_llm_generate_accepts_reasoning_kwargs(self):
-        from vllm.v1.engine.async_llm import AsyncLLM
+        from vllm.v1.engine.async_llm import AsyncLLM as VllmAsyncLLM
 
-        params = inspect.signature(AsyncLLM.generate).parameters
+        params = inspect.signature(VllmAsyncLLM.generate).parameters
         assert "reasoning_ended" in params
         assert "reasoning_parser_kwargs" in params
 
@@ -143,7 +143,7 @@ class TestSignaturesGuardVllmBump:
         assert list(params)[1:] == ["max_tokens", "default_sampling_params"]
 
     def test_render_chat_signature_unchanged(self):
-        params = inspect.signature(OpenAIServingRender.render_chat).parameters
+        params = inspect.signature(VllmOpenAIServingRender.render_chat).parameters
         assert "request" in params
 
 
@@ -159,32 +159,32 @@ class TestVllmParserAcceptsOurRequest:
 
     def _build_render(
         self, model: str, *, tokenizer_mode: str = "auto", **tool_reasoning_kwargs: Any
-    ) -> tuple[OpenAIServingRender, TokenizerLike]:
-        from vllm.engine.arg_utils import AsyncEngineArgs
-        from vllm.entrypoints.openai.models.protocol import BaseModelPath
-        from vllm.entrypoints.openai.models.serving import OpenAIModelRegistry
-        from vllm.entrypoints.serve.utils.request_logger import RequestLogger
-        from vllm.renderers import renderer_from_config
-        from vllm.usage.usage_lib import UsageContext
+    ) -> tuple[VllmOpenAIServingRender, VllmTokenizerLike]:
+        from vllm.engine.arg_utils import AsyncEngineArgs as VllmAsyncEngineArgs
+        from vllm.entrypoints.openai.models.protocol import BaseModelPath as VllmBaseModelPath
+        from vllm.entrypoints.openai.models.serving import OpenAIModelRegistry as VllmOpenAIModelRegistry
+        from vllm.entrypoints.serve.utils.request_logger import RequestLogger as VllmRequestLogger
+        from vllm.renderers import renderer_from_config as vllm_renderer_from_config
+        from vllm.usage.usage_lib import UsageContext as VllmUsageContext
 
         try:
-            engine_args = AsyncEngineArgs(
+            engine_args = VllmAsyncEngineArgs(
                 model=model, tokenizer_mode=tokenizer_mode, max_model_len=4096, enforce_eager=True
             )
-            vllm_config = engine_args.create_engine_config(usage_context=UsageContext.OPENAI_API_SERVER)
-            renderer = renderer_from_config(vllm_config)
+            vllm_config = engine_args.create_engine_config(usage_context=VllmUsageContext.OPENAI_API_SERVER)
+            renderer = vllm_renderer_from_config(vllm_config)
         except Exception as e:
             pytest.skip(f"could not build a GPU-free render pipeline for {model!r}: {e}")
 
-        registry = OpenAIModelRegistry(
+        registry = VllmOpenAIModelRegistry(
             model_config=vllm_config.model_config,
-            base_model_paths=[BaseModelPath(name="test-model", model_path=model)],
+            base_model_paths=[VllmBaseModelPath(name="test-model", model_path=model)],
         )
-        render = OpenAIServingRender(
+        render = VllmOpenAIServingRender(
             model_config=vllm_config.model_config,
             renderer=renderer,
             model_registry=registry,
-            request_logger=RequestLogger(max_log_len=None),
+            request_logger=VllmRequestLogger(max_log_len=None),
             chat_template=None,
             chat_template_content_format="auto",
             enable_auto_tools=True,

--- a/tests/test_vllm_responses.py
+++ b/tests/test_vllm_responses.py
@@ -11,7 +11,7 @@ mocks `engine_ops` out entirely to isolate VllmInfer.create_response's own logic
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
-from vllm.exceptions import VLLMValidationError
+from vllm.exceptions import VLLMValidationError as VllmValidationError
 
 from modelship.infer.vllm.capabilities import VllmCapabilities
 from modelship.infer.vllm.vllm_infer import VllmInfer
@@ -87,7 +87,7 @@ async def test_invalid_reasoning_effort_returns_400():
 
 @pytest.mark.asyncio
 async def test_stream_prevalidation_error_returns_plain_error_not_generator():
-    """A VLLMValidationError from render_and_params must short-circuit to a
+    """A VllmValidationError from render_and_params must short-circuit to a
     plain ErrorResponse before any generator is created — the client gets a
     400 body, not a broken/empty event stream."""
     infer = _make_infer()
@@ -95,7 +95,7 @@ async def test_stream_prevalidation_error_returns_plain_error_not_generator():
 
     with patch("modelship.infer.vllm.vllm_infer.engine_ops") as mock_ops:
         mock_ops.build_vllm_request.return_value = MagicMock()
-        mock_ops.render_and_params = AsyncMock(side_effect=VLLMValidationError("too long", parameter="messages"))
+        mock_ops.render_and_params = AsyncMock(side_effect=VllmValidationError("too long", parameter="messages"))
         result = await infer.create_response(request, raw_request=_FakeRawRequest())
 
     assert isinstance(result, ErrorResponse)


### PR DESCRIPTION
Applies the existing VllmChatCompletionRequest-style alias convention to every remaining bare vllm import (engine, serving, sampling, tokenizer, parser-manager classes and helper functions) so provenance is legible at every call site, not just where names collided with modelship's own protocol classes. Normalizes VLLMValidationError's casing to VllmValidationError in the process.

