### PR TITLE
refactor: unify infer stream/no-stream seams and error handling

### DIFF
--- a/modelship/infer/base_infer.py
+++ b/modelship/infer/base_infer.py
@@ -70,7 +70,7 @@ class ClientDisconnectedError(Exception):
     the guarded work finishes."""
 
 
-class BaseInfer(ABC):
+class BaseInfer[Prepared](ABC):
     def __init__(self, model_config: ModelshipModelConfig):
         self.model_config = model_config
         self.max_context_length: int | None = None
@@ -339,12 +339,73 @@ class BaseInfer(ABC):
     async def create_chat_completion(
         self, request: ChatCompletionRequest, raw_request: RawRequestProxy
     ) -> ErrorResponse | ChatCompletionResponse | AsyncGenerator[str, None]:
-        return _NOT_SUPPORTED
+        """Prepare the request, then dispatch to the loader's stream/no-stream seam.
+
+        `_prepare_chat` is the single place a loader shapes/renders the request and
+        can fail — a pre-generation failure (bad content, context overflow, ...)
+        comes back here as a plain `ErrorResponse`, matching `create_response` and
+        OpenAI's own behavior: a streaming request that fails before any token is
+        produced gets a normal HTTP 4xx JSON body, not a `200` SSE stream carrying
+        an error chunk.
+        """
+        prepared = await self._prepare_chat(request, raw_request)
+        if isinstance(prepared, ErrorResponse):
+            return prepared
+        if request.stream:
+            return self._create_chat_completion_stream(request, prepared, raw_request)
+        return await self._create_chat_completion_no_stream(request, prepared, raw_request)
 
     async def create_response(
         self, request: ResponsesRequest, raw_request: RawRequestProxy
     ) -> ErrorResponse | ResponseObject | AsyncGenerator[str, None]:
+        """Responses counterpart of `create_chat_completion` — see its docstring."""
+        prepared = await self._prepare_responses(request, raw_request)
+        if isinstance(prepared, ErrorResponse):
+            return prepared
+        if request.stream:
+            return self._create_response_stream(request, prepared, raw_request)
+        return await self._create_response_no_stream(request, prepared, raw_request)
+
+    async def _prepare_chat(
+        self, request: ChatCompletionRequest, raw_request: RawRequestProxy
+    ) -> ErrorResponse | Prepared:
+        """Shape/validate/render a chat request into whatever the loader's
+        stream/no-stream seams need. Default: unsupported. Loaders that override
+        `create_chat_completion`'s seams must override this instead."""
         return _NOT_SUPPORTED
+
+    async def _prepare_responses(
+        self, request: ResponsesRequest, raw_request: RawRequestProxy
+    ) -> ErrorResponse | Prepared:
+        """Responses counterpart of `_prepare_chat`."""
+        return _NOT_SUPPORTED
+
+    def _create_chat_completion_stream(
+        self, request: ChatCompletionRequest, prepared: Prepared, raw_request: RawRequestProxy
+    ) -> AsyncGenerator[str, None]:
+        """Streaming chat seam. `prepared` is whatever `_prepare_chat` returned —
+        rendering/validation already succeeded, so this only drives generation and
+        encodes SSE chunks. Unreachable unless a loader overrides `_prepare_chat`
+        without overriding this."""
+        raise NotImplementedError
+
+    async def _create_chat_completion_no_stream(
+        self, request: ChatCompletionRequest, prepared: Prepared, raw_request: RawRequestProxy
+    ) -> ErrorResponse | ChatCompletionResponse:
+        """Non-streaming chat seam. See `_create_chat_completion_stream`."""
+        raise NotImplementedError
+
+    def _create_response_stream(
+        self, request: ResponsesRequest, prepared: Prepared, raw_request: RawRequestProxy
+    ) -> AsyncGenerator[str, None]:
+        """Streaming Responses seam. See `_create_chat_completion_stream`."""
+        raise NotImplementedError
+
+    async def _create_response_no_stream(
+        self, request: ResponsesRequest, prepared: Prepared, raw_request: RawRequestProxy
+    ) -> ErrorResponse | ResponseObject:
+        """Non-streaming Responses seam. See `_create_chat_completion_stream`."""
+        raise NotImplementedError
 
     async def create_embedding(self, request: EmbeddingRequest, raw_request: RawRequestProxy) -> ErrorResponse:
         return _NOT_SUPPORTED

--- a/modelship/infer/llama_server/llama_server_infer.py
+++ b/modelship/infer/llama_server/llama_server_infer.py
@@ -23,6 +23,7 @@ from modelship.openai.chat_utils import (
     build_from_parsed,
     build_response_from_parsed,
     encode_chat_sse_chunk,
+    encode_error_sse,
     normalize_chat_messages,
     responses_validation_error,
 )
@@ -85,7 +86,7 @@ class _EarlyCrashError(RuntimeError):
 _pending_client_closes: set[asyncio.Task] = set()
 
 
