### PR TITLE
feat: add identity_key() caller-identity primitive for log correlation

### DIFF
--- a/docs/model-configuration.md
+++ b/docs/model-configuration.md
@@ -23,6 +23,7 @@ Models are configured in a YAML file (default: `config/models.yaml`). Each entry
 | `--no-metrics` | `MSHIP_METRICS` | enabled | Disable Prometheus metrics |
 | `--no-preflight` | `MSHIP_PREFLIGHT` | enabled | Disable preflight hardware auto-sizing; models run on loader/library defaults plus explicit config. Useful for benchmarking |
 | `--api-keys` | `MSHIP_API_KEYS` | — | Comma-separated API keys |
+| `--trusted-identity-header` | `MSHIP_TRUSTED_IDENTITY_HEADER` | — | Header name (e.g. `X-Consumer-Id`) a fronting credentials layer sets with a caller identity it already resolved and authorized. See [Trusted identity header](#trusted-identity-header) below |
 | `--max-request-body-bytes` | `MSHIP_MAX_REQUEST_BODY_BYTES` | `52428800` | Max request body size in bytes |
 
 ### Cache Directory Structure
@@ -63,6 +64,19 @@ Multiple gateways can run independently by using `--gateway-name`:
 python mship_deploy.py --config config/llm.yaml --gateway-name "llm-api"
 python mship_deploy.py --config config/tts.yaml --gateway-name "tts-api"
 ```
+
+## Trusted Identity Header
+
+modelship never authenticates callers itself — that's `MSHIP_API_KEYS`' job, and it stops at "is this caller allowed at all." modelship also has no concept of login, permissions, or per-model access control, and never will; those belong entirely to whatever sits in front of it (nginx, Kong, LiteLLM, a custom credentials layer). `MSHIP_TRUSTED_IDENTITY_HEADER` lets that fronting layer forward a caller identity it already resolved (e.g. a consumer/tenant id), which modelship uses purely for log correlation today and for scoping server-side state in the future — never for authorization.
+
+modelship trusts the header's value **unconditionally** — there is no signature check. That trust is only valid if both of the following hold:
+
+1. **The fronting layer unconditionally overwrites the header, stripping any client-supplied copy.** If it only sets the header when absent (or otherwise passes through a client-supplied value), a client can send `X-Consumer-Id: someone-elses-id` and impersonate them — this is independent of network placement and is the more common way this pattern is misconfigured.
+2. **modelship is reachable only from that fronting layer** — via network policy, a private subnet, or co-locating them on the same pod — never directly from any client. Anyone who can reach modelship's port directly can set this header themselves.
+
+For stronger guarantees than network isolation alone, add mTLS on that one internal hop (a service-mesh sidecar, Kong, or a local proxy terminating the connection) so the peer's certificate — not just network placement — proves the request came from the trusted layer. This is infrastructure the operator configures; modelship does not implement or verify certificates itself.
+
+If `MSHIP_TRUSTED_IDENTITY_HEADER` is unset (the default), modelship falls back to hashing the matched `MSHIP_API_KEYS` entry, and falls back further to a single shared bucket if no key matches either (or auth is disabled) — unchanged from today's behavior either way.
 
 ## Fields
 

--- a/modelship/infer/model_deployment.py
+++ b/modelship/infer/model_deployment.py
@@ -221,14 +221,22 @@ class ModelDeployment:
 
         request_id_var.set(request_id)
 
+    @staticmethod
+    def _set_identity(identity: str | None) -> None:
+        from modelship.logging import identity_var
+
+        identity_var.set(identity)
+
     async def generate(
         self,
         request: ChatCompletionRequest,
         request_headers: dict[str, str],
         disconnect_registry: Any,
         request_id: str | None = None,
+        identity: str | None = None,
     ):
         self._set_request_id(request_id)
+        self._set_identity(identity)
         proxy = RawRequestProxy(disconnect_registry, request_headers, request_id)
         start = time.monotonic()
         result = await self.infer.create_chat_completion(request, proxy)
@@ -251,8 +259,10 @@ class ModelDeployment:
         request_headers: dict[str, str],
         disconnect_registry: Any,
         request_id: str | None = None,
+        identity: str | None = None,
     ):
         self._set_request_id(request_id)
+        self._set_identity(identity)
         proxy = RawRequestProxy(disconnect_registry, request_headers, request_id)
         start = time.monotonic()
         result = await self.infer.create_response(request, proxy)
@@ -272,8 +282,10 @@ class ModelDeployment:
         request_headers: dict[str, str],
         disconnect_registry: Any,
         request_id: str | None = None,
+        identity: str | None = None,
     ):
         self._set_request_id(request_id)
+        self._set_identity(identity)
         proxy = RawRequestProxy(disconnect_registry, request_headers, request_id)
         start = time.monotonic()
         result = await self.infer.create_embedding(request, proxy)
@@ -291,8 +303,10 @@ class ModelDeployment:
         request_headers: dict[str, str],
         disconnect_registry: Any,
         request_id: str | None = None,
+        identity: str | None = None,
     ):
         self._set_request_id(request_id)
+        self._set_identity(identity)
         proxy = RawRequestProxy(disconnect_registry, request_headers, request_id)
         start = time.monotonic()
         result = await self.infer.create_transcription(audio_data, request, proxy)
@@ -310,8 +324,10 @@ class ModelDeployment:
         request_headers: dict[str, str],
         disconnect_registry: Any,
         request_id: str | None = None,
+        identity: str | None = None,
     ):
         self._set_request_id(request_id)
+        self._set_identity(identity)
         proxy = RawRequestProxy(disconnect_registry, request_headers, request_id)
         start = time.monotonic()
         result = await self.infer.create_translation(audio_data, request, proxy)
@@ -328,8 +344,10 @@ class ModelDeployment:
         request_headers: dict[str, str],
         disconnect_registry: Any,
         request_id: str | None = None,
+        identity: str | None = None,
     ):
         self._set_request_id(request_id)
+        self._set_identity(identity)
         proxy = RawRequestProxy(disconnect_registry, request_headers, request_id)
         start = time.monotonic()
         result = await self.infer.create_speech(request, proxy)
@@ -346,8 +364,10 @@ class ModelDeployment:
         request_headers: dict[str, str],
         disconnect_registry: Any,
         request_id: str | None = None,
+        identity: str | None = None,
     ):
         self._set_request_id(request_id)
+        self._set_identity(identity)
         proxy = RawRequestProxy(disconnect_registry, request_headers, request_id)
         start = time.monotonic()
         result = await self.infer.create_image_generation(request, proxy)
@@ -366,8 +386,10 @@ class ModelDeployment:
         request_headers: dict[str, str],
         disconnect_registry: Any,
         request_id: str | None = None,
+        identity: str | None = None,
     ):
         self._set_request_id(request_id)
+        self._set_identity(identity)
         proxy = RawRequestProxy(disconnect_registry, request_headers, request_id)
         start = time.monotonic()
         result = await self.infer.create_image_edit(image_data, mask_data, request, proxy)
@@ -385,8 +407,10 @@ class ModelDeployment:
         request_headers: dict[str, str],
         disconnect_registry: Any,
         request_id: str | None = None,
+        identity: str | None = None,
     ):
         self._set_request_id(request_id)
+        self._set_identity(identity)
         proxy = RawRequestProxy(disconnect_registry, request_headers, request_id)
         start = time.monotonic()
         result = await self.infer.create_image_variation(image_data, request, proxy)

--- a/modelship/logging.py
+++ b/modelship/logging.py
@@ -7,13 +7,21 @@ from logging.handlers import SysLogHandler
 from urllib.parse import urlparse
 
 request_id_var: contextvars.ContextVar[str | None] = contextvars.ContextVar("request_id", default=None)
+# Caller-identity fields for log correlation (see modelship.openai.auth.identity_key).
+# identity_tier records which resolution tier produced the identity ("header" /
+# "api_key" / "unscoped") so an unexpected shift to "unscoped" — e.g. a fronting
+# proxy that stopped setting the trusted header — is visible in logs.
+identity_var: contextvars.ContextVar[str | None] = contextvars.ContextVar("identity", default=None)
+identity_tier_var: contextvars.ContextVar[str | None] = contextvars.ContextVar("identity_tier", default=None)
 
 _configured = False
 
 
-class RequestIdFilter(logging.Filter):
+class RequestContextFilter(logging.Filter):
     def filter(self, record):
         record.request_id = request_id_var.get(None)
+        record.identity = identity_var.get(None)
+        record.identity_tier = identity_tier_var.get(None)
         return True
 
 
@@ -29,6 +37,12 @@ class ModelshipJsonFormatter(logging.Formatter):
         req_id = getattr(record, "request_id", None)
         if req_id:
             msg["request_id"] = req_id
+        identity = getattr(record, "identity", None)
+        if identity:
+            msg["identity"] = identity
+        identity_tier = getattr(record, "identity_tier", None)
+        if identity_tier:
+            msg["identity_tier"] = identity_tier
         if record.exc_info and record.exc_info[1] is not None:
             msg["exception"] = self.formatException(record.exc_info)
         return json.dumps(msg)
@@ -39,7 +53,9 @@ class ModelshipTextFormatter(logging.Formatter):
         ts = self.formatTime(record, self.datefmt)
         req_id = getattr(record, "request_id", None)
         req_part = f" [{req_id}]" if req_id else ""
-        base = f"[{ts}] {record.levelname:<8} {record.name}{req_part} | {record.getMessage()}"
+        identity = getattr(record, "identity", None)
+        id_part = f" id={identity}" if identity else ""
+        base = f"[{ts}] {record.levelname:<8} {record.name}{req_part}{id_part} | {record.getMessage()}"
         if record.exc_info and record.exc_info[1] is not None:
             base += "\n" + self.formatException(record.exc_info)
         return base
@@ -160,7 +176,7 @@ def configure_logging() -> None:
     else:
         handler.setFormatter(ModelshipTextFormatter(datefmt="%Y-%m-%d %H:%M:%S"))
 
-    handler.addFilter(RequestIdFilter())
+    handler.addFilter(RequestContextFilter())
     root_logger.addHandler(handler)
 
     # OpenTelemetry: add an OTLP log exporter as a second handler when configured.

--- a/modelship/openai/api.py
+++ b/modelship/openai/api.py
@@ -32,7 +32,7 @@ from modelship.metrics import (
     STREAM_CHUNKS_TOTAL,
     stamp_gateway,
 )
-from modelship.openai.auth import ApiKeyMiddleware, get_api_keys, identity_key, identity_tier
+from modelship.openai.auth import ApiKeyMiddleware, get_api_keys, resolve_identity
 from modelship.openai.protocol import (
     ChatCompletionRequest,
     ChatCompletionResponse,
@@ -362,9 +362,9 @@ class ModelshipAPI:
     def _set_identity(raw_request: Request) -> str:
         from modelship.logging import identity_tier_var, identity_var
 
-        identity = identity_key(raw_request)
+        identity, tier = resolve_identity(raw_request)
         identity_var.set(identity)
-        identity_tier_var.set(identity_tier(raw_request))
+        identity_tier_var.set(tier)
         return identity
 
     def _get_handle(self, model_name: str | None) -> DeploymentHandle:

--- a/modelship/openai/api.py
+++ b/modelship/openai/api.py
@@ -32,7 +32,7 @@ from modelship.metrics import (
     STREAM_CHUNKS_TOTAL,
     stamp_gateway,
 )
-from modelship.openai.auth import ApiKeyMiddleware, get_api_keys
+from modelship.openai.auth import ApiKeyMiddleware, get_api_keys, identity_key, identity_tier
 from modelship.openai.protocol import (
     ChatCompletionRequest,
     ChatCompletionResponse,
@@ -358,6 +358,15 @@ class ModelshipAPI:
 
         request_id_var.set(request_id)
 
+    @staticmethod
+    def _set_identity(raw_request: Request) -> str:
+        from modelship.logging import identity_tier_var, identity_var
+
+        identity = identity_key(raw_request)
+        identity_var.set(identity)
+        identity_tier_var.set(identity_tier(raw_request))
+        return identity
+
     def _get_handle(self, model_name: str | None) -> DeploymentHandle:
         self._ensure_watching()
         if model_name is None or model_name not in self.models:
@@ -516,6 +525,7 @@ class ModelshipAPI:
     async def create_chat_completion(self, request: ChatCompletionRequest, raw_request: Request):
         req_id = random_uuid()
         self._set_request_id(req_id)
+        identity = self._set_identity(raw_request)
         model = request.model or ""
         handle = self._get_handle(request.model)
         watcher = RequestWatcher(raw_request, req_id, model=model, endpoint="create_chat_completion")
@@ -537,13 +547,14 @@ class ModelshipAPI:
             request.max_tokens,
         )
         logger.debug("chat_completion full request: %s", request.model_dump_json())
-        response_gen = handle.generate.options(stream=True).remote(request, headers, watcher.registry, req_id)
+        response_gen = handle.generate.options(stream=True).remote(request, headers, watcher.registry, req_id, identity)
         return await self._handle_response(response_gen, watcher, model, "create_chat_completion")
 
     @app.post("/v1/responses")
     async def create_response(self, request: ResponsesRequest, raw_request: Request):
         req_id = random_uuid()
         self._set_request_id(req_id)
+        identity = self._set_identity(raw_request)
         model = request.model or ""
         handle = self._get_handle(request.model)
         watcher = RequestWatcher(raw_request, req_id, model=model, endpoint="create_response")
@@ -560,7 +571,7 @@ class ModelshipAPI:
         # doesn't overload on the stream literal, so narrow it explicitly.
         response_gen = cast(
             "DeploymentResponseGenerator[Any]",
-            handle.respond.options(stream=True).remote(request, headers, watcher.registry, req_id),
+            handle.respond.options(stream=True).remote(request, headers, watcher.registry, req_id, identity),
         )
         return await self._handle_response(response_gen, watcher, model, "create_response")
 
@@ -568,18 +579,20 @@ class ModelshipAPI:
     async def create_embeddings(self, request: EmbeddingRequest, raw_request: Request):
         req_id = random_uuid()
         self._set_request_id(req_id)
+        identity = self._set_identity(raw_request)
         model = request.model or ""
         handle = self._get_handle(request.model)
         watcher = RequestWatcher(raw_request, req_id, model=model, endpoint="create_embeddings")
         headers = dict(raw_request.headers)
         logger.info("embeddings model=%s", model)
-        response_gen = handle.embed.options(stream=True).remote(request, headers, watcher.registry, req_id)
+        response_gen = handle.embed.options(stream=True).remote(request, headers, watcher.registry, req_id, identity)
         return await self._handle_response(response_gen, watcher, model, "create_embeddings")
 
     @app.post("/v1/audio/transcriptions")
     async def create_transcriptions(self, request: Annotated[TranscriptionRequest, Form()], raw_request: Request):
         req_id = random_uuid()
         self._set_request_id(req_id)
+        identity = self._set_identity(raw_request)
         model = request.model or ""
         handle = self._get_handle(request.model)
         watcher = RequestWatcher(raw_request, req_id, model=model, endpoint="create_transcriptions")
@@ -593,7 +606,7 @@ class ModelshipAPI:
             await request.file.close()
         request_no_file = TranscriptionRequest.model_construct(**request.model_dump(exclude={"file"}))
         response_gen = handle.transcribe.options(stream=True).remote(
-            audio_data, request_no_file, headers, watcher.registry, req_id
+            audio_data, request_no_file, headers, watcher.registry, req_id, identity
         )
         return await self._handle_response(response_gen, watcher, model, "create_transcriptions")
 
@@ -601,6 +614,7 @@ class ModelshipAPI:
     async def create_translations(self, request: Annotated[TranslationRequest, Form()], raw_request: Request):
         req_id = random_uuid()
         self._set_request_id(req_id)
+        identity = self._set_identity(raw_request)
         model = request.model or ""
         handle = self._get_handle(request.model)
         watcher = RequestWatcher(raw_request, req_id, model=model, endpoint="create_translations")
@@ -614,7 +628,7 @@ class ModelshipAPI:
             await request.file.close()
         request_no_file = TranslationRequest.model_construct(**request.model_dump(exclude={"file"}))
         response_gen = handle.translate.options(stream=True).remote(
-            audio_data, request_no_file, headers, watcher.registry, req_id
+            audio_data, request_no_file, headers, watcher.registry, req_id, identity
         )
         return await self._handle_response(response_gen, watcher, model, "create_translations")
 
@@ -622,31 +636,34 @@ class ModelshipAPI:
     async def create_speech(self, request: SpeechRequest, raw_request: Request):
         req_id = random_uuid()
         self._set_request_id(req_id)
+        identity = self._set_identity(raw_request)
         logger.info("speech model=%s voice=%s format=%s", request.model, request.voice, request.response_format)
         logger.debug("speech full request: %s", request.model_dump_json())
         handle = self._get_handle(request.model)
         watcher = RequestWatcher(raw_request, req_id, model=request.model, endpoint="create_speech")
         headers = dict(raw_request.headers)
-        response_gen = handle.speak.options(stream=True).remote(request, headers, watcher.registry, req_id)
+        response_gen = handle.speak.options(stream=True).remote(request, headers, watcher.registry, req_id, identity)
         return await self._handle_response(response_gen, watcher, request.model, "create_speech")
 
     @app.post("/v1/images/generations")
     async def create_image(self, request: ImageGenerationRequest, raw_request: Request):
         req_id = random_uuid()
         self._set_request_id(req_id)
+        identity = self._set_identity(raw_request)
         logger.info(
             "image_generation model=%s prompt=%r n=%d size=%s", request.model, request.prompt, request.n, request.size
         )
         handle = self._get_handle(request.model)
         watcher = RequestWatcher(raw_request, req_id, model=request.model, endpoint="create_image")
         headers = dict(raw_request.headers)
-        response_gen = handle.imagine.options(stream=True).remote(request, headers, watcher.registry, req_id)
+        response_gen = handle.imagine.options(stream=True).remote(request, headers, watcher.registry, req_id, identity)
         return await self._handle_response(response_gen, watcher, request.model, "create_image")
 
     @app.post("/v1/images/edits")
     async def create_image_edit(self, request: Annotated[ImageEditRequest, Form()], raw_request: Request):
         req_id = random_uuid()
         self._set_request_id(req_id)
+        identity = self._set_identity(raw_request)
         logger.info(
             "image_edit model=%s prompt=%r n=%d size=%s mask=%s",
             request.model,
@@ -672,7 +689,7 @@ class ModelshipAPI:
                 await request.mask.close()
         request_no_file = ImageEditRequest.model_construct(**request.model_dump(exclude={"image", "mask"}))
         response_gen = handle.edit_image.options(stream=True).remote(
-            image_data, mask_data, request_no_file, headers, watcher.registry, req_id
+            image_data, mask_data, request_no_file, headers, watcher.registry, req_id, identity
         )
         return await self._handle_response(response_gen, watcher, request.model, "create_image_edit")
 
@@ -680,6 +697,7 @@ class ModelshipAPI:
     async def create_image_variation(self, request: Annotated[ImageVariationRequest, Form()], raw_request: Request):
         req_id = random_uuid()
         self._set_request_id(req_id)
+        identity = self._set_identity(raw_request)
         logger.info("image_variation model=%s n=%d size=%s", request.model, request.n, request.size)
         handle = self._get_handle(request.model)
         watcher = RequestWatcher(raw_request, req_id, model=request.model, endpoint="create_image_variation")
@@ -694,6 +712,6 @@ class ModelshipAPI:
             await request.image.close()
         request_no_file = ImageVariationRequest.model_construct(**request.model_dump(exclude={"image"}))
         response_gen = handle.vary_image.options(stream=True).remote(
-            image_data, request_no_file, headers, watcher.registry, req_id
+            image_data, request_no_file, headers, watcher.registry, req_id, identity
         )
         return await self._handle_response(response_gen, watcher, request.model, "create_image_variation")

--- a/modelship/openai/auth.py
+++ b/modelship/openai/auth.py
@@ -26,6 +26,13 @@ UNSCOPED_IDENTITY = "unscoped"
 # ever propagating untrusted bytes into a log line or a state-store key.
 _SAFE_IDENTITY_RE = re.compile(r"^[A-Za-z0-9_.:-]{1,128}$")
 
+# (raw env string, parsed value) caches for get_api_keys()/get_trusted_identity_header().
+# Keyed on the raw string rather than parsed once at import time so tests using
+# patch.dict(os.environ, ...) still see up-to-date values with no manual cache clearing —
+# the cache only pays off across the many requests within one unchanging-env process.
+_api_keys_cache: tuple[str, set[str]] | None = None
+_trusted_header_cache: tuple[str, str | None] | None = None
+
 
 class ApiKeyMiddleware(BaseHTTPMiddleware):
     """Validates ``Authorization: Bearer <key>`` against a set of allowed API keys."""
@@ -73,17 +80,30 @@ def _matched_api_key(token: str, keys: set[str]) -> str | None:
 
 def get_api_keys() -> set[str]:
     """Read allowed API keys from the ``MSHIP_API_KEYS`` environment variable (comma-separated)."""
+    global _api_keys_cache
     raw = os.environ.get("MSHIP_API_KEYS", "")
-    return {k.strip() for k in raw.split(",") if k.strip()}
+    cached = _api_keys_cache
+    if cached is not None and cached[0] == raw:
+        return cached[1]
+    keys = {k.strip() for k in raw.split(",") if k.strip()}
+    _api_keys_cache = (raw, keys)
+    return keys
 
 
 def get_trusted_identity_header() -> str | None:
     """Read the trusted identity header name from ``MSHIP_TRUSTED_IDENTITY_HEADER``, if set."""
-    return os.environ.get("MSHIP_TRUSTED_IDENTITY_HEADER", "").strip() or None
+    global _trusted_header_cache
+    raw = os.environ.get("MSHIP_TRUSTED_IDENTITY_HEADER", "")
+    cached = _trusted_header_cache
+    if cached is not None and cached[0] == raw:
+        return cached[1]
+    value = raw.strip() or None
+    _trusted_header_cache = (raw, value)
+    return value
 
 
-def identity_key(request: Request) -> str:
-    """Resolve a stable per-caller identity string for log correlation and future state-keying.
+def resolve_identity(request: Request) -> tuple[str, str]:
+    """Resolve (identity_key, identity_tier) in one pass and cache the result on ``request.state``.
 
     Not an auth check — never rejects a request. Resolution order:
 
@@ -91,40 +111,50 @@ def identity_key(request: Request) -> str:
        raw header value (sanitized) — a non-secret identifier an operator's
        credentials layer assigned, kept legible in logs/state keys. Requires that
        layer to unconditionally overwrite the header and modelship to be
-       unreachable except from it (see docs/model-configuration.md).
+       unreachable except from it (see docs/model-configuration.md). Tier: "header".
     2. The matched ``MSHIP_API_KEYS`` entry: sha256 hex (key material never
-       appears in logs or keys).
-    3. Neither: ``UNSCOPED_IDENTITY`` — every such caller shares one bucket.
+       appears in logs or keys). Tier: "api_key".
+    3. Neither: ``UNSCOPED_IDENTITY`` — every such caller shares one bucket. Tier: "unscoped".
+
+    identity_key() and identity_tier() both delegate here so the header lookup, token
+    extraction, and constant-time key match happen once per request instead of twice.
     """
+    # isinstance-gated rather than an `is not None` check: a MagicMock `request` (used
+    # throughout the test suite) auto-vivifies `.state._identity` as another MagicMock
+    # rather than raising AttributeError, which would otherwise look like a valid cache hit.
+    cached = getattr(request.state, "_identity", None)
+    if isinstance(cached, tuple):
+        return cached
+
     header_name = get_trusted_identity_header()
     if header_name:
         value = request.headers.get(header_name, "").strip()
         if value:
-            return value if _SAFE_IDENTITY_RE.match(value) else hashlib.sha256(value.encode()).hexdigest()
+            key = value if _SAFE_IDENTITY_RE.match(value) else hashlib.sha256(value.encode()).hexdigest()
+            request.state._identity = (key, "header")
+            return request.state._identity
 
     auth = request.headers.get("authorization", "")
     token = auth[7:] if auth.startswith("Bearer ") else ""
     if token:
         matched = _matched_api_key(token, get_api_keys())
         if matched is not None:
-            return hashlib.sha256(matched.encode()).hexdigest()
+            request.state._identity = (hashlib.sha256(matched.encode()).hexdigest(), "api_key")
+            return request.state._identity
 
-    return UNSCOPED_IDENTITY
+    request.state._identity = (UNSCOPED_IDENTITY, "unscoped")
+    return request.state._identity
+
+
+def identity_key(request: Request) -> str:
+    """Resolve a stable per-caller identity string for log correlation and future state-keying."""
+    return resolve_identity(request)[0]
 
 
 def identity_tier(request: Request) -> str:
-    """Return which identity_key() tier would resolve for *request*: "header" / "api_key" / "unscoped".
+    """Return which identity_key() tier resolved for *request*: "header" / "api_key" / "unscoped".
 
     For logging/observability only — lets an unexpected shift to "unscoped" (e.g. a
     fronting proxy that stopped setting the trusted header) show up in logs.
     """
-    header_name = get_trusted_identity_header()
-    if header_name and request.headers.get(header_name, "").strip():
-        return "header"
-
-    auth = request.headers.get("authorization", "")
-    token = auth[7:] if auth.startswith("Bearer ") else ""
-    if token and _matched_api_key(token, get_api_keys()) is not None:
-        return "api_key"
-
-    return "unscoped"
+    return resolve_identity(request)[1]

--- a/modelship/openai/auth.py
+++ b/modelship/openai/auth.py
@@ -21,10 +21,11 @@ _PUBLIC_PATHS = {"/health"}
 UNSCOPED_IDENTITY = "unscoped"
 
 # Charset a trusted-header identity value must match to be used raw (as a log
-# field / state-key segment). Anything outside this — newlines, "/", "..",
-# control chars, or overlong values — falls back to a sha256 hash instead of
-# ever propagating untrusted bytes into a log line or a state-store key.
-_SAFE_IDENTITY_RE = re.compile(r"^[A-Za-z0-9_.:-]{1,128}$")
+# field / state-key segment). Anything outside this — newlines, "/", control
+# chars, or overlong values — falls back to a sha256 hash instead of ever
+# propagating untrusted bytes into a log line or a state-store key. "." is in
+_SAFE_IDENTITY_RE = re.compile(r"^(?!\.\.?$)[A-Za-z0-9_.:-]{1,128}$")
+
 
 # (raw env string, parsed value) caches for get_api_keys()/get_trusted_identity_header().
 # Keyed on the raw string rather than parsed once at import time so tests using

--- a/modelship/openai/auth.py
+++ b/modelship/openai/auth.py
@@ -119,10 +119,8 @@ def resolve_identity(request: Request) -> tuple[str, str]:
     identity_key() and identity_tier() both delegate here so the header lookup, token
     extraction, and constant-time key match happen once per request instead of twice.
     """
-    # isinstance-gated rather than an `is not None` check: a MagicMock `request` (used
-    # throughout the test suite) auto-vivifies `.state._identity` as another MagicMock
-    # rather than raising AttributeError, which would otherwise look like a valid cache hit.
-    cached = getattr(request.state, "_identity", None)
+    state = getattr(request, "state", None)
+    cached = getattr(state, "_identity", None) if state is not None else None
     if isinstance(cached, tuple):
         return cached
 
@@ -131,19 +129,25 @@ def resolve_identity(request: Request) -> tuple[str, str]:
         value = request.headers.get(header_name, "").strip()
         if value:
             key = value if _SAFE_IDENTITY_RE.match(value) else hashlib.sha256(value.encode()).hexdigest()
-            request.state._identity = (key, "header")
-            return request.state._identity
+            result = (key, "header")
+            if state is not None:
+                state._identity = result
+            return result
 
     auth = request.headers.get("authorization", "")
     token = auth[7:] if auth.startswith("Bearer ") else ""
     if token:
         matched = _matched_api_key(token, get_api_keys())
         if matched is not None:
-            request.state._identity = (hashlib.sha256(matched.encode()).hexdigest(), "api_key")
-            return request.state._identity
+            result = (hashlib.sha256(matched.encode()).hexdigest(), "api_key")
+            if state is not None:
+                state._identity = result
+            return result
 
-    request.state._identity = (UNSCOPED_IDENTITY, "unscoped")
-    return request.state._identity
+    result = (UNSCOPED_IDENTITY, "unscoped")
+    if state is not None:
+        state._identity = result
+    return result
 
 
 def identity_key(request: Request) -> str:

--- a/modelship/openai/auth.py
+++ b/modelship/openai/auth.py
@@ -1,5 +1,7 @@
+import hashlib
 import hmac
 import os
+import re
 
 from starlette.middleware.base import BaseHTTPMiddleware
 from starlette.requests import Request
@@ -11,6 +13,18 @@ from modelship.metrics import AUTH_FAILURES_TOTAL
 logger = get_logger("api.auth")
 
 _PUBLIC_PATHS = {"/health"}
+
+# Sentinel returned by identity_key() when no identity is resolvable (no trusted
+# header, no matched API key). Deliberately not hash-shaped (a sha256 hex digest
+# is 64 lowercase hex chars) so it can never collide with a real identity value.
+# Every caller with no resolvable identity shares this one bucket.
+UNSCOPED_IDENTITY = "unscoped"
+
+# Charset a trusted-header identity value must match to be used raw (as a log
+# field / state-key segment). Anything outside this — newlines, "/", "..",
+# control chars, or overlong values — falls back to a sha256 hash instead of
+# ever propagating untrusted bytes into a log line or a state-store key.
+_SAFE_IDENTITY_RE = re.compile(r"^[A-Za-z0-9_.:-]{1,128}$")
 
 
 class ApiKeyMiddleware(BaseHTTPMiddleware):
@@ -41,7 +55,7 @@ class ApiKeyMiddleware(BaseHTTPMiddleware):
                 },
             )
 
-        if not any(hmac.compare_digest(token, key) for key in self.api_keys):
+        if _matched_api_key(token, self.api_keys) is None:
             AUTH_FAILURES_TOTAL.inc(tags={"reason": "invalid"})
             logger.warning("auth failed (invalid key): %s %s", request.method, request.url.path)
             return JSONResponse(
@@ -52,7 +66,65 @@ class ApiKeyMiddleware(BaseHTTPMiddleware):
         return await call_next(request)
 
 
+def _matched_api_key(token: str, keys: set[str]) -> str | None:
+    """Return the key in *keys* that constant-time-matches *token*, or None."""
+    return next((key for key in keys if hmac.compare_digest(token, key)), None)
+
+
 def get_api_keys() -> set[str]:
     """Read allowed API keys from the ``MSHIP_API_KEYS`` environment variable (comma-separated)."""
     raw = os.environ.get("MSHIP_API_KEYS", "")
     return {k.strip() for k in raw.split(",") if k.strip()}
+
+
+def get_trusted_identity_header() -> str | None:
+    """Read the trusted identity header name from ``MSHIP_TRUSTED_IDENTITY_HEADER``, if set."""
+    return os.environ.get("MSHIP_TRUSTED_IDENTITY_HEADER", "").strip() or None
+
+
+def identity_key(request: Request) -> str:
+    """Resolve a stable per-caller identity string for log correlation and future state-keying.
+
+    Not an auth check — never rejects a request. Resolution order:
+
+    1. A configured ``MSHIP_TRUSTED_IDENTITY_HEADER`` present on the request: the
+       raw header value (sanitized) — a non-secret identifier an operator's
+       credentials layer assigned, kept legible in logs/state keys. Requires that
+       layer to unconditionally overwrite the header and modelship to be
+       unreachable except from it (see docs/model-configuration.md).
+    2. The matched ``MSHIP_API_KEYS`` entry: sha256 hex (key material never
+       appears in logs or keys).
+    3. Neither: ``UNSCOPED_IDENTITY`` — every such caller shares one bucket.
+    """
+    header_name = get_trusted_identity_header()
+    if header_name:
+        value = request.headers.get(header_name, "").strip()
+        if value:
+            return value if _SAFE_IDENTITY_RE.match(value) else hashlib.sha256(value.encode()).hexdigest()
+
+    auth = request.headers.get("authorization", "")
+    token = auth[7:] if auth.startswith("Bearer ") else ""
+    if token:
+        matched = _matched_api_key(token, get_api_keys())
+        if matched is not None:
+            return hashlib.sha256(matched.encode()).hexdigest()
+
+    return UNSCOPED_IDENTITY
+
+
+def identity_tier(request: Request) -> str:
+    """Return which identity_key() tier would resolve for *request*: "header" / "api_key" / "unscoped".
+
+    For logging/observability only — lets an unexpected shift to "unscoped" (e.g. a
+    fronting proxy that stopped setting the trusted header) show up in logs.
+    """
+    header_name = get_trusted_identity_header()
+    if header_name and request.headers.get(header_name, "").strip():
+        return "header"
+
+    auth = request.headers.get("authorization", "")
+    token = auth[7:] if auth.startswith("Bearer ") else ""
+    if token and _matched_api_key(token, get_api_keys()) is not None:
+        return "api_key"
+
+    return "unscoped"

--- a/modelship/utils/cli.py
+++ b/modelship/utils/cli.py
@@ -16,6 +16,7 @@ _STRING_ARG_TO_ENV: dict[str, str] = {
     "log_target": "MSHIP_LOG_TARGET",
     "otel_endpoint": "OTEL_EXPORTER_OTLP_ENDPOINT",
     "api_keys": "MSHIP_API_KEYS",
+    "trusted_identity_header": "MSHIP_TRUSTED_IDENTITY_HEADER",
     "gateway_name": "MSHIP_GATEWAY_NAME",
 }
 
@@ -83,6 +84,16 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         ),
     )
     parser.add_argument("--api-keys", help="Comma-separated API keys (env: MSHIP_API_KEYS)")
+    parser.add_argument(
+        "--trusted-identity-header",
+        help=(
+            "Header name (e.g. X-Consumer-Id) whose value a fronting credentials layer has "
+            "already resolved and authorized; modelship trusts it unconditionally for log "
+            "correlation and future state-keying (env: MSHIP_TRUSTED_IDENTITY_HEADER). "
+            "Only enable when modelship is reachable exclusively from that layer — see "
+            "docs/model-configuration.md."
+        ),
+    )
     parser.add_argument(
         "--max-request-body-bytes", type=int, help="Max request body size in bytes (env: MSHIP_MAX_REQUEST_BODY_BYTES)"
     )

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,5 +1,6 @@
 """Tests for API key authentication middleware."""
 
+import hashlib
 import os
 from unittest.mock import patch
 
@@ -8,7 +9,22 @@ from fastapi.testclient import TestClient
 from starlette.requests import Request
 from starlette.responses import JSONResponse
 
-from modelship.openai.auth import ApiKeyMiddleware, get_api_keys
+from modelship.openai.auth import (
+    UNSCOPED_IDENTITY,
+    ApiKeyMiddleware,
+    get_api_keys,
+    identity_key,
+    identity_tier,
+)
+
+
+def _make_request(headers: dict[str, str] | None = None) -> Request:
+    """Build a bare Request carrying only the given headers, for identity_key/identity_tier tests."""
+    scope = {
+        "type": "http",
+        "headers": [(k.lower().encode(), v.encode()) for k, v in (headers or {}).items()],
+    }
+    return Request(scope)
 
 
 def _make_app(api_keys: set[str]) -> FastAPI:
@@ -124,3 +140,94 @@ class TestGetApiKeys:
         with patch.dict(os.environ, {"MSHIP_API_KEYS": "sk-a,,,,sk-b,"}):
             keys = get_api_keys()
         assert keys == {"sk-a", "sk-b"}
+
+
+class TestIdentityKey:
+    def test_trusted_header_used_raw(self):
+        env = {"MSHIP_TRUSTED_IDENTITY_HEADER": "X-Consumer-Id", "MSHIP_API_KEYS": ""}
+        with patch.dict(os.environ, env):
+            request = _make_request({"X-Consumer-Id": "customer-42"})
+            assert identity_key(request) == "customer-42"
+
+    def test_trusted_header_stripped(self):
+        env = {"MSHIP_TRUSTED_IDENTITY_HEADER": "X-Consumer-Id"}
+        with patch.dict(os.environ, env):
+            request = _make_request({"X-Consumer-Id": "  customer-42  "})
+            assert identity_key(request) == "customer-42"
+
+    def test_header_configured_but_absent_falls_back_to_matched_key(self):
+        env = {"MSHIP_TRUSTED_IDENTITY_HEADER": "X-Consumer-Id", "MSHIP_API_KEYS": "sk-a"}
+        with patch.dict(os.environ, env):
+            request = _make_request({"Authorization": "Bearer sk-a"})
+            assert identity_key(request) == hashlib.sha256(b"sk-a").hexdigest()
+
+    def test_header_configured_but_empty_falls_back(self):
+        env = {"MSHIP_TRUSTED_IDENTITY_HEADER": "X-Consumer-Id", "MSHIP_API_KEYS": "sk-a"}
+        with patch.dict(os.environ, env):
+            request = _make_request({"X-Consumer-Id": "   ", "Authorization": "Bearer sk-a"})
+            assert identity_key(request) == hashlib.sha256(b"sk-a").hexdigest()
+
+    def test_header_wins_over_matched_key(self):
+        env = {"MSHIP_TRUSTED_IDENTITY_HEADER": "X-Consumer-Id", "MSHIP_API_KEYS": "sk-a"}
+        with patch.dict(os.environ, env):
+            request = _make_request({"X-Consumer-Id": "customer-42", "Authorization": "Bearer sk-a"})
+            assert identity_key(request) == "customer-42"
+
+    def test_matched_key_hashed_when_no_header_configured(self):
+        with patch.dict(os.environ, {"MSHIP_API_KEYS": "sk-a,sk-b"}, clear=False):
+            os.environ.pop("MSHIP_TRUSTED_IDENTITY_HEADER", None)
+            request = _make_request({"Authorization": "Bearer sk-a"})
+            assert identity_key(request) == hashlib.sha256(b"sk-a").hexdigest()
+
+    def test_distinct_keys_yield_distinct_hashes(self):
+        with patch.dict(os.environ, {"MSHIP_API_KEYS": "sk-a,sk-b"}, clear=False):
+            os.environ.pop("MSHIP_TRUSTED_IDENTITY_HEADER", None)
+            id_a = identity_key(_make_request({"Authorization": "Bearer sk-a"}))
+            id_b = identity_key(_make_request({"Authorization": "Bearer sk-b"}))
+        assert id_a != id_b
+
+    def test_no_header_no_key_returns_unscoped_sentinel(self):
+        with patch.dict(os.environ, {"MSHIP_API_KEYS": ""}, clear=False):
+            os.environ.pop("MSHIP_TRUSTED_IDENTITY_HEADER", None)
+            request = _make_request()
+            result = identity_key(request)
+        assert result == UNSCOPED_IDENTITY
+        # Must never collide with a real sha256 hex digest (64 lowercase hex chars).
+        assert len(result) != 64 or not all(c in "0123456789abcdef" for c in result)
+
+    def test_unsafe_header_value_falls_back_to_hash(self):
+        env = {"MSHIP_TRUSTED_IDENTITY_HEADER": "X-Consumer-Id"}
+        with patch.dict(os.environ, env):
+            unsafe = "../../etc/passwd"
+            request = _make_request({"X-Consumer-Id": unsafe})
+            result = identity_key(request)
+        assert result == hashlib.sha256(unsafe.encode()).hexdigest()
+        assert "/" not in result
+
+    def test_overlong_header_value_falls_back_to_hash(self):
+        env = {"MSHIP_TRUSTED_IDENTITY_HEADER": "X-Consumer-Id"}
+        with patch.dict(os.environ, env):
+            overlong = "a" * 200
+            request = _make_request({"X-Consumer-Id": overlong})
+            result = identity_key(request)
+        assert result == hashlib.sha256(overlong.encode()).hexdigest()
+
+
+class TestIdentityTier:
+    def test_header_tier(self):
+        env = {"MSHIP_TRUSTED_IDENTITY_HEADER": "X-Consumer-Id"}
+        with patch.dict(os.environ, env):
+            request = _make_request({"X-Consumer-Id": "customer-42"})
+            assert identity_tier(request) == "header"
+
+    def test_api_key_tier(self):
+        with patch.dict(os.environ, {"MSHIP_API_KEYS": "sk-a"}, clear=False):
+            os.environ.pop("MSHIP_TRUSTED_IDENTITY_HEADER", None)
+            request = _make_request({"Authorization": "Bearer sk-a"})
+            assert identity_tier(request) == "api_key"
+
+    def test_unscoped_tier(self):
+        with patch.dict(os.environ, {"MSHIP_API_KEYS": ""}, clear=False):
+            os.environ.pop("MSHIP_TRUSTED_IDENTITY_HEADER", None)
+            request = _make_request()
+            assert identity_tier(request) == "unscoped"

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -13,8 +13,10 @@ from modelship.openai.auth import (
     UNSCOPED_IDENTITY,
     ApiKeyMiddleware,
     get_api_keys,
+    get_trusted_identity_header,
     identity_key,
     identity_tier,
+    resolve_identity,
 )
 
 
@@ -231,3 +233,44 @@ class TestIdentityTier:
             os.environ.pop("MSHIP_TRUSTED_IDENTITY_HEADER", None)
             request = _make_request()
             assert identity_tier(request) == "unscoped"
+
+
+class TestEnvCaching:
+    """get_api_keys()/get_trusted_identity_header() cache on the raw env string, so a
+    changed env value must still be picked up (only an unchanged raw string should hit cache)."""
+
+    def test_get_api_keys_reflects_env_change(self):
+        with patch.dict(os.environ, {"MSHIP_API_KEYS": "sk-a"}, clear=False):
+            assert get_api_keys() == {"sk-a"}
+        with patch.dict(os.environ, {"MSHIP_API_KEYS": "sk-b"}, clear=False):
+            assert get_api_keys() == {"sk-b"}
+
+    def test_get_trusted_identity_header_reflects_env_change(self):
+        with patch.dict(os.environ, {"MSHIP_TRUSTED_IDENTITY_HEADER": "X-A"}, clear=False):
+            assert get_trusted_identity_header() == "X-A"
+        with patch.dict(os.environ, {"MSHIP_TRUSTED_IDENTITY_HEADER": "X-B"}, clear=False):
+            assert get_trusted_identity_header() == "X-B"
+
+
+class TestResolveIdentityCaching:
+    """resolve_identity() caches its result on request.state so a second call for the
+    same request is free and stable even if env vars change in between."""
+
+    def test_result_is_cached_on_request_state(self):
+        with patch.dict(os.environ, {"MSHIP_API_KEYS": "sk-a"}, clear=False):
+            os.environ.pop("MSHIP_TRUSTED_IDENTITY_HEADER", None)
+            request = _make_request({"Authorization": "Bearer sk-a"})
+            first = resolve_identity(request)
+            os.environ["MSHIP_API_KEYS"] = "sk-b"
+            second = resolve_identity(request)
+        assert first == second == (hashlib.sha256(b"sk-a").hexdigest(), "api_key")
+
+    def test_identity_key_and_identity_tier_share_one_resolution(self):
+        with patch.dict(os.environ, {"MSHIP_API_KEYS": "sk-a"}, clear=False):
+            os.environ.pop("MSHIP_TRUSTED_IDENTITY_HEADER", None)
+            request = _make_request({"Authorization": "Bearer sk-a"})
+            key = identity_key(request)
+            os.environ["MSHIP_API_KEYS"] = "sk-b"
+            tier = identity_tier(request)
+        assert key == hashlib.sha256(b"sk-a").hexdigest()
+        assert tier == "api_key"

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -214,6 +214,22 @@ class TestIdentityKey:
             result = identity_key(request)
         assert result == hashlib.sha256(overlong.encode()).hexdigest()
 
+    def test_dot_dot_header_value_falls_back_to_hash(self):
+        """ ".." matches the charset (dots are allowed mid-value, e.g. "svc.billing") but as
+        a whole segment would traverse a future file-based state store keyed by this value."""
+        env = {"MSHIP_TRUSTED_IDENTITY_HEADER": "X-Consumer-Id"}
+        with patch.dict(os.environ, env):
+            request = _make_request({"X-Consumer-Id": ".."})
+            result = identity_key(request)
+        assert result == hashlib.sha256(b"..").hexdigest()
+
+    def test_single_dot_header_value_falls_back_to_hash(self):
+        env = {"MSHIP_TRUSTED_IDENTITY_HEADER": "X-Consumer-Id"}
+        with patch.dict(os.environ, env):
+            request = _make_request({"X-Consumer-Id": "."})
+            result = identity_key(request)
+        assert result == hashlib.sha256(b".").hexdigest()
+
 
 class TestIdentityTier:
     def test_header_tier(self):

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -274,3 +274,18 @@ class TestResolveIdentityCaching:
             tier = identity_tier(request)
         assert key == hashlib.sha256(b"sk-a").hexdigest()
         assert tier == "api_key"
+
+    def test_request_like_object_without_state_attribute(self):
+        """A request-like object with no `state` attribute at all must not raise —
+        caching is simply skipped, resolution still succeeds every call."""
+
+        class _NoStateRequest:
+            def __init__(self, headers: dict[str, str]) -> None:
+                self.headers = headers
+
+        with patch.dict(os.environ, {"MSHIP_API_KEYS": "sk-a"}, clear=False):
+            os.environ.pop("MSHIP_TRUSTED_IDENTITY_HEADER", None)
+            request = _NoStateRequest({"authorization": "Bearer sk-a"})
+            assert not hasattr(request, "state")
+            result = resolve_identity(request)  # type: ignore[arg-type]
+        assert result == (hashlib.sha256(b"sk-a").hexdigest(), "api_key")

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -15,11 +15,13 @@ from modelship.logging import (
     _LOWERCASE_LEVEL_LIBS,
     ModelshipJsonFormatter,
     ModelshipTextFormatter,
-    RequestIdFilter,
+    RequestContextFilter,
     _parse_syslog_target,
     _setup_otel,
     configure_logging,
     get_logger,
+    identity_tier_var,
+    identity_var,
     propagate_lib_log_env,
     request_id_var,
 )
@@ -43,8 +45,12 @@ def _reset_logging():
     for k in _LIB_ENV_VARS:
         os.environ.pop(k, None)
     token = request_id_var.set(None)
+    identity_token = identity_var.set(None)
+    identity_tier_token = identity_tier_var.set(None)
     yield
     request_id_var.reset(token)
+    identity_var.reset(identity_token)
+    identity_tier_var.reset(identity_tier_token)
     yl._configured = False
     root.handlers.clear()
     for name, lvl in saved_lib_levels.items():
@@ -157,19 +163,30 @@ class TestVllmConfigureLoggingOptOut:
             assert os.environ["VLLM_CONFIGURE_LOGGING"] == "1"
 
 
-class TestRequestIdFilter:
+class TestRequestContextFilter:
     def test_injects_request_id(self):
-        filt = RequestIdFilter()
+        filt = RequestContextFilter()
         record = logging.LogRecord("test", logging.INFO, "", 0, "msg", (), None)
         request_id_var.set("abc-123")
         filt.filter(record)
         assert record.request_id == "abc-123"
 
     def test_none_when_not_set(self):
-        filt = RequestIdFilter()
+        filt = RequestContextFilter()
         record = logging.LogRecord("test", logging.INFO, "", 0, "msg", (), None)
         filt.filter(record)
         assert record.request_id is None
+        assert record.identity is None
+        assert record.identity_tier is None
+
+    def test_injects_identity_and_tier(self):
+        filt = RequestContextFilter()
+        record = logging.LogRecord("test", logging.INFO, "", 0, "msg", (), None)
+        identity_var.set("customer-42")
+        identity_tier_var.set("header")
+        filt.filter(record)
+        assert record.identity == "customer-42"
+        assert record.identity_tier == "header"
 
 
 class TestModelshipJsonFormatter:
@@ -214,6 +231,26 @@ class TestModelshipJsonFormatter:
         assert "exception" in parsed
         assert "ValueError: boom" in parsed["exception"]
 
+    def test_includes_identity_and_tier(self):
+        formatter = ModelshipJsonFormatter(datefmt="%Y-%m-%dT%H:%M:%S")
+        record = logging.LogRecord("modelship.api", logging.INFO, "", 0, "test", (), None)
+        record.identity = "customer-42"
+        record.identity_tier = "header"
+        output = formatter.format(record)
+        parsed = json.loads(output)
+        assert parsed["identity"] == "customer-42"
+        assert parsed["identity_tier"] == "header"
+
+    def test_excludes_identity_when_none(self):
+        formatter = ModelshipJsonFormatter(datefmt="%Y-%m-%dT%H:%M:%S")
+        record = logging.LogRecord("modelship.api", logging.INFO, "", 0, "test", (), None)
+        record.identity = None
+        record.identity_tier = None
+        output = formatter.format(record)
+        parsed = json.loads(output)
+        assert "identity" not in parsed
+        assert "identity_tier" not in parsed
+
 
 class TestModelshipTextFormatter:
     def test_basic_format(self):
@@ -239,6 +276,20 @@ class TestModelshipTextFormatter:
         output = formatter.format(record)
         assert "None" not in output
 
+    def test_includes_identity(self):
+        formatter = ModelshipTextFormatter(datefmt="%Y-%m-%d %H:%M:%S")
+        record = logging.LogRecord("modelship.api", logging.INFO, "", 0, "hello", (), None)
+        record.identity = "customer-42"
+        output = formatter.format(record)
+        assert "id=customer-42" in output
+
+    def test_excludes_identity_when_none(self):
+        formatter = ModelshipTextFormatter(datefmt="%Y-%m-%d %H:%M:%S")
+        record = logging.LogRecord("modelship.api", logging.INFO, "", 0, "hello", (), None)
+        record.identity = None
+        output = formatter.format(record)
+        assert "id=" not in output
+
 
 class TestEndToEnd:
     def test_log_output_with_request_id(self, capsys):
@@ -260,6 +311,18 @@ class TestEndToEnd:
         parsed = json.loads(captured.err)
         assert parsed["request_id"] == "json-test-id"
         assert parsed["message"] == "json test"
+
+    @patch.dict(os.environ, {"MSHIP_LOG_FORMAT": "json"})
+    def test_json_log_output_includes_identity(self, capsys):
+        configure_logging()
+        log = get_logger("test")
+        identity_var.set("customer-42")
+        identity_tier_var.set("header")
+        log.info("identity test")
+        captured = capsys.readouterr()
+        parsed = json.loads(captured.err)
+        assert parsed["identity"] == "customer-42"
+        assert parsed["identity_tier"] == "header"
 
 
 class TestParseSyslogTarget:


### PR DESCRIPTION
Resolves a stable per-caller identity (trusted proxy header, else hashed matched API key, else a shared "unscoped" bucket) and threads it through every gateway handler and actor method alongside request_id, so logs can be correlated by caller. Lays the groundwork for future Responses-state scoping without implementing it yet.


