### PR TITLE
fix: prevent whispercpp from loading a corrupt/truncated ggml model

### DIFF
--- a/modelship/utils/__init__.py
+++ b/modelship/utils/__init__.py
@@ -49,7 +49,9 @@ def download(url: str, file_path: str, overwrite: bool = False):
     """Download ``url`` to ``file_path``, skipping if it already exists.
 
     Streams to a per-call unique temp file and atomically renames it into place
-    only on success
+    only after the transfer completes and matches the advertised size, so a
+    killed process or an early-EOF stream never leaves a truncated file at
+    ``file_path``.
     """
     if not overwrite and os.path.isfile(file_path):
         return
@@ -58,10 +60,14 @@ def download(url: str, file_path: str, overwrite: bool = False):
     try:
         with requests.get(url, stream=True) as response:
             response.raise_for_status()
+            expected = int(response.headers.get("Content-Length") or 0)
+            written = 0
             with open(tmp_path, "wb") as f:
-                for chunk in response.iter_content(chunk_size=1024):
+                for chunk in response.iter_content(chunk_size=1024 * 1024):
                     if chunk:
-                        f.write(chunk)
+                        written += f.write(chunk)
+        if expected and written != expected:
+            raise OSError(f"incomplete download from {url}: got {written} of {expected} bytes")
         os.replace(tmp_path, file_path)
     finally:
         if os.path.exists(tmp_path):

--- a/plugins/whispercpp/whispercpp/whispercpp.py
+++ b/plugins/whispercpp/whispercpp/whispercpp.py
@@ -38,12 +38,31 @@ from modelship.infer.infer_config import ModelshipModelConfig
 from modelship.logging import get_logger
 from modelship.openai.protocol import ErrorResponse, RawSegment, RawTranscription, RawTranslation
 from modelship.plugins.base_plugin import BasePlugin
-from modelship.utils import plugins_dir
+from modelship.utils import download, plugins_dir
 from modelship.utils.audio import decode_audio
 
 logger = get_logger("plugin.whispercpp")
 
 _WHISPER_SAMPLE_RATE = 16000
+
+# whisper.cpp ggml weights, mirrored by pywhispercpp's own downloader.
+_GGML_BASE_URL = "https://huggingface.co/ggerganov/whisper.cpp/resolve/main"
+
+
+def _resolve_model_file(model: str, models_dir: str) -> str:
+    """Return a local ggml file for ``model``, fetching it atomically if named.
+
+    A direct path is used as-is. Otherwise the model is downloaded via
+    ``modelship.utils.download`` — verified and atomic — rather than through
+    pywhispercpp, whose downloader writes straight to the final path and reuses
+    whatever is there, so a killed download leaves a truncated file that every
+    later load silently reuses.
+    """
+    if os.path.isfile(model):
+        return model
+    file_path = f"{models_dir}/ggml-{model}.bin"
+    download(f"{_GGML_BASE_URL}/ggml-{model}.bin", file_path)
+    return file_path
 
 
 class ModelPlugin(BasePlugin):
@@ -54,12 +73,23 @@ class ModelPlugin(BasePlugin):
         models_dir = plugin_config.get("models_dir", f"{plugins_dir()}/whispercpp")
         os.makedirs(models_dir, exist_ok=True)
 
-        kwargs: dict = {"models_dir": models_dir}
+        kwargs: dict = {}
         if (n_threads := plugin_config.get("n_threads")) is not None:
             kwargs["n_threads"] = n_threads
 
         logger.info("loading whisper.cpp model: %s (dir=%s)", model_config.model, models_dir)
-        self.model = Model(model_config.model, **kwargs)
+        is_user_path = os.path.isfile(model_config.model)
+        model_path = _resolve_model_file(model_config.model, models_dir)
+        self.model = Model(model_path, **kwargs)
+
+        # pywhispercpp leaves _ctx None instead of raising when the ggml file
+        # fails to load, so the replica would otherwise come up "ready" but
+        # crash on every request. Drop a bad file we fetched so the next start
+        # refetches; never touch a path the user pointed us at.
+        if not self.model._ctx:
+            if not is_user_path:
+                os.remove(model_path)
+            raise RuntimeError(f"whisper.cpp failed to load model from {model_path}")
 
     async def start(self):
         pass

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -38,9 +38,10 @@ def test_utils_plugins_dir():
 
 
 class _FakeResponse:
-    def __init__(self, chunks, status_error=None):
+    def __init__(self, chunks, status_error=None, headers=None):
         self._chunks = chunks
         self._status_error = status_error
+        self.headers = headers or {}
 
     def __enter__(self):
         return self
@@ -95,6 +96,24 @@ def test_interrupted_download_leaves_no_corrupt_file(tmp_path):
     # Neither the final path nor any temp file is left behind — next run re-downloads.
     assert not dest.exists()
     assert list(tmp_path.glob("*.tmp")) == []
+
+
+def test_download_rejects_truncated_stream(tmp_path):
+    # Stream ends cleanly (no exception) but short of the advertised length.
+    dest = tmp_path / "model.onnx"
+    resp = _FakeResponse([b"abc"], headers={"Content-Length": "10"})
+    with mock.patch("modelship.utils.requests.get", return_value=resp), pytest.raises(OSError):
+        download("http://x/model.onnx", str(dest))
+    assert not dest.exists()
+    assert list(tmp_path.glob("*.tmp")) == []
+
+
+def test_download_accepts_complete_stream(tmp_path):
+    dest = tmp_path / "model.onnx"
+    resp = _FakeResponse([b"abc", b"def"], headers={"Content-Length": "6"})
+    with mock.patch("modelship.utils.requests.get", return_value=resp):
+        download("http://x/model.onnx", str(dest))
+    assert dest.read_bytes() == b"abcdef"
 
 
 def test_download_does_not_save_error_body(tmp_path):


### PR DESCRIPTION
A killed or short download left a truncated ggml file that every later start silently reused (pywhispercpp writes straight to the final path, skips re-download if present, and leaves _ctx None instead of raising), so the replica came up "ready" but crashed on every request.

- download(): verify bytes written against Content-Length and only commit on a complete transfer, so an early-EOF stream never lands on disk
- whispercpp: fetch weights via modelship's atomic download() instead of pywhispercpp's downloader, and fail loudly (removing the bad file we fetched) when the model fails to load