-class LlamaServerInfer(BaseInfer):
+class LlamaServerInfer(BaseInfer[dict[str, Any]]):
     """Drives a `llama-server` subprocess over its native OpenAI-compatible
     HTTP API. llama-server does its own chat templating, tool-call, and
     reasoning parsing — this loader is a thin, concurrency-safe proxy that
@@ -416,11 +417,11 @@ class LlamaServerInfer(BaseInfer):
             return create_error_response(message or "Unknown error returned from llama-server", status_code=502)
         return _project_embedding_response(data, model_name=self.model_config.name)
 
-    async def create_chat_completion(
+    async def _prepare_chat(
         self, request: ChatCompletionRequest, raw_request: RawRequestProxy
-    ) -> ErrorResponse | ChatCompletionResponse | AsyncGenerator[str, None]:
+    ) -> ErrorResponse | dict[str, Any]:
         if self._client is None:
-            return await super().create_chat_completion(request, raw_request)
+            return await super()._prepare_chat(request, raw_request)
 
         request_id = f"chat-{base_request_id(raw_request)}"
         logger.info("chat completion request %s: stream=%s", request_id, request.stream)
@@ -440,13 +441,14 @@ class LlamaServerInfer(BaseInfer):
             logger.warning("chat request %s rejected: %s", request_id, e)
             return create_error_response(e)
 
-        payload = _build_payload(request, messages, model_name=self.model_config.name)
+        return _build_payload(request, messages, model_name=self.model_config.name)
 
-        if request.stream:
-            return self._stream_chat_completion(payload, request_id, raw_request)
-
+    async def _create_chat_completion_no_stream(
+        self, request: ChatCompletionRequest, prepared: dict[str, Any], raw_request: RawRequestProxy
+    ) -> ErrorResponse | ChatCompletionResponse:
+        request_id = f"chat-{base_request_id(raw_request)}"
         try:
-            return await self.run_cancellable(self._send_chat_completion(payload, request_id), raw_request)
+            return await self.run_cancellable(self._send_chat_completion(prepared, request_id), raw_request)
         except ClientDisconnectedError:
             logger.info("chat request %s aborted: client disconnected", request_id)
             return create_error_response("Client disconnected")
@@ -459,11 +461,11 @@ class LlamaServerInfer(BaseInfer):
             return data
         return _project_chat_response(data, model_name=self.model_config.name, request_id=request_id)
 
-    async def create_response(
+    async def _prepare_responses(
         self, request: ResponsesRequest, raw_request: RawRequestProxy
-    ) -> ErrorResponse | ResponseObject | AsyncGenerator[str, None]:
+    ) -> ErrorResponse | dict[str, Any]:
         if self._client is None:
-            return await super().create_response(request, raw_request)
+            return await super()._prepare_responses(request, raw_request)
 
         try:
             chat_request = responses_request_to_chat(request)
@@ -483,13 +485,14 @@ class LlamaServerInfer(BaseInfer):
             return create_error_response(e)
 
         chat_request.stream = bool(request.stream)
-        payload = _build_payload(chat_request, messages, model_name=self.model_config.name)
+        return _build_payload(chat_request, messages, model_name=self.model_config.name)
 
-        if request.stream:
-            return self._create_response_stream(payload, request, request_id, raw_request)
-
+    async def _create_response_no_stream(
+        self, request: ResponsesRequest, prepared: dict[str, Any], raw_request: RawRequestProxy
+    ) -> ErrorResponse | ResponseObject:
+        request_id = f"resp-{base_request_id(raw_request)}"
         try:
-            return await self.run_cancellable(self._send_response(payload, request, request_id), raw_request)
+            return await self.run_cancellable(self._send_response(prepared, request, request_id), raw_request)
         except ClientDisconnectedError:
             logger.info("responses request %s aborted: client disconnected", request_id)
             return create_error_response("Client disconnected")
@@ -528,8 +531,8 @@ class LlamaServerInfer(BaseInfer):
             return create_error_response(message or "Unknown error returned from llama-server", status_code=502)
         return data
 
-    async def _stream_chat_completion(
-        self, payload: dict[str, Any], request_id: str, raw_request: RawRequestProxy
+    async def _create_chat_completion_stream(
+        self, request: ChatCompletionRequest, prepared: dict[str, Any], raw_request: RawRequestProxy
     ) -> AsyncGenerator[str, None]:
         """Race the llama-server SSE stream against the client's disconnect signal.
 
