### PR TITLE
feat: harden state store for async, TTL, listing, and availability er…

### DIFF
--- a/modelship/state/__init__.py
+++ b/modelship/state/__init__.py
@@ -12,13 +12,15 @@ One arg covers a full Redis connection, and a new backend is one entry in
 from ``MSHIP_STATE_STORE``.
 """
 
+from __future__ import annotations
+
 import os
 import time
 from pathlib import Path
 from urllib.parse import ParseResult, urlparse
 
 from modelship.metrics import STATE_STORE_OPERATION_DURATION_SECONDS, STATE_STORE_OPERATIONS_TOTAL
-from modelship.state.base import JsonValue, StateStore
+from modelship.state.base import JsonValue, StateStore, StateStoreUnavailableError
 from modelship.state.file import FileStateStore
 from modelship.state.memory import MemoryStateStore
 
@@ -27,6 +29,7 @@ __all__ = [
     "JsonValue",
     "MemoryStateStore",
     "StateStore",
+    "StateStoreUnavailableError",
     "get_state_store",
     "state_store_from_uri",
 ]
@@ -58,6 +61,16 @@ class _InstrumentedStateStore(StateStore):
             raise AttributeError(name)
         return getattr(self._inner, name)
 
+    def _record(self, op: str, start: float, result: str) -> None:
+        # Best-effort: a metrics-agent hiccup must never mask the real op error.
+        try:
+            STATE_STORE_OPERATION_DURATION_SECONDS.observe(
+                time.perf_counter() - start, tags={"backend": self._backend, "op": op}
+            )
+            STATE_STORE_OPERATIONS_TOTAL.inc(tags={"backend": self._backend, "op": op, "result": result})
+        except Exception:
+            pass
+
     def _run(self, op: str, fn):
         start = time.perf_counter()
         result = "ok"
@@ -67,23 +80,42 @@ class _InstrumentedStateStore(StateStore):
             result = "error"
             raise
         finally:
-            # Best-effort: a metrics-agent hiccup must never mask the real op error.
-            try:
-                STATE_STORE_OPERATION_DURATION_SECONDS.observe(
-                    time.perf_counter() - start, tags={"backend": self._backend, "op": op}
-                )
-                STATE_STORE_OPERATIONS_TOTAL.inc(tags={"backend": self._backend, "op": op, "result": result})
-            except Exception:
-                pass
+            self._record(op, start, result)
+
+    async def _arun(self, op: str, coro):
+        start = time.perf_counter()
+        result = "ok"
+        try:
+            return await coro
+        except Exception:
+            result = "error"
+            raise
+        finally:
+            self._record(op, start, result)
 
     def get(self, key: str) -> JsonValue | None:
         return self._run("get", lambda: self._inner.get(key))
 
-    def set(self, key: str, value: JsonValue) -> None:
-        self._run("set", lambda: self._inner.set(key, value))
+    def set(self, key: str, value: JsonValue, *, ttl_seconds: float | None = None) -> None:
+        self._run("set", lambda: self._inner.set(key, value, ttl_seconds=ttl_seconds))
 
     def delete(self, key: str) -> None:
         self._run("delete", lambda: self._inner.delete(key))
+
+    def list(self, prefix: str) -> list[str]:
+        return self._run("list", lambda: self._inner.list(prefix))
+
+    async def get_async(self, key: str) -> JsonValue | None:
+        return await self._arun("get", self._inner.get_async(key))
+
+    async def set_async(self, key: str, value: JsonValue, *, ttl_seconds: float | None = None) -> None:
+        await self._arun("set", self._inner.set_async(key, value, ttl_seconds=ttl_seconds))
+
+    async def delete_async(self, key: str) -> None:
+        await self._arun("delete", self._inner.delete_async(key))
+
+    async def list_async(self, prefix: str) -> list[str]:
+        return await self._arun("list", self._inner.list_async(prefix))
 
 
 def _default_file_dir() -> Path:

--- a/modelship/state/base.py
+++ b/modelship/state/base.py
@@ -26,6 +26,14 @@ from abc import ABC, abstractmethod
 JsonValue = dict | list
 
 
+def normalize_prefix(prefix: str) -> str:
+    """Canonicalize a ``list()`` prefix the same way keys themselves are built (see
+    each backend's key-building), so a trailing/leading/doubled slash — e.g.
+    ``"responses/u1/"`` — still matches ``"responses/u1/x"`` instead of never
+    matching due to a literal ``"//"`` in the comparison."""
+    return "/".join(p for p in prefix.split("/") if p)
+
+
 class StateStoreUnavailableError(Exception):
     """The backend is unreachable/errored — distinct from a key being absent.
 

--- a/modelship/state/base.py
+++ b/modelship/state/base.py
@@ -9,8 +9,16 @@ actors can use it for their own state (e.g. ``/v1/responses``). Keys are
 Backends differ in durability, so each caller picks the one its use needs: the
 default file backend survives cluster death (required for the effective config),
 while an in-memory / Ray-actor backend would suit ephemeral actor state.
+
+Sync ``get``/``set``/``delete``/``list`` are the primitive each backend must
+implement; the ``*_async`` variants default to running the sync method in a thread
+(non-blocking on an event loop) and a backend overrides them where a native/direct
+path is better (redis: ``redis.asyncio``; memory: no thread at all).
 """
 
+from __future__ import annotations
+
+import asyncio
 from abc import ABC, abstractmethod
 
 # JSON/YAML-serializable value. Kept deliberately narrow so every backend (file,
@@ -18,17 +26,48 @@ from abc import ABC, abstractmethod
 JsonValue = dict | list
 
 
+class StateStoreUnavailableError(Exception):
+    """The backend is unreachable/errored — distinct from a key being absent.
+
+    ``get``/``list`` raise this on genuine I/O failure so a caller can tell a real
+    outage (surface a 503) apart from a missing key (``None`` / empty). Never raised
+    for merely-corrupt stored data, which is logged and treated as missing.
+    """
+
+
 class StateStore(ABC):
     """Key→value store. Keys are ``/``-separated namespace paths."""
 
     @abstractmethod
     def get(self, key: str) -> JsonValue | None:
-        """Return the value for *key*, or ``None`` if absent/unreadable."""
+        """Return the value for *key*, or ``None`` if absent/expired. Raise
+        ``StateStoreUnavailableError`` if the backend can't be reached."""
 
     @abstractmethod
-    def set(self, key: str, value: JsonValue) -> None:
-        """Persist *value* under *key*, replacing any existing value."""
+    def set(self, key: str, value: JsonValue, *, ttl_seconds: float | None = None) -> None:
+        """Persist *value* under *key*, replacing any existing value. With
+        *ttl_seconds* the entry expires after that many seconds."""
 
     @abstractmethod
     def delete(self, key: str) -> None:
         """Remove *key* if present (no error if absent)."""
+
+    @abstractmethod
+    def list(self, prefix: str) -> list[str]:
+        """Return the keys under *prefix*. Best-effort on expiry (may transiently
+        include just-expired keys — ``get`` is authoritative). Raise
+        ``StateStoreUnavailableError`` if the backend can't be reached."""
+
+    # Async variants: default to offloading the sync method to a thread so a caller
+    # on an event loop never blocks. Backends override where they can do better.
+    async def get_async(self, key: str) -> JsonValue | None:
+        return await asyncio.to_thread(self.get, key)
+
+    async def set_async(self, key: str, value: JsonValue, *, ttl_seconds: float | None = None) -> None:
+        await asyncio.to_thread(self.set, key, value, ttl_seconds=ttl_seconds)
+
+    async def delete_async(self, key: str) -> None:
+        await asyncio.to_thread(self.delete, key)
+
+    async def list_async(self, prefix: str) -> list[str]:
+        return await asyncio.to_thread(self.list, prefix)

--- a/modelship/state/file.py
+++ b/modelship/state/file.py
@@ -79,15 +79,17 @@ class FileStateStore(StateStore):
         path = self._path(key)
         expires_at = time.time() + ttl_seconds if ttl_seconds is not None else None
         doc = {_MARKER: {"exp": expires_at}, "value": value}
+        # Atomic replace: a crash mid-write never leaves a torn file the next read
+        # would choke on. Unique suffix avoids concurrent writers to the same key
+        # colliding on one tmp file.
+        tmp = path.with_name(f"{path.name}.{uuid.uuid4().hex}.tmp")
         try:
             path.parent.mkdir(parents=True, exist_ok=True)
-            # Atomic replace: a crash mid-write never leaves a torn file the next
-            # read would choke on. Unique suffix avoids concurrent writers to the
-            # same key colliding on one tmp file.
-            tmp = path.with_name(f"{path.name}.{uuid.uuid4().hex}.tmp")
             tmp.write_text(json.dumps(doc, indent=2))
             tmp.replace(path)
         except OSError as exc:
+            with contextlib.suppress(OSError):
+                tmp.unlink(missing_ok=True)
             raise StateStoreUnavailableError(f"writing state at {path}") from exc
 
     def delete(self, key: str) -> None:

--- a/modelship/state/file.py
+++ b/modelship/state/file.py
@@ -19,7 +19,7 @@ import uuid
 from pathlib import Path
 
 from modelship.logging import get_logger
-from modelship.state.base import JsonValue, StateStore, StateStoreUnavailableError
+from modelship.state.base import JsonValue, StateStore, StateStoreUnavailableError, normalize_prefix
 
 logger = get_logger("startup")
 
@@ -99,6 +99,7 @@ class FileStateStore(StateStore):
             raise StateStoreUnavailableError(f"deleting state {key!r}") from exc
 
     def list(self, prefix: str) -> list[str]:
+        prefix = normalize_prefix(prefix)
         if not self.base_dir.exists():
             return []
         try:

--- a/modelship/state/file.py
+++ b/modelship/state/file.py
@@ -15,6 +15,7 @@ import contextlib
 import json
 import re
 import time
+import uuid
 from pathlib import Path
 
 from modelship.logging import get_logger
@@ -81,8 +82,9 @@ class FileStateStore(StateStore):
         try:
             path.parent.mkdir(parents=True, exist_ok=True)
             # Atomic replace: a crash mid-write never leaves a torn file the next
-            # read would choke on.
-            tmp = path.with_name(path.name + ".tmp")
+            # read would choke on. Unique suffix avoids concurrent writers to the
+            # same key colliding on one tmp file.
+            tmp = path.with_name(f"{path.name}.{uuid.uuid4().hex}.tmp")
             tmp.write_text(json.dumps(doc, indent=2))
             tmp.replace(path)
         except OSError as exc:
@@ -108,6 +110,6 @@ class FileStateStore(StateStore):
             # Reconstruct the (slugged) key from the path; lossy for keys with
             # unsafe chars, so list() round-trips only already-safe segments.
             key = "/".join(path.relative_to(self.base_dir).with_suffix("").parts)
-            if key.startswith(prefix):
+            if not prefix or key == prefix or key.startswith(f"{prefix}/"):
                 keys.append(key)
         return keys

--- a/modelship/state/file.py
+++ b/modelship/state/file.py
@@ -5,14 +5,20 @@ dir defaults into the model cache, which is already a mounted volume (Docker), a
 PVC (k8s), or a local dir — so it survives the Ray cluster dying. Plain atomic
 JSON writes (vs. an embedded DB) stay reliable on NFS-style RWX volumes and match
 the ``JsonValue`` contract exactly.
+
+Each file holds an envelope ``{_MARKER: {"exp": <epoch|null>}, "value": <value>}``
+so a TTL can travel with the value; a file without the marker is read as a legacy
+raw value (back-compat with pre-envelope effective-config state).
 """
 
+import contextlib
 import json
 import re
+import time
 from pathlib import Path
 
 from modelship.logging import get_logger
-from modelship.state.base import JsonValue, StateStore
+from modelship.state.base import JsonValue, StateStore, StateStoreUnavailableError
 
 logger = get_logger("startup")
 
@@ -20,9 +26,21 @@ logger = get_logger("startup")
 # slugify each before using it as a path component.
 _SLUG_RE = re.compile(r"[^A-Za-z0-9._-]+")
 
+# Envelope marker. Deliberately unusual so a real stored value never collides.
+_MARKER = "__mship_state_v1__"
+
 
 def _slug(segment: str) -> str:
     return _SLUG_RE.sub("-", segment).strip("-") or "_"
+
+
+def _unwrap(doc: JsonValue) -> tuple[JsonValue | None, float | None]:
+    """Return (value, expires_at) from a stored doc; a doc without the marker is a
+    legacy raw value with no expiry."""
+    if isinstance(doc, dict) and _MARKER in doc:
+        meta = doc.get(_MARKER) or {}
+        return doc.get("value"), meta.get("exp") if isinstance(meta, dict) else None
+    return doc, None
 
 
 class FileStateStore(StateStore):
@@ -38,22 +56,58 @@ class FileStateStore(StateStore):
 
     def get(self, key: str) -> JsonValue | None:
         path = self._path(key)
-        if not path.exists():
-            return None
         try:
-            return json.loads(path.read_text())
-        except (json.JSONDecodeError, OSError):
-            logger.exception("Corrupt/unreadable state at %s; treating as missing.", path)
+            raw = path.read_text()
+        except FileNotFoundError:
             return None
+        except OSError as exc:
+            raise StateStoreUnavailableError(f"reading state at {path}") from exc
+        try:
+            doc = json.loads(raw)
+        except json.JSONDecodeError:
+            logger.exception("Corrupt state at %s; treating as missing.", path)
+            return None
+        value, expires_at = _unwrap(doc)
+        if expires_at is not None and time.time() >= expires_at:
+            with contextlib.suppress(OSError):
+                path.unlink()  # opportunistic cleanup; harmless if it fails
+            return None
+        return value
 
-    def set(self, key: str, value: JsonValue) -> None:
+    def set(self, key: str, value: JsonValue, *, ttl_seconds: float | None = None) -> None:
         path = self._path(key)
-        path.parent.mkdir(parents=True, exist_ok=True)
-        # Atomic replace: a crash mid-write never leaves a torn file the next read
-        # would choke on.
-        tmp = path.with_name(path.name + ".tmp")
-        tmp.write_text(json.dumps(value, indent=2))
-        tmp.replace(path)
+        expires_at = time.time() + ttl_seconds if ttl_seconds is not None else None
+        doc = {_MARKER: {"exp": expires_at}, "value": value}
+        try:
+            path.parent.mkdir(parents=True, exist_ok=True)
+            # Atomic replace: a crash mid-write never leaves a torn file the next
+            # read would choke on.
+            tmp = path.with_name(path.name + ".tmp")
+            tmp.write_text(json.dumps(doc, indent=2))
+            tmp.replace(path)
+        except OSError as exc:
+            raise StateStoreUnavailableError(f"writing state at {path}") from exc
 
     def delete(self, key: str) -> None:
-        self._path(key).unlink(missing_ok=True)
+        try:
+            self._path(key).unlink(missing_ok=True)
+        except OSError as exc:
+            raise StateStoreUnavailableError(f"deleting state {key!r}") from exc
+
+    def list(self, prefix: str) -> list[str]:
+        if not self.base_dir.exists():
+            return []
+        try:
+            files = list(self.base_dir.rglob("*.json"))
+        except OSError as exc:
+            raise StateStoreUnavailableError(f"listing state under {self.base_dir}") from exc
+        keys = []
+        for path in files:
+            if path.name.endswith(".tmp"):
+                continue
+            # Reconstruct the (slugged) key from the path; lossy for keys with
+            # unsafe chars, so list() round-trips only already-safe segments.
+            key = "/".join(path.relative_to(self.base_dir).with_suffix("").parts)
+            if key.startswith(prefix):
+                keys.append(key)
+        return keys

--- a/modelship/state/memory.py
+++ b/modelship/state/memory.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 import copy
 import time
 
-from modelship.state.base import JsonValue, StateStore
+from modelship.state.base import JsonValue, StateStore, normalize_prefix
 
 
 class MemoryStateStore(StateStore):
@@ -38,6 +38,7 @@ class MemoryStateStore(StateStore):
         self._data.pop(key, None)
 
     def list(self, prefix: str) -> list[str]:
+        prefix = normalize_prefix(prefix)
         now = time.time()
         return [
             k

--- a/modelship/state/memory.py
+++ b/modelship/state/memory.py
@@ -42,7 +42,7 @@ class MemoryStateStore(StateStore):
         return [
             k
             for k, (_, expires_at) in list(self._data.items())
-            if k.startswith(prefix) and (expires_at is None or now < expires_at)
+            if (not prefix or k == prefix or k.startswith(f"{prefix}/")) and (expires_at is None or now < expires_at)
         ]
 
     # In-process: no thread needed, so skip the base's to_thread hop.

--- a/modelship/state/memory.py
+++ b/modelship/state/memory.py
@@ -6,22 +6,54 @@ that wants the StateStore interface without durable infra. Selected by the
 ``memory://`` URI scheme.
 """
 
+from __future__ import annotations
+
 import copy
+import time
 
 from modelship.state.base import JsonValue, StateStore
 
 
 class MemoryStateStore(StateStore):
     def __init__(self) -> None:
-        self._data: dict[str, JsonValue] = {}
+        # key -> (value, expires_at epoch | None). Expiry is enforced lazily on read.
+        self._data: dict[str, tuple[JsonValue, float | None]] = {}
 
     def get(self, key: str) -> JsonValue | None:
-        value = self._data.get(key)
+        entry = self._data.get(key)
+        if entry is None:
+            return None
+        value, expires_at = entry
+        if expires_at is not None and time.time() >= expires_at:
+            self._data.pop(key, None)
+            return None
         # Deep-copy on the way out so callers can't mutate stored state in place.
-        return copy.deepcopy(value) if value is not None else None
+        return copy.deepcopy(value)
 
-    def set(self, key: str, value: JsonValue) -> None:
-        self._data[key] = copy.deepcopy(value)
+    def set(self, key: str, value: JsonValue, *, ttl_seconds: float | None = None) -> None:
+        expires_at = time.time() + ttl_seconds if ttl_seconds is not None else None
+        self._data[key] = (copy.deepcopy(value), expires_at)
 
     def delete(self, key: str) -> None:
         self._data.pop(key, None)
+
+    def list(self, prefix: str) -> list[str]:
+        now = time.time()
+        return [
+            k
+            for k, (_, expires_at) in list(self._data.items())
+            if k.startswith(prefix) and (expires_at is None or now < expires_at)
+        ]
+
+    # In-process: no thread needed, so skip the base's to_thread hop.
+    async def get_async(self, key: str) -> JsonValue | None:
+        return self.get(key)
+
+    async def set_async(self, key: str, value: JsonValue, *, ttl_seconds: float | None = None) -> None:
+        self.set(key, value, ttl_seconds=ttl_seconds)
+
+    async def delete_async(self, key: str) -> None:
+        self.delete(key)
+
+    async def list_async(self, prefix: str) -> list[str]:
+        return self.list(prefix)

--- a/modelship/state/redis.py
+++ b/modelship/state/redis.py
@@ -4,49 +4,118 @@ Durable across cluster / head death (the value lives in Redis, not the actor), s
 it's the backend for the coordinator registry and effective config in k8s, where
 the same Redis also backs Ray's GCS fault tolerance. Selected by the ``redis://``
 (or ``rediss://`` for TLS) URI scheme; the URL carries host/port/db/user/password,
-parsed natively by ``redis.from_url`` — so a password may be inlined
-(``redis://:pw@host``) or injected by the deployment (e.g. a k8s Secret expanded
-into the URL).
+parsed natively by ``from_url`` — so a password may be inlined (``redis://:pw@host``)
+or injected by the deployment (e.g. a k8s Secret expanded into the URL).
+
+Two clients are held, created lazily: a sync ``redis.Redis`` for the sync methods
+and a native ``redis.asyncio.Redis`` for the ``*_async`` ones — so an event-loop
+caller gets true async I/O, not a thread hop. TTL uses Redis's native expiry (no
+value envelope needed).
 """
 
+from __future__ import annotations
+
+import contextlib
 import json
 
+import redis
+import redis.asyncio as aioredis
+from redis.exceptions import ConnectionError as RedisConnectionError
+from redis.exceptions import TimeoutError as RedisTimeoutError
+
 from modelship.logging import get_logger
-from modelship.state.base import JsonValue, StateStore
+from modelship.state.base import JsonValue, StateStore, StateStoreUnavailableError
 
 logger = get_logger("startup")
 
+_PREFIX = "modelship/state/"
+
 
 def _slug(key: str) -> str:
-    # Mirror the file backend's key shape: collapse the namespace path into one
-    # Redis key under a shared prefix, so backends stay swappable by URI alone.
-    return "modelship/state/" + "/".join(p for p in key.split("/") if p)
+    # Collapse the namespace path into one Redis key under a shared prefix, so
+    # backends stay swappable by URI alone.
+    return _PREFIX + "/".join(p for p in key.split("/") if p)
+
+
+def _decode(raw: str | bytes | None) -> JsonValue | None:
+    if raw is None:
+        return None
+    try:
+        return json.loads(raw)
+    except json.JSONDecodeError:
+        logger.exception("Corrupt JSON in redis; treating as missing.")
+        return None
+
+
+@contextlib.contextmanager
+def _mapped(what: str):
+    """Map a Redis connectivity failure to StateStoreUnavailableError (an outage, not a
+    missing key). Wraps both sync calls and awaited async calls."""
+    try:
+        yield
+    except (RedisConnectionError, RedisTimeoutError) as exc:
+        raise StateStoreUnavailableError(what) from exc
 
 
 class RedisStateStore(StateStore):
     def __init__(self, url: str) -> None:
-        # Lazy import: redis is only needed when this scheme is actually selected.
-        import redis
+        self._url = url
+        self._sync_client: redis.Redis | None = None
+        self._async_client: aioredis.Redis | None = None
 
-        # decode_responses so get() returns str, not bytes, for json.loads.
-        self._client = redis.from_url(url, decode_responses=True)
+    def _sync(self) -> redis.Redis:
+        if self._sync_client is None:
+            # decode_responses so get() returns str, not bytes, for json.loads.
+            self._sync_client = redis.Redis.from_url(self._url, decode_responses=True)
+        return self._sync_client
+
+    def _async(self) -> aioredis.Redis:
+        if self._async_client is None:
+            self._async_client = aioredis.Redis.from_url(self._url, decode_responses=True)
+        return self._async_client
+
+    @staticmethod
+    def _px(ttl_seconds: float | None) -> int | None:
+        # Native expiry in ms; floor at 1ms so a sub-second TTL never becomes a
+        # no-expiry / rejected ``ex=0``.
+        return None if ttl_seconds is None else max(1, int(ttl_seconds * 1000))
 
     def get(self, key: str) -> JsonValue | None:
-        try:
-            raw = self._client.get(_slug(key))
-        except Exception:
-            logger.exception("Redis unreadable for key %s; treating as missing.", key)
-            return None
-        if raw is None:
-            return None
-        try:
-            return json.loads(raw)
-        except json.JSONDecodeError:
-            logger.exception("Corrupt JSON at redis key %s; treating as missing.", key)
-            return None
+        with _mapped(f"redis get {key!r}"):
+            raw = self._sync().get(_slug(key))
+        return _decode(raw)
 
-    def set(self, key: str, value: JsonValue) -> None:
-        self._client.set(_slug(key), json.dumps(value))
+    def set(self, key: str, value: JsonValue, *, ttl_seconds: float | None = None) -> None:
+        with _mapped(f"redis set {key!r}"):
+            self._sync().set(_slug(key), json.dumps(value), px=self._px(ttl_seconds))
 
     def delete(self, key: str) -> None:
-        self._client.delete(_slug(key))
+        with _mapped(f"redis delete {key!r}"):
+            self._sync().delete(_slug(key))
+
+    def list(self, prefix: str) -> list[str]:
+        match = _slug(prefix) + "*"
+        with _mapped(f"redis scan {prefix!r}"):
+            keys = list(self._sync().scan_iter(match=match))
+        return [k[len(_PREFIX) :] for k in keys]
+
+    async def get_async(self, key: str) -> JsonValue | None:
+        with _mapped(f"redis get {key!r}"):
+            raw = await self._async().get(_slug(key))
+        return _decode(raw)
+
+    async def set_async(self, key: str, value: JsonValue, *, ttl_seconds: float | None = None) -> None:
+        with _mapped(f"redis set {key!r}"):
+            await self._async().set(_slug(key), json.dumps(value), px=self._px(ttl_seconds))
+
+    async def delete_async(self, key: str) -> None:
+        with _mapped(f"redis delete {key!r}"):
+            await self._async().delete(_slug(key))
+
+    async def list_async(self, prefix: str) -> list[str]:
+        match = _slug(prefix) + "*"
+        keys = []
+        with _mapped(f"redis scan {prefix!r}"):
+            async for k in self._async().scan_iter(match=match):
+                keys.append(k)
+        return [k[len(_PREFIX) :] for k in keys]

--- a/modelship/state/redis.py
+++ b/modelship/state/redis.py
@@ -24,7 +24,7 @@ from redis.exceptions import ConnectionError as RedisConnectionError
 from redis.exceptions import TimeoutError as RedisTimeoutError
 
 from modelship.logging import get_logger
-from modelship.state.base import JsonValue, StateStore, StateStoreUnavailableError
+from modelship.state.base import JsonValue, StateStore, StateStoreUnavailableError, normalize_prefix
 
 logger = get_logger("startup")
 
@@ -100,6 +100,7 @@ class RedisStateStore(StateStore):
             self._sync().delete(_slug(key))
 
     def list(self, prefix: str) -> list[str]:
+        prefix = normalize_prefix(prefix)
         match = _slug(prefix) + "*"
         with _mapped(f"redis scan {prefix!r}"):
             keys = list(self._sync().scan_iter(match=match))
@@ -119,6 +120,7 @@ class RedisStateStore(StateStore):
             await self._async().delete(_slug(key))
 
     async def list_async(self, prefix: str) -> list[str]:
+        prefix = normalize_prefix(prefix)
         match = _slug(prefix) + "*"
         keys = []
         with _mapped(f"redis scan {prefix!r}"):

--- a/modelship/state/redis.py
+++ b/modelship/state/redis.py
@@ -37,6 +37,12 @@ def _slug(key: str) -> str:
     return _PREFIX + "/".join(p for p in key.split("/") if p)
 
 
+def _in_namespace(key: str, prefix: str) -> bool:
+    # SCAN's MATCH glob has no path-segment concept, so "prefix*" also matches a
+    # sibling like "responses/u10" under prefix "responses/u1"; re-check the boundary.
+    return not prefix or key == prefix or key.startswith(f"{prefix}/")
+
+
 def _decode(raw: str | bytes | None) -> JsonValue | None:
     if raw is None:
         return None
@@ -97,7 +103,7 @@ class RedisStateStore(StateStore):
         match = _slug(prefix) + "*"
         with _mapped(f"redis scan {prefix!r}"):
             keys = list(self._sync().scan_iter(match=match))
-        return [k[len(_PREFIX) :] for k in keys]
+        return [k[len(_PREFIX) :] for k in keys if _in_namespace(k[len(_PREFIX) :], prefix)]
 
     async def get_async(self, key: str) -> JsonValue | None:
         with _mapped(f"redis get {key!r}"):
@@ -118,4 +124,4 @@ class RedisStateStore(StateStore):
         with _mapped(f"redis scan {prefix!r}"):
             async for k in self._async().scan_iter(match=match):
                 keys.append(k)
-        return [k[len(_PREFIX) :] for k in keys]
+        return [k[len(_PREFIX) :] for k in keys if _in_namespace(k[len(_PREFIX) :], prefix)]

--- a/tests/test_effective_config.py
+++ b/tests/test_effective_config.py
@@ -135,8 +135,9 @@ class TestRawRoundTrip:
         raw = {"name": "x", "model": "org/x", "usecase": "generate", "loader": "vllm", "num_gpus": 2}
         store = FileStateStore(tmp_path)
         write_effective(store, "g", [raw])
+        # The value is stored inside the TTL envelope; unwrap to inspect it.
         on_disk = json.loads((tmp_path / "effective" / "g.json").read_text())
-        assert on_disk["models"][0]["num_gpus"] == 2
+        assert on_disk["value"]["models"][0]["num_gpus"] == 2
 
 
 def _dep(name: str, gw: str = "g", **overrides) -> str:

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -128,6 +128,15 @@ class TestFileStateStore:
         with pytest.raises(StateStoreUnavailableError):
             store.get("k")
 
+    def test_write_failure_cleans_up_tmp_file(self, tmp_path):
+        # A directory where the value file should be makes the final tmp.replace()
+        # raise OSError; the tmp file it created must not be left behind.
+        store = FileStateStore(tmp_path)
+        (tmp_path / "k.json").mkdir()
+        with pytest.raises(StateStoreUnavailableError):
+            store.set("k", {"x": 1})
+        assert list(tmp_path.glob("*.tmp")) == []
+
 
 class TestRedisStateStore:
     def test_ttl_sets_native_expiry(self):

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -69,6 +69,13 @@ class TestBackends:
             "responses/u2/c",
         ]
 
+    def test_list_prefix_trailing_slash(self, store):
+        # A trailing slash on the prefix must not turn the boundary check into a
+        # literal "//" that can never match.
+        store.set("responses/u1/a", {"n": 1})
+        store.set("responses/u1/b", {"n": 2})
+        assert sorted(store.list("responses/u1/")) == ["responses/u1/a", "responses/u1/b"]
+
     @pytest.mark.asyncio
     async def test_async_mirrors_sync(self, store):
         await store.set_async("k", {"x": 1})

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -1,35 +1,83 @@
-"""Tests for the state-store URI factory and the memory/redis backends.
-
-(FileStateStore round-trip lives in test_effective_config.py.)
+"""Tests for the state-store URI factory and the memory/file/redis backends —
+sync and async paths, TTL, prefix listing, and availability-vs-absent semantics.
 """
+
+import json
 
 import pytest
 
 from modelship.state import (
     FileStateStore,
     MemoryStateStore,
+    StateStoreUnavailableError,
     get_state_store,
     state_store_from_uri,
 )
 from modelship.state.redis import RedisStateStore
 
 
-class TestMemoryStateStore:
-    def test_set_get_roundtrip(self):
-        store = MemoryStateStore()
+def _fake_redis_store():
+    """A RedisStateStore whose sync + async clients share one fakeredis server, so
+    a value written via one path is visible from the other."""
+    fakeredis = pytest.importorskip("fakeredis")
+    server = fakeredis.FakeServer()
+    s = RedisStateStore.__new__(RedisStateStore)
+    s._url = "redis://fake"
+    s._sync_client = fakeredis.FakeRedis(server=server, decode_responses=True)
+    s._async_client = fakeredis.FakeAsyncRedis(server=server, decode_responses=True)
+    return s
+
+
+@pytest.fixture(params=["memory", "file", "redis"])
+def store(request, tmp_path):
+    if request.param == "memory":
+        return MemoryStateStore()
+    if request.param == "file":
+        return FileStateStore(tmp_path)
+    return _fake_redis_store()
+
+
+class TestBackends:
+    """Behaviour shared by every backend (parametrized via the `store` fixture)."""
+
+    def test_set_get_roundtrip(self, store):
         store.set("a/b", {"x": [1, 2]})
         assert store.get("a/b") == {"x": [1, 2]}
 
-    def test_missing_returns_none(self):
-        assert MemoryStateStore().get("nope") is None
+    def test_missing_returns_none(self, store):
+        assert store.get("nope") is None
 
-    def test_delete(self):
-        store = MemoryStateStore()
+    def test_delete(self, store):
         store.set("k", {"x": 1})
         store.delete("k")
         assert store.get("k") is None
         store.delete("k")  # idempotent
 
+    def test_list_prefix(self, store):
+        store.set("responses/u1/a", {"n": 1})
+        store.set("responses/u1/b", {"n": 2})
+        store.set("responses/u2/c", {"n": 3})
+        store.set("other/x", {"n": 4})
+        assert sorted(store.list("responses/u1")) == ["responses/u1/a", "responses/u1/b"]
+        assert sorted(store.list("responses")) == [
+            "responses/u1/a",
+            "responses/u1/b",
+            "responses/u2/c",
+        ]
+
+    @pytest.mark.asyncio
+    async def test_async_mirrors_sync(self, store):
+        await store.set_async("k", {"x": 1})
+        assert await store.get_async("k") == {"x": 1}
+        assert await store.list_async("k") == ["k"]
+        # cross-path visibility: a sync write is seen by an async read
+        store.set("k2", {"y": 2})
+        assert await store.get_async("k2") == {"y": 2}
+        await store.delete_async("k")
+        assert await store.get_async("k") is None
+
+
+class TestMemoryStateStore:
     def test_isolates_stored_value_from_caller_mutation(self):
         store = MemoryStateStore()
         payload = {"x": 1}
@@ -40,6 +88,69 @@ class TestMemoryStateStore:
         assert isinstance(got, dict)
         got["x"] = 7  # mutate a returned copy
         assert store.get("k") == {"x": 1}
+
+    def test_ttl_expires(self, monkeypatch):
+        clock = {"t": 1000.0}
+        monkeypatch.setattr("time.time", lambda: clock["t"])
+        store = MemoryStateStore()
+        store.set("k", {"x": 1}, ttl_seconds=10)
+        assert store.get("k") == {"x": 1}
+        clock["t"] = 1011.0
+        assert store.get("k") is None
+        assert store.list("k") == []
+
+
+class TestFileStateStore:
+    def test_ttl_expires(self, tmp_path, monkeypatch):
+        clock = {"t": 1000.0}
+        monkeypatch.setattr("time.time", lambda: clock["t"])
+        store = FileStateStore(tmp_path)
+        store.set("k", {"x": 1}, ttl_seconds=10)
+        assert store.get("k") == {"x": 1}
+        clock["t"] = 1011.0
+        assert store.get("k") is None
+
+    def test_reads_legacy_raw_value(self, tmp_path):
+        # A pre-envelope file (raw value, no marker) still reads back as the value.
+        store = FileStateStore(tmp_path)
+        (tmp_path / "k.json").write_text(json.dumps({"models": ["a"]}))
+        assert store.get("k") == {"models": ["a"]}
+
+    def test_unreadable_existing_file_raises_unavailable(self, tmp_path):
+        # A directory where the value file should be makes read_text raise OSError
+        # (not FileNotFoundError) — an availability failure, not a missing key.
+        store = FileStateStore(tmp_path)
+        (tmp_path / "k.json").mkdir()
+        with pytest.raises(StateStoreUnavailableError):
+            store.get("k")
+
+
+class TestRedisStateStore:
+    def test_ttl_sets_native_expiry(self):
+        store = _fake_redis_store()
+        store.set("k", {"x": 1}, ttl_seconds=100)
+        assert store._sync_client.pttl("modelship/state/k") > 0
+        store.set("k2", {"x": 1})  # no ttl
+        assert store._sync_client.pttl("modelship/state/k2") == -1  # no expiry
+
+    def test_corrupt_value_treated_as_missing(self):
+        store = _fake_redis_store()
+        store._sync_client.set("modelship/state/k", "not json{")
+        assert store.get("k") is None
+
+    def test_connection_error_raises_unavailable(self):
+        from redis.exceptions import ConnectionError as RedisConnectionError
+
+        class Boom:
+            def get(self, *a, **k):
+                raise RedisConnectionError("down")
+
+        store = RedisStateStore.__new__(RedisStateStore)
+        store._url = "redis://fake"
+        store._sync_client = Boom()
+        store._async_client = None
+        with pytest.raises(StateStoreUnavailableError):
+            store.get("k")
 
 
 class TestStateStoreFromUri:
@@ -68,11 +179,8 @@ class TestStateStoreFromUri:
         with pytest.raises(ValueError, match="must have an empty host"):
             state_store_from_uri("file://some/dir")
 
-    def test_redis_scheme_builds_redis_store(self, monkeypatch):
-        # Don't hit a real server: stub redis.from_url.
-        import redis
-
-        monkeypatch.setattr(redis, "from_url", lambda *a, **k: object())
+    def test_redis_scheme_builds_redis_store(self):
+        # Construction is inert (clients are lazy) — no server contacted.
         assert isinstance(state_store_from_uri("redis://cache:6379/0").inner, RedisStateStore)
 
     def test_unknown_scheme_raises(self):
@@ -88,29 +196,3 @@ class TestStateStoreFromUri:
         store = get_state_store().inner
         assert isinstance(store, FileStateStore)
         assert str(store.base_dir) == "/tmp/mship-env-state"
-
-
-class TestRedisStateStore:
-    @pytest.fixture
-    def store(self):
-        fakeredis = pytest.importorskip("fakeredis")
-
-        s = RedisStateStore.__new__(RedisStateStore)
-        s._client = fakeredis.FakeRedis(decode_responses=True)
-        return s
-
-    def test_set_get_roundtrip(self, store):
-        store.set("gw/models", {"app-1": "qwen", "list": [1, 2]})
-        assert store.get("gw/models") == {"app-1": "qwen", "list": [1, 2]}
-
-    def test_missing_returns_none(self, store):
-        assert store.get("absent") is None
-
-    def test_delete(self, store):
-        store.set("k", {"x": 1})
-        store.delete("k")
-        assert store.get("k") is None
-
-    def test_corrupt_value_treated_as_missing(self, store):
-        store._client.set("modelship/state/k", "not json{")
-        assert store.get("k") is None

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -57,11 +57,15 @@ class TestBackends:
         store.set("responses/u1/a", {"n": 1})
         store.set("responses/u1/b", {"n": 2})
         store.set("responses/u2/c", {"n": 3})
+        store.set("responses/u10/c", {"n": 5})
         store.set("other/x", {"n": 4})
+        # "responses/u1" must match only its own segment, not the sibling "u10" whose
+        # name happens to share "u1" as a string prefix.
         assert sorted(store.list("responses/u1")) == ["responses/u1/a", "responses/u1/b"]
         assert sorted(store.list("responses")) == [
             "responses/u1/a",
             "responses/u1/b",
+            "responses/u10/c",
             "responses/u2/c",
         ]
 


### PR DESCRIPTION
…rors

Prepares the generic modelship/state/ KV store for stateful /v1/responses: it was built for the deploy layer's effective config (low-frequency, single-writer, never-expiring) and needs to back a per-request, multi-reader, expiring store on the async gateway.

- Async access: keep sync get/set/delete, add list; base provides *_async as asyncio.to_thread wrappers. Backends override where better — redis with native redis.asyncio (sync + async clients, lazy), memory with direct calls; file inherits the to_thread default. Sync consumers (coordinator, deploy driver) are unchanged.
- TTL: set(..., ttl_seconds=). Redis native px expiry; file/memory carry expiry (file via a versioned envelope, legacy raw files still read) with lazy expiry-on-read.
- list(prefix): dict-filter / glob / redis scan_iter.
- Availability semantics: StateStoreUnavailableError on genuine I/O failure vs None for absent (corrupt data still treated as missing). read_effective lets it propagate so a store outage fails a deploy loudly instead of acting on phantom-empty desired state.

Background TTL sweeper and memory:// multi-replica correctness are left as follow-ups. Tests cover both sync and async paths across all three backends.