@@ -538,7 +541,8 @@ class LlamaServerInfer(BaseInfer):
         (and its `httpx` stream against llama-server) running to completion,
         holding a `--parallel` slot until the response finishes on its own.
         """
-        stream = self._stream_chat_completion_body(payload, request_id)
+        request_id = f"chat-{base_request_id(raw_request)}"
+        stream = self._stream_chat_completion_body(prepared, request_id)
         try:
             async for chunk in self.run_cancellable_stream(stream, raw_request):
                 yield chunk
@@ -561,24 +565,27 @@ class LlamaServerInfer(BaseInfer):
                 yield encode_chat_sse_chunk(chunk)
             yield "data: [DONE]\n\n"
         except _LlamaServerStreamError as e:
-            yield _encode_error(str(e))
+            yield encode_error_sse(create_error_response(str(e), err_type="api_error", status_code=502))
             yield "data: [DONE]\n\n"
         except httpx.HTTPError as e:
             logger.warning("chat request %s failed mid-stream: %s", request_id, e)
-            yield _encode_error(f"llama-server request failed: {e}")
+            yield encode_error_sse(
+                create_error_response(f"llama-server request failed: {e}", err_type="api_error", status_code=502)
+            )
             yield "data: [DONE]\n\n"
         finally:
             if trace:
                 logger.log(TRACE, "chat response %s (stream): %r", request_id, "".join(buffered))
 
     async def _create_response_stream(
-        self, payload: dict[str, Any], request: ResponsesRequest, request_id: str, raw_request: RawRequestProxy
+        self, request: ResponsesRequest, prepared: dict[str, Any], raw_request: RawRequestProxy
     ) -> AsyncGenerator[str, None]:
         """Native streaming Responses path: feeds `BaseInfer._stream_responses` directly
         from `_raw_stream_chunks`'s typed chunks, same source `_stream_chat_completion_body`
         uses — no chat SSE text round trip."""
         assert self._client is not None
-        stream = _raw_stream_chunks(self._client, payload, model_name=self.model_config.name, request_id=request_id)
+        request_id = f"resp-{base_request_id(raw_request)}"
+        stream = _raw_stream_chunks(self._client, prepared, model_name=self.model_config.name, request_id=request_id)
         chunks = self.run_cancellable_stream(stream, raw_request)
         async for event in self._stream_responses(
             request, chunks, request_id=request_id, client_error=_llama_stream_error
@@ -846,7 +853,3 @@ def _project_embedding_response(data: dict, *, model_name: str) -> EmbeddingResp
         data=projected_data,
         usage=usage,
     )
-
-
-def _encode_error(detail: str) -> str:
-    return f"data: {json.dumps({'error': {'message': detail, 'type': 'api_error'}})}\n\n"

--- a/modelship/infer/vllm/vllm_infer.py
+++ b/modelship/infer/vllm/vllm_infer.py
@@ -1,6 +1,6 @@
 import io
-import json
 from collections.abc import AsyncGenerator
+from dataclasses import dataclass
 from http import HTTPStatus
 from typing import Any, ClassVar, cast
 
@@ -51,7 +51,9 @@ from vllm.entrypoints.speech_to_text.translation.serving import (
 )
 from vllm.exceptions import VLLMValidationError as VllmValidationError
 from vllm.inputs import EngineInput as VllmEngineInput
+from vllm.parser import Parser as VllmParser
 from vllm.sampling_params import SamplingParams as VllmSamplingParams
+from vllm.tokenizers import TokenizerLike as VllmTokenizerLike
 from vllm.usage.usage_lib import UsageContext as VllmUsageContext
 from vllm.v1.engine.async_llm import AsyncLLM as VllmAsyncLLM
 
@@ -73,6 +75,7 @@ from modelship.openai.chat_utils import (
     build_from_parsed,
     build_response_from_parsed,
     encode_chat_sse_chunk,
+    encode_error_sse,
     normalize_chat_messages,
     responses_validation_error,
 )
@@ -103,20 +106,33 @@ from modelship.utils import base_request_id
 logger = get_logger("infer.vllm")
 
 
-def _encode_error(error: ErrorResponse) -> str:
-    return f"data: {json.dumps(error.model_dump(mode='json'))}\n\n"
+def _to_error_response(
+    err: VllmValidationError | VllmErrorResponse | Exception | str,
+    *,
+    err_type: str = "invalid_request_error",
+    status_code: HTTPStatus | int = HTTPStatus.BAD_REQUEST,
+) -> ErrorResponse:
+    """The one place this loader converts any failure into a client-facing
+    `ErrorResponse`, funnelling every shape through `create_error_response`.
 
-
-def _validation_error(exc: VllmValidationError) -> ErrorResponse:
-    # VllmValidationError.__str__ appends "(parameter=..., value=...)"; keep the
-    # original message and surface the offending field via the OpenAI `param` slot.
-    base = exc.args[0] if exc.args else str(exc)
-    return create_error_response(
-        message=base,
-        err_type="invalid_request_error",
-        status_code=HTTPStatus.BAD_REQUEST,
-        param=exc.parameter,
-    )
+    """
+    if isinstance(err, VllmValidationError):
+        base = err.args[0] if err.args else str(err)
+        return create_error_response(
+            message=base,
+            err_type="invalid_request_error",
+            status_code=HTTPStatus.BAD_REQUEST,
+            param=err.parameter,
+        )
+    if isinstance(err, VllmErrorResponse):
+        info = err.error
+        return create_error_response(
+            message=info.message,
+            err_type=info.type,
+            status_code=info.code,
+            param=info.param,
+        )
+    return create_error_response(err, err_type=err_type, status_code=status_code)
 
 
 def _vllm_stream_error(exc: Exception) -> str | None:
@@ -129,7 +145,17 @@ def _vllm_stream_error(exc: Exception) -> str | None:
     return None
 
 
-class VllmInfer(BaseInfer):
+@dataclass
+class _VllmPrepared:
+    """Everything a stream/no-stream seam needs once `_prepare_chat`/`_prepare_responses`
+    has rendered the chat template and derived sampling params."""
+
+    vllm_request: VllmChatCompletionRequest
+    engine_input: VllmEngineInput
+    sampling_params: VllmSamplingParams
+
+
+class VllmInfer(BaseInfer[_VllmPrepared]):
     _vllm_usecases: ClassVar[list[ModelUsecase]] = [
         ModelUsecase.generate,
         ModelUsecase.embed,
@@ -329,6 +355,32 @@ class VllmInfer(BaseInfer):
             tool_parser=tool_parser_name,
             reasoning_parser=reasoning_parser_name,
         )
+        tokenizer = self.openai_serving_render.renderer.tokenizer
+        assert tokenizer is not None, "vllm renderer has no tokenizer (skip_tokenizer_init=True is unsupported here)"
+        self._tokenizer: VllmTokenizerLike = tokenizer
+
+    def _make_parsers(self, vllm_request: VllmChatCompletionRequest, n: int) -> list[VllmParser | None]:
+        """One stateful parser instance per choice — the streaming path (see `engine_ops.make_parsers`)."""
+        return engine_ops.make_parsers(
+            self.openai_serving_render, self._tokenizer, vllm_request, vllm_request.chat_template_kwargs, n
+        )
+
+    def _make_parser(self, vllm_request: VllmChatCompletionRequest) -> VllmParser | None:
+        """Single parser instance for the non-streaming path, which reuses it
+        (stateless `.parse()` call) across every choice — see `engine_ops.build_choices`."""
+        return self._make_parsers(vllm_request, n=1)[0]
+
+    async def _render_bundle(self, vllm_request: VllmChatCompletionRequest) -> ErrorResponse | _VllmPrepared:
+        """Render the chat template and derive sampling params — the single place
+        this happens, so every seam sees a pre-generation failure the same way."""
+        try:
+            result = await engine_ops.render_and_params(self.openai_serving_render, vllm_request)
+        except VllmValidationError as exc:
+            return _to_error_response(exc)
+        if isinstance(result, VllmErrorResponse):
+            return _to_error_response(result)
+        engine_input, sampling_params = result
+        return _VllmPrepared(vllm_request, engine_input, sampling_params)
 
     async def init_serving_embedding(self) -> VllmServingEmbedding | None:
         logger.info("init_serving_embedding: %s, %s", self.supported_tasks, self.model_config.usecase)
@@ -385,11 +437,11 @@ class VllmInfer(BaseInfer):
             else None
         )
 
-    async def create_chat_completion(
+    async def _prepare_chat(
         self, request: ChatCompletionRequest, raw_request: RawRequestProxy
-    ) -> ErrorResponse | ChatCompletionResponse | AsyncGenerator[str, None]:
+    ) -> ErrorResponse | _VllmPrepared:
         if not hasattr(self, "openai_serving_render"):
-            return await super().create_chat_completion(request, raw_request)
+            return await super()._prepare_chat(request, raw_request)
         try:
             request.messages = normalize_chat_messages(
                 request.messages,
@@ -397,46 +449,30 @@ class VllmInfer(BaseInfer):
                 supports_audio=self._caps.supports_audio,
             )
         except UnsupportedContentError as exc:
-            return create_error_response(exc)
+            return _to_error_response(exc)
         vllm_request = engine_ops.build_vllm_request(request, self.model_config.chat_template_kwargs)
-
-        if request.stream:
-            return self._create_chat_completion_stream(request, vllm_request, raw_request)
-
-        return await self._create_chat_completion_no_stream(request, vllm_request, raw_request)
+        return await self._render_bundle(vllm_request)
 
     async def _create_chat_completion_stream(
         self,
         request: ChatCompletionRequest,
-        vllm_request: VllmChatCompletionRequest,
+        prepared: _VllmPrepared,
         raw_request: RawRequestProxy,
     ) -> AsyncGenerator[str, None]:
-        """Streaming chat path via `engine_ops`, bypassing `OpenAIServingChat`."""
+        """Streaming chat path via `engine_ops`, bypassing `OpenAIServingChat`.
+        Rendering already succeeded in `_prepare_chat` — this only drives generation."""
         request_id = f"chatcmpl-{base_request_id(raw_request)}"
-        try:
-            render_result = await engine_ops.render_and_params(self.openai_serving_render, vllm_request)
-        except VllmValidationError as exc:
-            yield _encode_error(_validation_error(exc))
-            yield "data: [DONE]\n\n"
-            return
-        if isinstance(render_result, VllmErrorResponse):
-            yield _encode_error(ErrorResponse.model_validate(render_result.model_dump()))
-            yield "data: [DONE]\n\n"
-            return
-        engine_input, sampling_params = render_result
-
-        tokenizer = self.openai_serving_render.renderer.tokenizer
-        assert tokenizer is not None, "vllm renderer has no tokenizer (skip_tokenizer_init=True is unsupported here)"
+        vllm_request = prepared.vllm_request
 
         stream = engine_ops.stream_chat_completion(
             self.engine,
             self.openai_serving_render,
             vllm_request,
-            engine_input,
-            sampling_params,
+            prepared.engine_input,
+            prepared.sampling_params,
             request_id,
             self.model_config.name,
-            tokenizer,
+            self._tokenizer,
             enable_auto_tools=self._enable_auto_tools,
             want_logprobs=bool(request.logprobs),
             num_output_top_logprobs=request.top_logprobs,
@@ -454,13 +490,13 @@ class VllmInfer(BaseInfer):
             logger.info("chat request %s aborted: client disconnected", request_id)
             return
         except VllmValidationError as exc:
-            yield _encode_error(_validation_error(exc))
+            yield encode_error_sse(_to_error_response(exc))
             yield "data: [DONE]\n\n"
             return
         except Exception:
             logger.exception("chat request %s failed mid-stream", request_id)
-            yield _encode_error(
-                create_error_response("Internal error during generation", err_type="api_error", status_code=500)
+            yield encode_error_sse(
+                _to_error_response("Internal error during generation", err_type="api_error", status_code=500)
             )
             yield "data: [DONE]\n\n"
             return
@@ -472,26 +508,14 @@ class VllmInfer(BaseInfer):
     async def _create_chat_completion_no_stream(
         self,
         request: ChatCompletionRequest,
-        vllm_request: VllmChatCompletionRequest,
+        prepared: _VllmPrepared,
         raw_request: RawRequestProxy,
     ) -> ErrorResponse | ChatCompletionResponse:
         """Non-stream chat path via `engine_ops`, bypassing `OpenAIServingChat`."""
-        try:
-            render_result = await engine_ops.render_and_params(self.openai_serving_render, vllm_request)
-        except VllmValidationError as exc:
-            return _validation_error(exc)
-        if isinstance(render_result, VllmErrorResponse):
-            return ErrorResponse.model_validate(render_result.model_dump())
-        engine_input, sampling_params = render_result
+        vllm_request = prepared.vllm_request
+        engine_input, sampling_params = prepared.engine_input, prepared.sampling_params
 
-        tokenizer = self.openai_serving_render.renderer.tokenizer
-        assert tokenizer is not None, "vllm renderer has no tokenizer (skip_tokenizer_init=True is unsupported here)"
-
-        # Non-streaming reuses one parser instance across every choice (see
-        # engine_ops.build_choices), so only one is needed here regardless of n.
-        parser = engine_ops.make_parsers(
-            self.openai_serving_render, tokenizer, vllm_request, vllm_request.chat_template_kwargs, n=1
-        )[0]
+        parser = self._make_parser(vllm_request)
         prompt_token_ids = engine_ops.extract_prompt_token_ids(self.openai_serving_render, engine_input)
         reasoning_ended = engine_ops.derive_reasoning_ended(vllm_request, parser, prompt_token_ids)
 
@@ -510,22 +534,22 @@ class VllmInfer(BaseInfer):
                 raw_request,
             )
         except ClientDisconnectedError:
-            return create_error_response("Client disconnected")
+            return _to_error_response("Client disconnected")
         except VllmValidationError as exc:
-            return _validation_error(exc)
+            return _to_error_response(exc)
 
         choices, finish_reasons, logprobs_list = engine_ops.build_choices(
             final_res,
             vllm_request,
             parser,
-            tokenizer,
+            self._tokenizer,
             enable_auto_tools=self._enable_auto_tools,
             want_logprobs=bool(request.logprobs),
             num_output_top_logprobs=request.top_logprobs,
         )
 
         if final_res.prompt_token_ids is None:
-            return create_error_response("vllm returned no prompt_token_ids for a completed request", status_code=502)
+            return _to_error_response("vllm returned no prompt_token_ids for a completed request", status_code=502)
         prompt_tokens = len(final_res.prompt_token_ids)
         completion_tokens = sum(len(output.token_ids) for output in final_res.outputs)
 
@@ -542,16 +566,16 @@ class VllmInfer(BaseInfer):
             logprobs=logprobs_list,
         )
 
-    async def create_response(
+    async def _prepare_responses(
         self, request: ResponsesRequest, raw_request: RawRequestProxy
-    ) -> ErrorResponse | ResponseObject | AsyncGenerator[str, None]:
+    ) -> ErrorResponse | _VllmPrepared:
         if not hasattr(self, "openai_serving_render"):
-            return await super().create_response(request, raw_request)
+            return await super()._prepare_responses(request, raw_request)
 
         try:
             chat_request = responses_request_to_chat(request)
         except UnsupportedResponsesFeatureError as e:
-            return create_error_response(e)
+            return _to_error_response(e)
         except ValidationError as e:
             return responses_validation_error(e)
 
@@ -562,54 +586,23 @@ class VllmInfer(BaseInfer):
                 supports_audio=self._caps.supports_audio,
             )
         except UnsupportedContentError as exc:
-            return create_error_response(exc)
+            return _to_error_response(exc)
         chat_request.stream = request.stream or False
         vllm_request = engine_ops.build_vllm_request(chat_request, self.model_config.chat_template_kwargs)
-
-        if request.stream:
-            return await self._create_response_stream_or_error(request, vllm_request, raw_request)
-        return await self._create_response_no_stream(request, vllm_request, raw_request)
-
-    async def _create_response_stream_or_error(
-        self,
-        request: ResponsesRequest,
-        vllm_request: VllmChatCompletionRequest,
-        raw_request: RawRequestProxy,
-    ) -> ErrorResponse | AsyncGenerator[str, None]:
-        """Render + derive sampling params before committing to a Responses event
-        stream, so a pre-generation failure (e.g. context overflow) can still be
-        returned as a plain `ErrorResponse` instead of a mid-stream `response.failed`."""
-        try:
-            render_result = await engine_ops.render_and_params(self.openai_serving_render, vllm_request)
-        except VllmValidationError as exc:
-            return _validation_error(exc)
-        if isinstance(render_result, VllmErrorResponse):
-            return ErrorResponse.model_validate(render_result.model_dump())
-        engine_input, sampling_params = render_result
-        return self._create_response_stream(request, vllm_request, engine_input, sampling_params, raw_request)
+        return await self._render_bundle(vllm_request)
 
     async def _create_response_no_stream(
         self,
         request: ResponsesRequest,
-        vllm_request: VllmChatCompletionRequest,
+        prepared: _VllmPrepared,
         raw_request: RawRequestProxy,
     ) -> ErrorResponse | ResponseObject:
         """Non-stream Responses path via `engine_ops`, shaping items directly from
         `ParsedChatOutput` instead of round-tripping through a `ChatCompletionResponse`."""
-        try:
-            render_result = await engine_ops.render_and_params(self.openai_serving_render, vllm_request)
-        except VllmValidationError as exc:
-            return _validation_error(exc)
-        if isinstance(render_result, VllmErrorResponse):
-            return ErrorResponse.model_validate(render_result.model_dump())
-        engine_input, sampling_params = render_result
+        vllm_request = prepared.vllm_request
+        engine_input, sampling_params = prepared.engine_input, prepared.sampling_params
 
-        tokenizer = self.openai_serving_render.renderer.tokenizer
-        assert tokenizer is not None, "vllm renderer has no tokenizer (skip_tokenizer_init=True is unsupported here)"
-
-        parser = engine_ops.make_parsers(
-            self.openai_serving_render, tokenizer, vllm_request, vllm_request.chat_template_kwargs, n=1
-        )[0]
+        parser = self._make_parser(vllm_request)
         prompt_token_ids = engine_ops.extract_prompt_token_ids(self.openai_serving_render, engine_input)
         reasoning_ended = engine_ops.derive_reasoning_ended(vllm_request, parser, prompt_token_ids)
 
@@ -628,22 +621,22 @@ class VllmInfer(BaseInfer):
                 raw_request,
             )
         except ClientDisconnectedError:
-            return create_error_response("Client disconnected")
+            return _to_error_response("Client disconnected")
         except VllmValidationError as exc:
-            return _validation_error(exc)
+            return _to_error_response(exc)
 
         choices, finish_reasons, _logprobs_list = engine_ops.build_choices(
             final_res,
             vllm_request,
             parser,
-            tokenizer,
+            self._tokenizer,
             enable_auto_tools=self._enable_auto_tools,
             want_logprobs=False,
             num_output_top_logprobs=None,
         )
 
         if final_res.prompt_token_ids is None:
-            return create_error_response("vllm returned no prompt_token_ids for a completed request", status_code=502)
+            return _to_error_response("vllm returned no prompt_token_ids for a completed request", status_code=502)
         prompt_tokens = len(final_res.prompt_token_ids)
         completion_tokens = sum(len(output.token_ids) for output in final_res.outputs)
 
@@ -662,27 +655,24 @@ class VllmInfer(BaseInfer):
     async def _create_response_stream(
         self,
         request: ResponsesRequest,
-        vllm_request: VllmChatCompletionRequest,
-        engine_input: VllmEngineInput,
-        sampling_params: VllmSamplingParams,
+        prepared: _VllmPrepared,
         raw_request: RawRequestProxy,
     ) -> AsyncGenerator[str, None]:
         """Native streaming Responses path: feeds `BaseInfer._stream_responses` directly
         from `engine_ops.stream_chat_completion`'s typed chunks — no chat SSE text
-        round trip."""
+        round trip. Rendering already succeeded in `_prepare_responses`."""
         request_id = f"resp-{base_request_id(raw_request)}"
-        tokenizer = self.openai_serving_render.renderer.tokenizer
-        assert tokenizer is not None, "vllm renderer has no tokenizer (skip_tokenizer_init=True is unsupported here)"
+        vllm_request = prepared.vllm_request
 
         stream = engine_ops.stream_chat_completion(
             self.engine,
             self.openai_serving_render,
             vllm_request,
-            engine_input,
-            sampling_params,
+            prepared.engine_input,
+            prepared.sampling_params,
             request_id,
             self.model_config.name,
-            tokenizer,
+            self._tokenizer,
             enable_auto_tools=self._enable_auto_tools,
             want_logprobs=False,
             num_output_top_logprobs=None,
@@ -702,9 +692,9 @@ class VllmInfer(BaseInfer):
         try:
             result = await self.serving_embedding(vllm_request, cast("Request", raw_request))
         except VllmValidationError as exc:
-            return _validation_error(exc)
+            return _to_error_response(exc)
         if isinstance(result, VllmErrorResponse):
-            return ErrorResponse.model_validate(result.model_dump())
+            return _to_error_response(result)
         return cast("ErrorResponse | Response", result)
 
     async def create_transcription(
@@ -722,9 +712,9 @@ class VllmInfer(BaseInfer):
                 audio_data, vllm_request, cast("Request", raw_request)
             )
         except VllmValidationError as exc:
-            return _validation_error(exc)
+            return _to_error_response(exc)
         if isinstance(result, VllmErrorResponse):
-            return ErrorResponse.model_validate(result.model_dump())
+            return _to_error_response(result)
         if isinstance(result, VllmTranscriptionResponseVerbose):
             return TranscriptionResponseVerbose.model_validate(result.model_dump())
         if isinstance(result, VllmTranscriptionResponse):
@@ -747,9 +737,9 @@ class VllmInfer(BaseInfer):
                 audio_data, vllm_request, cast("Request", raw_request)
             )
         except VllmValidationError as exc:
-            return _validation_error(exc)
+            return _to_error_response(exc)
         if isinstance(result, VllmErrorResponse):
-            return ErrorResponse.model_validate(result.model_dump())
+            return _to_error_response(result)
         if isinstance(result, VllmTranslationResponseVerbose):
             return TranslationResponseVerbose.model_validate(result.model_dump())
         if isinstance(result, VllmTranslationResponse):

--- a/modelship/openai/chat_utils.py
+++ b/modelship/openai/chat_utils.py
@@ -1,5 +1,6 @@
 """Validation and normalization helpers for OpenAI chat-completion messages."""
 
+import json
 import time
 from dataclasses import dataclass, field
 from typing import Any
@@ -290,6 +291,16 @@ def build_from_parsed(
 def encode_chat_sse_chunk(chunk: ChatCompletionStreamResponse) -> str:
     """Encode one chat-completion stream chunk as an SSE `data:` line."""
     return f"data: {chunk.model_dump_json()}\n\n"
+
+
+def encode_error_sse(error: ErrorResponse) -> str:
+    """Encode a mid-stream `ErrorResponse` as an SSE `data:` line.
+
+    Shared by every loader's streaming chat/responses paths — a pre-generation
+    failure is returned as a plain `ErrorResponse` instead (see `BaseInfer.create_chat_completion`);
+    this is only for a failure after the stream has already started.
+    """
+    return f"data: {json.dumps(error.model_dump(mode='json'))}\n\n"
 
 
 def build_responses_items_from_parsed(parsed: ParsedChatOutput) -> list[ResponseOutputItem]:

--- a/tests/test_vllm_responses.py
+++ b/tests/test_vllm_responses.py
@@ -45,6 +45,7 @@ def _make_infer() -> VllmInfer:
     infer.model_config.name = "m"
     infer.model_config.chat_template_kwargs = {}
     infer.openai_serving_render = MagicMock()
+    infer._tokenizer = MagicMock()
     infer.engine = MagicMock()
     infer._enable_auto_tools = True
     return infer
@@ -105,7 +106,6 @@ async def test_stream_prevalidation_error_returns_plain_error_not_generator():
 @pytest.mark.asyncio
 async def test_stream_success_produces_native_responses_events():
     infer = _make_infer()
-    infer.openai_serving_render.renderer.tokenizer = MagicMock()
     request = ResponsesRequest(model="m", input="hi", stream=True)
 
     async def fake_stream(*_args, **_kwargs):
@@ -132,7 +132,6 @@ async def test_stream_success_produces_native_responses_events():
 @pytest.mark.asyncio
 async def test_stream_mid_stream_exception_emits_failed_event():
     infer = _make_infer()
-    infer.openai_serving_render.renderer.tokenizer = MagicMock()
     request = ResponsesRequest(model="m", input="hi", stream=True)
 
     async def fake_stream(*_args, **_kwargs):

--- a/tests/test_vllm_vision.py
+++ b/tests/test_vllm_vision.py
@@ -9,7 +9,7 @@ tested via :class:`VllmInfer.create_chat_completion` with the streaming path
 stubbed out — the goal there is the 400-rejection path, not the inference call.
 """
 
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 from vllm.entrypoints.openai.chat_completion.protocol import ChatCompletionRequest as VllmChatCompletionRequest
@@ -77,22 +77,33 @@ def test_data_uri_image_survives_protocol_hop():
 # ---------------------------------------------------------------------------
 
 
-def _make_infer(*, supports_image: bool) -> VllmInfer:
+def _make_infer(*, supports_image: bool, monkeypatch: pytest.MonkeyPatch) -> VllmInfer:
     """Build a VllmInfer with __init__/start bypassed; only the fields the
-    chat-completion path reads are populated."""
+    chat-completion path reads are populated.
+
+    `_prepare_chat` now renders the request (via `engine_ops.render_and_params`)
+    before dispatching to the streaming seam, so a real render call against the
+    MagicMock `openai_serving_render` would blow up — stub it to return a
+    trivial `(engine_input, sampling_params)` pair instead.
+    """
     infer = VllmInfer.__new__(VllmInfer)
     infer._caps = VllmCapabilities(supports_image=supports_image)  # type: ignore[attr-defined]
     infer.model_config = MagicMock(chat_template_kwargs={})
     infer.openai_serving_render = MagicMock()
+    infer._tokenizer = MagicMock()
     infer._create_chat_completion_stream = MagicMock(return_value=MagicMock())
+    monkeypatch.setattr(
+        "modelship.infer.vllm.engine_ops.render_and_params",
+        AsyncMock(return_value=(MagicMock(), MagicMock())),
+    )
     return infer
 
 
 @pytest.mark.asyncio
-async def test_image_part_rejected_on_text_only_model_with_400():
+async def test_image_part_rejected_on_text_only_model_with_400(monkeypatch: pytest.MonkeyPatch):
     """A text-only model receiving image_url returns a 400 BadRequest with
     our error envelope — same shape llama.cpp produces."""
-    infer = _make_infer(supports_image=False)
+    infer = _make_infer(supports_image=False, monkeypatch=monkeypatch)
     request = ChatCompletionRequest(
         model="llm",
         messages=[
@@ -116,12 +127,12 @@ async def test_image_part_rejected_on_text_only_model_with_400():
 
 
 @pytest.mark.asyncio
-async def test_text_only_request_reaches_streaming_path_on_vlm():
+async def test_text_only_request_reaches_streaming_path_on_vlm(monkeypatch: pytest.MonkeyPatch):
     """Sanity check: a plain text request on a VLM is not blocked by the
     gating layer. Streaming, since non-stream no longer calls `_create_chat_completion_stream`
     (see test_vllm_engine_ops.py / test_integration.py::TestChatCapable for
     the engine_ops-based non-stream path; TestChatStreamingCapable for streaming)."""
-    infer = _make_infer(supports_image=True)
+    infer = _make_infer(supports_image=True, monkeypatch=monkeypatch)
     request = ChatCompletionRequest(
         model="qwen-vl",
         messages=[{"role": "user", "content": "hello"}],
@@ -134,14 +145,14 @@ async def test_text_only_request_reaches_streaming_path_on_vlm():
 
 
 @pytest.mark.asyncio
-async def test_model_chat_template_kwargs_merged_into_vllm_request():
+async def test_model_chat_template_kwargs_merged_into_vllm_request(monkeypatch: pytest.MonkeyPatch):
     """The model's chat_template_kwargs default reaches the vLLM request built
     for the streaming path."""
-    infer = _make_infer(supports_image=False)
+    infer = _make_infer(supports_image=False, monkeypatch=monkeypatch)
     infer.model_config.chat_template_kwargs = {"enable_thinking": False}
     request = ChatCompletionRequest(model="llm", messages=[{"role": "user", "content": "hi"}], stream=True)
 
     await infer.create_chat_completion(request, raw_request=MagicMock())
 
-    vllm_request = infer._create_chat_completion_stream.call_args.args[1]
-    assert vllm_request.chat_template_kwargs == {"enable_thinking": False}
+    prepared = infer._create_chat_completion_stream.call_args.args[1]
+    assert prepared.vllm_request.chat_template_kwargs == {"enable_thinking": False}


### PR DESCRIPTION
BaseInfer now owns request.stream dispatch via a generic _prepare_chat/ _prepare_responses hook plus overridable _create_*_stream/_create_*_no_stream seams, instead of vllm/llama_server hijacking one method for both paths.

Rendering moves into _prepare_* so pre-generation failures (including chat streaming) return a plain ErrorResponse instead of a mid-stream SSE error chunk, matching /responses and OpenAI's own behavior. This also removes _create_response_stream_or_error.

Collapses the vllm loader's 4x-duplicated render_and_params try/except into a single _render_bundle, replaces the two divergent per-loader _encode_error helpers with one encode_error_sse, and funnels every vllm-side error through a single _to_error_response -> create_error_response path (fixing a bug where vLLM's int-typed ErrorInfo.code was misrouted into modelship's string code field instead of the HTTP status).

