### PR TITLE
fix: stop vLLM reasoning models trapping their answer in the reasonin…

### DIFF
--- a/modelship/infer/vllm/engine_ops.py
+++ b/modelship/infer/vllm/engine_ops.py
@@ -23,6 +23,7 @@ from vllm.entrypoints.serve.render.serving import OpenAIServingRender as VllmOpe
 from vllm.entrypoints.serve.utils.api_utils import get_max_tokens as vllm_get_max_tokens
 from vllm.inputs import EngineInput as VllmEngineInput
 from vllm.logprobs import Logprob as VllmLogprob
+from vllm.outputs import CompletionOutput as VllmCompletionOutput
 from vllm.outputs import RequestOutput as VllmRequestOutput
 from vllm.parser import Parser as VllmParser
 from vllm.renderers.inputs.preprocess import extract_prompt_components as vllm_extract_prompt_components
@@ -31,6 +32,7 @@ from vllm.sampling_params import SamplingParams as VllmSamplingParams
 from vllm.tokenizers import TokenizerLike as VllmTokenizerLike
 from vllm.v1.engine.async_llm import AsyncLLM as VllmAsyncLLM
 
+from modelship.logging import get_logger
 from modelship.openai.chat_utils import ParsedChatOutput
 from modelship.openai.protocol import (
     ChatCompletionLogProb,
@@ -39,6 +41,7 @@ from modelship.openai.protocol import (
     ChatCompletionRequest,
     ChatCompletionResponseStreamChoice,
     ChatCompletionStreamResponse,
+    CompletionTokenUsageInfo,
     DeltaFunctionCall,
     DeltaMessage,
     DeltaToolCall,
@@ -47,6 +50,8 @@ from modelship.openai.protocol import (
     UsageInfo,
     random_uuid,
 )
+
+logger = get_logger("infer.vllm.engine_ops")
 
 
 def build_vllm_request(
@@ -323,6 +328,18 @@ def _finish_reason_for_choice(
     return "tool_calls"
 
 
+def total_reasoning_tokens(outputs: Sequence[VllmCompletionOutput], parser: VllmParser | None) -> int | None:
+    """Sum reasoning-classified tokens across every choice's completed `token_ids`,
+    mirroring vLLM's own `entrypoints.openai.responses.serving` usage accounting.
+
+    Returns `None` when no reasoning parser is active for this request, so callers can
+    leave `completion_tokens_details` unset rather than reporting a misleading zero.
+    """
+    if parser is None or parser.reasoning_parser is None:
+        return None
+    return sum(parser.reasoning_parser.count_reasoning_tokens(list(o.token_ids)) for o in outputs)
+
+
 def build_choices(
     final_res: VllmRequestOutput,
     vllm_req: VllmChatCompletionRequest,
@@ -368,6 +385,47 @@ def build_choices(
     return choices, finish_reasons, logprobs_list
 
 
+def _reconcile_trapped_content(
+    render: VllmOpenAIServingRender,
+    tokenizer: VllmTokenizerLike,
+    vllm_req: VllmChatCompletionRequest,
+    full_text: str,
+    token_ids: list[int],
+    *,
+    enable_auto_tools: bool,
+) -> str | None:
+    """Recover an answer the streaming parser left stranded in `reasoning`.
+
+    vLLM's streaming parser engine starts in `REASONING` whenever the prompt primes
+    thinking, and its `finish()` only marks `REASONING_END` — it never reclassifies
+    chunks it already emitted. So a model that ends a turn without its reasoning-close
+    marker leaves the whole reply in `reasoning` with empty `content`, while the
+    full-text `parse()` the non-streaming path uses (`build_choices`) reads the same
+    tokens as `content`. This re-runs that authoritative parse to settle the
+    disagreement in favour of the non-streaming answer.
+
+    `full_text` must be the engine's own detokenized text (the streamed deltas joined),
+    not a re-decode of `token_ids`: the engine drops the stop token from its text while
+    `token_ids` retains it, and this `parse()` — unlike the offline `parse_thinking_output`
+    helper — does not strip trailing sentinels, so a re-decode leaks e.g. `<turn|>` into
+    the recovered answer.
+
+    A fresh parser is required: the streamed instance carries mid-stream state and
+    would not reproduce the full-text result. Returns the recovered content, or None
+    when the parse agrees there is none (e.g. reasoning that closed with no answer).
+    """
+    parser = make_parsers(render, tokenizer, vllm_req, vllm_req.chat_template_kwargs, n=1)[0]
+    if parser is None:
+        return None
+    _reasoning, content, _tool_calls = parser.parse(
+        full_text,
+        vllm_req,
+        enable_auto_tools=enable_auto_tools,
+        model_output_token_ids=token_ids,
+    )
+    return content or None
+
+
 async def stream_chat_completion(
     engine: VllmAsyncLLM,
     render: VllmOpenAIServingRender,
@@ -401,8 +459,17 @@ async def stream_chat_completion(
     include_continuous_usage = include_usage and bool(stream_options and stream_options.continuous_usage_stats)
 
     previous_num_tokens = [0] * num_choices
+    accumulated_token_ids: list[list[int]] = [[] for _ in range(num_choices)]
     finish_reason_sent = [False] * num_choices
     tools_streamed = [False] * num_choices
+    # Per-choice record of what actually reached the client, so the finish branch can
+    # spot a reasoning-only stream and reconcile it (see `_reconcile_trapped_content`).
+    content_streamed = [False] * num_choices
+    reasoning_streamed = [False] * num_choices
+    # The engine's own detokenized text, kept only until this choice streams content —
+    # at that point it can never be reconciled, so the buffer is dropped rather than
+    # carried for the rest of the request.
+    accumulated_text: list[list[str]] = [[] for _ in range(num_choices)]
     first_iteration = True
     num_prompt_tokens = 0
 
@@ -456,6 +523,12 @@ async def stream_chat_completion(
                 vllm_delta = VllmDeltaMessage(content=delta_text)
 
             previous_num_tokens[i] += len(output.token_ids)
+            accumulated_token_ids[i].extend(output.token_ids)
+            # Mirror the raw engine text alongside the ids: the parser returns None
+            # while it defers text it hasn't decided on yet, and those deltas must
+            # still reach the reconcile's full-text parse.
+            if not content_streamed[i]:
+                accumulated_text[i].append(delta_text)
 
             if vllm_delta is None:
                 # VllmParser swallowed a control token (e.g. a `<think>` marker) with
@@ -471,6 +544,11 @@ async def stream_chat_completion(
                 reasoning=vllm_delta.reasoning,
                 tool_calls=project_delta_tool_calls(vllm_delta.tool_calls),
             )
+            if delta_message.content:
+                content_streamed[i] = True
+                accumulated_text[i].clear()
+            if delta_message.reasoning:
+                reasoning_streamed[i] = True
 
             logprobs = None
             if want_logprobs and output.logprobs is not None:
@@ -479,6 +557,26 @@ async def stream_chat_completion(
             if output.finish_reason is None:
                 choice = ChatCompletionResponseStreamChoice(index=i, delta=delta_message, logprobs=logprobs)
             else:
+                # Reasoning-only stream: the answer may be trapped in `reasoning`. The
+                # flags are a cheap pre-filter; the re-parse is what decides, so a
+                # genuinely answer-less turn stays untouched.
+                if parser is not None and reasoning_streamed[i] and not content_streamed[i] and not tools_streamed[i]:
+                    recovered = _reconcile_trapped_content(
+                        render,
+                        tokenizer,
+                        vllm_req,
+                        "".join(accumulated_text[i]),
+                        accumulated_token_ids[i],
+                        enable_auto_tools=enable_auto_tools,
+                    )
+                    if recovered:
+                        logger.debug(
+                            "request %s choice %d: recovered %d chars trapped in reasoning",
+                            request_id,
+                            i,
+                            len(recovered),
+                        )
+                        delta_message.content = recovered
                 finish_reason_sent[i] = True
                 choice = ChatCompletionResponseStreamChoice(
                     index=i,
@@ -499,6 +597,12 @@ async def stream_chat_completion(
 
     if include_usage:
         completion_tokens = sum(previous_num_tokens)
+        reasoning_tokens = None
+        if parsers[0] is not None and parsers[0].reasoning_parser is not None:
+            reasoning_tokens = 0
+            for i, choice_parser in enumerate(parsers):
+                if choice_parser is not None and choice_parser.reasoning_parser is not None:
+                    reasoning_tokens += choice_parser.reasoning_parser.count_reasoning_tokens(accumulated_token_ids[i])
         yield ChatCompletionStreamResponse(
             id=request_id,
             model=model_name,
@@ -507,6 +611,9 @@ async def stream_chat_completion(
                 prompt_tokens=num_prompt_tokens,
                 completion_tokens=completion_tokens,
                 total_tokens=num_prompt_tokens + completion_tokens,
+                completion_tokens_details=CompletionTokenUsageInfo(reasoning_tokens=reasoning_tokens)
+                if reasoning_tokens is not None
+                else None,
             ),
         )
 

--- a/modelship/infer/vllm/engine_ops.py
+++ b/modelship/infer/vllm/engine_ops.py
@@ -412,17 +412,23 @@ def _reconcile_trapped_content(
 
     A fresh parser is required: the streamed instance carries mid-stream state and
     would not reproduce the full-text result. Returns the recovered content, or None
-    when the parse agrees there is none (e.g. reasoning that closed with no answer).
+    when the parse agrees there is none (e.g. reasoning that closed with no answer)
+    or when the re-parse itself fails — this runs after reasoning has already been
+    streamed out, so a parser error here must not crash the generator mid-stream.
     """
-    parser = make_parsers(render, tokenizer, vllm_req, vllm_req.chat_template_kwargs, n=1)[0]
-    if parser is None:
+    try:
+        parser = make_parsers(render, tokenizer, vllm_req, vllm_req.chat_template_kwargs, n=1)[0]
+        if parser is None:
+            return None
+        _reasoning, content, _tool_calls = parser.parse(
+            full_text,
+            vllm_req,
+            enable_auto_tools=enable_auto_tools,
+            model_output_token_ids=token_ids,
+        )
+    except Exception:
+        logger.exception("Reconcile re-parse failed; leaving trapped content in reasoning.")
         return None
-    _reasoning, content, _tool_calls = parser.parse(
-        full_text,
-        vllm_req,
-        enable_auto_tools=enable_auto_tools,
-        model_output_token_ids=token_ids,
-    )
     return content or None
 
 

--- a/modelship/infer/vllm/parsing/detect.py
+++ b/modelship/infer/vllm/parsing/detect.py
@@ -9,10 +9,19 @@ validate against vLLM's registry directly rather than a modelship-side one.
 
 from __future__ import annotations
 
+import inspect
+from collections.abc import Callable
+from typing import Any
+
 from modelship.infer.infer_config import ModelLoader, ModelshipModelConfig
 from modelship.logging import get_logger
 
 logger = get_logger("infer.vllm.parsing.detect")
+
+# A fixed, minimal conversation to render templates against when probing their
+# boolean toggle defaults. Content is irrelevant — only which branches the
+# template takes for a given kwarg matters.
+_PROBE_MESSAGES = [{"role": "user", "content": "hi"}]
 
 
 def classify_tool_template(template: str) -> str | None:
@@ -72,6 +81,73 @@ def _is_tool_opt_out(cfg: ModelshipModelConfig) -> bool:
 def _is_reasoning_opt_out(cfg: ModelshipModelConfig) -> bool:
     """Explicit "no auto reasoning detection" signal: ``enable_reasoning: false``."""
     return cfg.loader == ModelLoader.vllm and cfg.vllm_engine_kwargs.enable_reasoning is False
+
+
+def discover_template_vars(template_src: str) -> set[str]:
+    """Undeclared (caller-supplied) variables a Jinja template reads.
+
+    These are the names ``chat_template_kwargs`` can influence — the set we probe
+    for boolean toggle defaults.
+    """
+    import jinja2
+    from jinja2 import meta as jinja2_meta
+
+    env = jinja2.Environment()
+    return jinja2_meta.find_undeclared_variables(env.parse(template_src))
+
+
+def detect_boolean_defaults(candidates: set[str], render: Callable[..., str]) -> dict[str, bool]:
+    """Detect each candidate var's boolean default by rendering with it forced on/off.
+
+    A var is a boolean toggle iff ``render(var=True)`` and ``render(var=False)``
+    differ. Its default is whichever of the two the base render (no kwarg for that
+    var) matches *exactly*. If the base matches neither or both, the var isn't a
+    plain boolean (e.g. a token string interpolated verbatim) and is skipped. A
+    render that raises for a given var skips that var; a base render that raises
+    aborts entirely (``{}``) so the caller leaves the config untouched.
+    """
+    try:
+        base = render()
+    except Exception:
+        return {}
+
+    defaults: dict[str, bool] = {}
+    for var in candidates:
+        try:
+            on = render(**{var: True})
+            off = render(**{var: False})
+        except Exception:
+            continue
+        if on == off:
+            continue  # inert for this probe — not a toggle we can pin
+        if base == on and base != off:
+            defaults[var] = True
+        elif base == off and base != on:
+            defaults[var] = False
+        # base matching neither/both -> ambiguous (non-bool); skip.
+    return defaults
+
+
+def detect_template_toggle_defaults(template_src: str, tokenizer: Any) -> dict[str, bool]:
+    """Each chat-template boolean toggle's own default, for pinning into config.
+
+    Renders a fixed probe conversation through ``tokenizer.apply_chat_template``
+    with each discovered variable forced True/False (see ``detect_boolean_defaults``).
+    Variables that are real ``apply_chat_template`` parameters (``add_generation_prompt``,
+    ``tools``, ``messages``, ...) are excluded — pinning them into
+    ``chat_template_kwargs`` would collide with vLLM's own explicit argument at
+    request time (``TypeError: multiple values``).
+    """
+    candidates = discover_template_vars(template_src)
+    reserved = set(inspect.signature(tokenizer.apply_chat_template).parameters)
+    candidates -= reserved
+    if not candidates:
+        return {}
+
+    def render(**kwargs: bool) -> str:
+        return tokenizer.apply_chat_template(_PROBE_MESSAGES, tokenize=False, add_generation_prompt=True, **kwargs)
+
+    return detect_boolean_defaults(candidates, render)
 
 
 def resolve_tool_parser(cfg: ModelshipModelConfig, template: str | None) -> str | None:

--- a/modelship/infer/vllm/parsing/detect.py
+++ b/modelship/infer/vllm/parsing/detect.py
@@ -87,13 +87,18 @@ def discover_template_vars(template_src: str) -> set[str]:
     """Undeclared (caller-supplied) variables a Jinja template reads.
 
     These are the names ``chat_template_kwargs`` can influence — the set we probe
-    for boolean toggle defaults.
+    for boolean toggle defaults. Runs at deployment init, so a template Jinja can't
+    even parse must not abort startup — it just means no toggle defaults get pinned.
     """
     import jinja2
     from jinja2 import meta as jinja2_meta
 
     env = jinja2.Environment()
-    return jinja2_meta.find_undeclared_variables(env.parse(template_src))
+    try:
+        return jinja2_meta.find_undeclared_variables(env.parse(template_src))
+    except jinja2.TemplateError:
+        logger.warning("Chat template failed to parse for toggle-var discovery; skipping default pinning.")
+        return set()
 
 
 def detect_boolean_defaults(candidates: set[str], render: Callable[..., str]) -> dict[str, bool]:

--- a/modelship/infer/vllm/parsing/detect.py
+++ b/modelship/infer/vllm/parsing/detect.py
@@ -144,7 +144,14 @@ def detect_template_toggle_defaults(template_src: str, tokenizer: Any) -> dict[s
     request time (``TypeError: multiple values``).
     """
     candidates = discover_template_vars(template_src)
-    reserved = set(inspect.signature(tokenizer.apply_chat_template).parameters)
+    try:
+        reserved = set(inspect.signature(tokenizer.apply_chat_template).parameters)
+    except (TypeError, ValueError):
+        # Some tokenizer wrappers expose an uninspectable `apply_chat_template` (e.g.
+        # a C-extension or mocked callable). Falling back to no exclusions is safe:
+        # any reserved name that slips through as a candidate just fails its own
+        # render probe below, which `detect_boolean_defaults` already tolerates.
+        reserved = set()
     candidates -= reserved
     if not candidates:
         return {}

--- a/modelship/infer/vllm/vllm_infer.py
+++ b/modelship/infer/vllm/vllm_infer.py
@@ -1,5 +1,5 @@
 import io
-from collections.abc import AsyncGenerator
+from collections.abc import AsyncGenerator, Sequence
 from dataclasses import dataclass
 from http import HTTPStatus
 from typing import Any, ClassVar, cast
@@ -67,10 +67,15 @@ from modelship.infer.infer_config import (
 )
 from modelship.infer.vllm import engine_ops
 from modelship.infer.vllm.capabilities import VllmCapabilities
-from modelship.infer.vllm.parsing.detect import resolve_reasoning_parser, resolve_tool_parser
+from modelship.infer.vllm.parsing.detect import (
+    detect_template_toggle_defaults,
+    resolve_reasoning_parser,
+    resolve_tool_parser,
+)
 from modelship.logging import TRACE, get_logger
 from modelship.metrics import _ENABLED as _METRICS_ENABLED
 from modelship.openai.chat_utils import (
+    ParsedChatOutput,
     UnsupportedContentError,
     build_from_parsed,
     build_response_from_parsed,
@@ -82,6 +87,7 @@ from modelship.openai.chat_utils import (
 from modelship.openai.protocol import (
     ChatCompletionRequest,
     ChatCompletionResponse,
+    CompletionTokenUsageInfo,
     EmbeddingCompletionRequest,
     EmbeddingRequest,
     ErrorResponse,
@@ -143,6 +149,80 @@ def _vllm_stream_error(exc: Exception) -> str | None:
         base = exc.args[0] if exc.args else str(exc)
         return str(base)
     return None
+
+
+def _trace_request(
+    request_id: str, vllm_request: VllmChatCompletionRequest, sampling_params: VllmSamplingParams
+) -> None:
+    """TRACE-log the effective request: the generation budget and the
+    `chat_template_kwargs` actually in play (e.g. `enable_thinking`), so a
+    truncated-mid-reasoning failure can be tied back to what was sent."""
+    if not logger.isEnabledFor(TRACE):
+        return
+    logger.log(
+        TRACE,
+        "%s request: max_tokens=%s chat_template_kwargs=%s messages=%s tools=%s",
+        request_id,
+        sampling_params.max_tokens,
+        vllm_request.chat_template_kwargs,
+        vllm_request.messages,
+        vllm_request.tools,
+    )
+
+
+def _trace_parsed_response(
+    request_id: str,
+    choices: Sequence[ParsedChatOutput],
+    finish_reasons: Sequence[str | None],
+    usage: UsageInfo,
+) -> None:
+    """TRACE-log the parsed non-stream result: finish reason, usage, and both
+    reasoning and content per choice — so an answer trapped in `reasoning` (empty
+    `content`) versus budget exhaustion (`finish=length`) is obvious at a glance."""
+    if not logger.isEnabledFor(TRACE):
+        return
+    for i, parsed in enumerate(choices):
+        fr = finish_reasons[i] if i < len(finish_reasons) else None
+        logger.log(
+            TRACE,
+            "%s response choice[%d]: finish=%s reasoning_len=%d content_len=%d tool_calls=%d reasoning=%r content=%r",
+            request_id,
+            i,
+            fr,
+            len(parsed.reasoning or ""),
+            len(parsed.content or ""),
+            len(parsed.tool_calls),
+            parsed.reasoning,
+            parsed.content,
+        )
+    logger.log(TRACE, "%s usage: %s", request_id, usage)
+
+
+async def _trace_chunks(chunks: AsyncGenerator[Any, None], request_id: str) -> AsyncGenerator[Any, None]:
+    """Pass streaming chunks through unchanged while buffering reasoning + content
+    deltas, TRACE-logging a summary when the stream ends. Only wrapped around a
+    stream when TRACE is enabled, so it costs nothing otherwise."""
+    reasoning: list[str] = []
+    content: list[str] = []
+    try:
+        async for chunk in chunks:
+            for choice in chunk.choices:
+                if choice.delta.reasoning:
+                    reasoning.append(choice.delta.reasoning)
+                if choice.delta.content:
+                    content.append(choice.delta.content)
+            yield chunk
+    finally:
+        r, c = "".join(reasoning), "".join(content)
+        logger.log(
+            TRACE,
+            "%s response (stream): reasoning_len=%d content_len=%d reasoning=%r content=%r",
+            request_id,
+            len(r),
+            len(c),
+            r,
+            c,
+        )
 
 
 @dataclass
@@ -340,6 +420,28 @@ class VllmInfer(BaseInfer[_VllmPrepared]):
         # get_chat_template isn't in vLLM's TokenizerLike protocol (it's a plain
         # HF PreTrainedTokenizer method the real tokenizer always has).
         template = cast(Any, self.engine.get_tokenizer()).get_chat_template()
+
+        # A reasoning parser reads chat_template_kwargs["enable_thinking"] (and
+        # similar toggles) and defaults them True when absent, but a template may
+        # default the same toggle False — leaving the parser primed to reason on a
+        # model that was never told to. Pin each toggle to the template's own
+        # detected default so both sides agree; user/config values still win.
+        if template is not None:
+            defaults = detect_template_toggle_defaults(template, cast(Any, self.engine.get_tokenizer()))
+            applied = {k: v for k, v in defaults.items() if k not in self.model_config.chat_template_kwargs}
+            for key, value in applied.items():
+                self.model_config.chat_template_kwargs[key] = value
+            if applied:
+                logger.info("Pinned chat-template toggle defaults for '%s': %s", self.model_config.name, applied)
+            overridden = {k: v for k, v in defaults.items() if k not in applied}
+            if overridden:
+                logger.info(
+                    "Chat-template toggle defaults for '%s' overridden by config: %s (detected defaults: %s)",
+                    self.model_config.name,
+                    {k: self.model_config.chat_template_kwargs[k] for k in overridden},
+                    overridden,
+                )
+
         tool_parser_name = resolve_tool_parser(self.model_config, template)
         enable_tools = tool_parser_name is not None
         reasoning_parser_name = resolve_reasoning_parser(self.model_config, template) or ""
@@ -464,6 +566,7 @@ class VllmInfer(BaseInfer[_VllmPrepared]):
         Rendering already succeeded in `_prepare_chat` — this only drives generation."""
         request_id = f"chatcmpl-{base_request_id(raw_request)}"
         vllm_request = prepared.vllm_request
+        _trace_request(request_id, vllm_request, prepared.sampling_params)
 
         stream = engine_ops.stream_chat_completion(
             self.engine,
@@ -478,14 +581,11 @@ class VllmInfer(BaseInfer[_VllmPrepared]):
             want_logprobs=bool(request.logprobs),
             num_output_top_logprobs=request.top_logprobs,
         )
-        trace = logger.isEnabledFor(TRACE)
-        buffered: list[str] = []
+        chunks = self.run_cancellable_stream(stream, raw_request)
+        if logger.isEnabledFor(TRACE):
+            chunks = _trace_chunks(chunks, request_id)
         try:
-            async for chunk in self.run_cancellable_stream(stream, raw_request):
-                if trace:
-                    for choice in chunk.choices:
-                        if choice.delta.content:
-                            buffered.append(choice.delta.content)
+            async for chunk in chunks:
                 yield encode_chat_sse_chunk(chunk)
         except ClientDisconnectedError:
             logger.info("chat request %s aborted: client disconnected", request_id)
@@ -501,9 +601,6 @@ class VllmInfer(BaseInfer[_VllmPrepared]):
             )
             yield "data: [DONE]\n\n"
             return
-        finally:
-            if trace:
-                logger.log(TRACE, "chat response %s (stream): %r", request_id, "".join(buffered))
         yield "data: [DONE]\n\n"
 
     async def _create_chat_completion_no_stream(
@@ -521,6 +618,7 @@ class VllmInfer(BaseInfer[_VllmPrepared]):
         reasoning_ended = engine_ops.derive_reasoning_ended(vllm_request, parser, prompt_token_ids)
 
         request_id = f"chatcmpl-{base_request_id(raw_request)}"
+        _trace_request(request_id, vllm_request, sampling_params)
         try:
             final_res = await self.run_cancellable(
                 engine_ops.consume_final_output(
@@ -553,16 +651,22 @@ class VllmInfer(BaseInfer[_VllmPrepared]):
             return _to_error_response("vllm returned no prompt_token_ids for a completed request", status_code=502)
         prompt_tokens = len(final_res.prompt_token_ids)
         completion_tokens = sum(len(output.token_ids) for output in final_res.outputs)
+        reasoning_tokens = engine_ops.total_reasoning_tokens(final_res.outputs, parser)
 
+        usage = UsageInfo(
+            prompt_tokens=prompt_tokens,
+            completion_tokens=completion_tokens,
+            total_tokens=prompt_tokens + completion_tokens,
+            completion_tokens_details=CompletionTokenUsageInfo(reasoning_tokens=reasoning_tokens)
+            if reasoning_tokens is not None
+            else None,
+        )
+        _trace_parsed_response(request_id, choices, finish_reasons, usage)
         return build_from_parsed(
             request_id=request_id,
             model_name=self.model_config.name,
             choices=choices,
-            usage=UsageInfo(
-                prompt_tokens=prompt_tokens,
-                completion_tokens=completion_tokens,
-                total_tokens=prompt_tokens + completion_tokens,
-            ),
+            usage=usage,
             finish_reasons=finish_reasons,
             logprobs=logprobs_list,
         )
@@ -608,6 +712,7 @@ class VllmInfer(BaseInfer[_VllmPrepared]):
         reasoning_ended = engine_ops.derive_reasoning_ended(vllm_request, parser, prompt_token_ids)
 
         request_id = f"resp-{base_request_id(raw_request)}"
+        _trace_request(request_id, vllm_request, sampling_params)
         try:
             final_res = await self.run_cancellable(
                 engine_ops.consume_final_output(
@@ -640,15 +745,21 @@ class VllmInfer(BaseInfer[_VllmPrepared]):
             return _to_error_response("vllm returned no prompt_token_ids for a completed request", status_code=502)
         prompt_tokens = len(final_res.prompt_token_ids)
         completion_tokens = sum(len(output.token_ids) for output in final_res.outputs)
+        reasoning_tokens = engine_ops.total_reasoning_tokens(final_res.outputs, parser)
 
+        usage = UsageInfo(
+            prompt_tokens=prompt_tokens,
+            completion_tokens=completion_tokens,
+            total_tokens=prompt_tokens + completion_tokens,
+            completion_tokens_details=CompletionTokenUsageInfo(reasoning_tokens=reasoning_tokens)
+            if reasoning_tokens is not None
+            else None,
+        )
+        _trace_parsed_response(request_id, choices, finish_reasons, usage)
         return build_response_from_parsed(
             choices[0],
             request,
-            usage=UsageInfo(
-                prompt_tokens=prompt_tokens,
-                completion_tokens=completion_tokens,
-                total_tokens=prompt_tokens + completion_tokens,
-            ),
+            usage=usage,
             finish_reason=finish_reasons[0],
             model=self.model_config.name,
         )
@@ -664,6 +775,7 @@ class VllmInfer(BaseInfer[_VllmPrepared]):
         round trip. Rendering already succeeded in `_prepare_responses`."""
         request_id = f"resp-{base_request_id(raw_request)}"
         vllm_request = prepared.vllm_request
+        _trace_request(request_id, vllm_request, prepared.sampling_params)
 
         stream = engine_ops.stream_chat_completion(
             self.engine,
@@ -679,6 +791,8 @@ class VllmInfer(BaseInfer[_VllmPrepared]):
             num_output_top_logprobs=None,
         )
         chunks = self.run_cancellable_stream(stream, raw_request)
+        if logger.isEnabledFor(TRACE):
+            chunks = _trace_chunks(chunks, request_id)
         async for event in self._stream_responses(
             request, chunks, request_id=request_id, client_error=_vllm_stream_error
         ):

--- a/tests/test_vllm_engine_ops.py
+++ b/tests/test_vllm_engine_ops.py
@@ -14,13 +14,17 @@ Two tiers:
 """
 
 import inspect
-from typing import Any
+from types import SimpleNamespace
+from typing import Any, ClassVar
 from unittest.mock import Mock
 
 import pytest
 from vllm.entrypoints.openai.chat_completion.protocol import (
     ChatCompletionRequest as VllmChatCompletionRequest,
 )
+from vllm.entrypoints.openai.engine.protocol import DeltaFunctionCall as VllmDeltaFunctionCall
+from vllm.entrypoints.openai.engine.protocol import DeltaMessage as VllmDeltaMessage
+from vllm.entrypoints.openai.engine.protocol import DeltaToolCall as VllmDeltaToolCall
 from vllm.entrypoints.serve.render.serving import OpenAIServingRender as VllmOpenAIServingRender
 from vllm.parser import Parser as VllmParser
 from vllm.tokenizers import TokenizerLike as VllmTokenizerLike
@@ -92,6 +96,38 @@ class TestDeriveReasoningEnded:
         assert engine_ops.derive_reasoning_ended(vllm_req, parser=None, prompt_token_ids=[]) is None
 
 
+class TestTotalReasoningTokens:
+    """Regression: `usage.completion_tokens_details.reasoning_tokens` was never
+    populated anywhere -- always silently 0/omitted -- even though vLLM's own
+    reasoning parsers expose `count_reasoning_tokens` for exactly this. That
+    hid the common "the whole token budget went to reasoning, not the answer"
+    failure mode from API consumers."""
+
+    def test_no_parser_returns_none(self):
+        outputs = [Mock(token_ids=[1, 2, 3])]
+        assert engine_ops.total_reasoning_tokens(outputs, parser=None) is None
+
+    def test_parser_without_reasoning_returns_none(self):
+        parser = Mock(spec=VllmParser)
+        parser.reasoning_parser = None
+        outputs = [Mock(token_ids=[1, 2, 3])]
+        assert engine_ops.total_reasoning_tokens(outputs, parser=parser) is None
+
+    def test_sums_across_choices(self):
+        parser = Mock(spec=VllmParser)
+        parser.reasoning_parser = Mock()
+        parser.reasoning_parser.count_reasoning_tokens.side_effect = [5, 2]
+        outputs = [Mock(token_ids=[1, 2, 3, 4, 5]), Mock(token_ids=[6, 7])]
+
+        result = engine_ops.total_reasoning_tokens(outputs, parser=parser)
+
+        assert result == 7
+        assert parser.reasoning_parser.count_reasoning_tokens.call_args_list == [
+            ((list(outputs[0].token_ids),),),
+            ((list(outputs[1].token_ids),),),
+        ]
+
+
 class TestMakeParsers:
     def test_no_parser_class_returns_n_nones(self):
         render = Mock(spec=VllmOpenAIServingRender)
@@ -116,6 +152,147 @@ class TestMakeParsers:
             args, kwargs = call
             assert args == (tokenizer, vllm_req.tools)
             assert kwargs == {"chat_template_kwargs": {"k": "v"}}
+
+
+class _TrapParser:
+    """Mirrors vLLM's parse/parse_delta split for a model that never closes its
+    reasoning: `parse_delta` streams everything as reasoning and never emits content,
+    while the authoritative full-text `parse` reads the same tokens as an answer."""
+
+    full_parse_result: ClassVar[tuple[str | None, str | None, Any]] = (None, "the answer", None)
+    delta_tool_calls: ClassVar[list[VllmDeltaToolCall]] = []
+    delta_as_content = False
+    parsed_text: ClassVar[str | None] = None
+
+    def __init__(self, tokenizer, tools=None, chat_template_kwargs=None):
+        self.reasoning_parser = None
+
+    def parse_delta(self, *, delta_text, delta_token_ids, request, prompt_token_ids, finished):
+        if self.delta_as_content:
+            return VllmDeltaMessage(content=delta_text)
+        return VllmDeltaMessage(reasoning=delta_text, tool_calls=self.delta_tool_calls)
+
+    def parse(self, model_output, request, enable_auto_tools=False, model_output_token_ids=()):
+        # Record what the reconcile handed us: it must be the engine's own streamed text,
+        # not a re-decode of the token ids (which would carry the stop token).
+        type(self).parsed_text = model_output
+        return self.full_parse_result
+
+
+def _res(text: str, token_ids: list[int], finish_reason: str | None):
+    output = SimpleNamespace(
+        index=0, text=text, token_ids=token_ids, finish_reason=finish_reason, logprobs=None, stop_reason=None
+    )
+    return SimpleNamespace(prompt_token_ids=[1, 2], outputs=[output])
+
+
+async def _drive_stream(monkeypatch, parser_cls, *, results=None) -> list[Any]:
+    """Run `stream_chat_completion` over a scripted engine stream, returning the chunks."""
+    monkeypatch.setattr(engine_ops, "extract_prompt_token_ids", lambda render, engine_input: [1, 2])
+
+    async def fake_generate(*args, **kwargs):
+        for r in results or [_res("Hello there", [10], None), _res("", [], "stop")]:
+            yield r
+
+    engine = Mock()
+    engine.generate = fake_generate
+    render = Mock(spec=VllmOpenAIServingRender)
+    render.parser = parser_cls
+
+    chunks = []
+    async for chunk in engine_ops.stream_chat_completion(
+        engine,
+        render,
+        _vllm_req(tools=None),
+        engine_input=Mock(),
+        sampling_params=Mock(),
+        request_id="req-1",
+        model_name="m",
+        tokenizer=Mock(decode=Mock(return_value="a token re-decode, not the engine's text")),
+        enable_auto_tools=False,
+        want_logprobs=False,
+        num_output_top_logprobs=None,
+    ):
+        chunks.append(chunk)
+    return chunks
+
+
+class TestStreamReconcilesTrappedContent:
+    """Regression: vLLM's streaming parser engine starts in REASONING when thinking is
+    primed and never reclassifies chunks it already emitted, so a model that ends a turn
+    without its close marker leaves the whole reply in `reasoning` with empty `content` —
+    while the non-streaming `parse()` reads the same tokens as `content`. The finish
+    branch must settle that disagreement in favour of the non-streaming answer."""
+
+    @pytest.mark.asyncio
+    async def test_reasoning_only_stream_recovers_content_on_finish(self, monkeypatch):
+        chunks = await _drive_stream(monkeypatch, _TrapParser)
+
+        final = chunks[-1]
+        assert final.choices[0].finish_reason == "stop"
+        assert final.choices[0].delta.content == "the answer"
+
+    @pytest.mark.asyncio
+    async def test_deferred_deltas_still_reach_the_parse(self, monkeypatch):
+        # Regression: vLLM parsers return None while deferring text they haven't
+        # classified yet, and that branch `continue`s. Accumulating only on emitted
+        # deltas dropped exactly those chunks, mangling the recovered answer
+        # ("2 + 2 equals **4**." came back as "2 +2 equals4."). Also pins that the parse
+        # gets the engine's own streamed text -- a re-decode of the token ids would
+        # carry the stop token the engine drops.
+        class DeferringParser(_TrapParser):
+            def parse_delta(self, *, delta_text, delta_token_ids, request, prompt_token_ids, finished):
+                if delta_text == " + ":  # deferred: consumed but not emitted
+                    return None
+                return VllmDeltaMessage(reasoning=delta_text)
+
+        _TrapParser.parsed_text = None
+        results = [
+            _res("2", [1], None),
+            _res(" + ", [2], None),
+            _res("2 equals 4.", [3], None),
+            _res("", [], "stop"),
+        ]
+        await _drive_stream(monkeypatch, DeferringParser, results=results)
+
+        assert DeferringParser.parsed_text == "2 + 2 equals 4."
+
+    @pytest.mark.asyncio
+    async def test_streamed_content_is_not_reconciled(self, monkeypatch):
+        class ContentParser(_TrapParser):
+            delta_as_content = True
+            full_parse_result = (None, "SHOULD NOT APPEAR", None)
+
+        chunks = await _drive_stream(monkeypatch, ContentParser)
+
+        streamed = "".join(c.choices[0].delta.content or "" for c in chunks if c.choices)
+        assert "SHOULD NOT APPEAR" not in streamed
+        assert "Hello there" in streamed
+
+    @pytest.mark.asyncio
+    async def test_reasoning_with_no_answer_stays_empty(self, monkeypatch):
+        # Reasoning that genuinely closed with no answer: the re-parse agrees there is
+        # no content, so nothing is attached (the flags alone would have fired here).
+        class NoAnswerParser(_TrapParser):
+            full_parse_result = ("some reasoning", None, None)
+
+        chunks = await _drive_stream(monkeypatch, NoAnswerParser)
+
+        assert chunks[-1].choices[0].delta.content is None
+
+    @pytest.mark.asyncio
+    async def test_tool_call_stream_is_not_reconciled(self, monkeypatch):
+        class ToolParser(_TrapParser):
+            delta_tool_calls: ClassVar[list[VllmDeltaToolCall]] = [
+                VllmDeltaToolCall(
+                    index=0, id="c1", type="function", function=VllmDeltaFunctionCall(name="f", arguments="{}")
+                )
+            ]
+            full_parse_result: ClassVar[tuple[str | None, str | None, Any]] = (None, "SHOULD NOT APPEAR", None)
+
+        chunks = await _drive_stream(monkeypatch, ToolParser)
+
+        assert chunks[-1].choices[0].delta.content is None
 
 
 class TestSignaturesGuardVllmBump:

--- a/tests/test_vllm_parsing.py
+++ b/tests/test_vllm_parsing.py
@@ -17,6 +17,9 @@ from modelship.infer.infer_config import (
 from modelship.infer.vllm.parsing.detect import (
     classify_reasoning_template,
     classify_tool_template,
+    detect_boolean_defaults,
+    detect_template_toggle_defaults,
+    discover_template_vars,
     resolve_reasoning_parser,
     resolve_tool_parser,
 )
@@ -89,6 +92,9 @@ class TestClassifyReasoningTemplate:
     def test_empty_returns_none(self):
         assert classify_reasoning_template("") is None
 
+    def test_gemma4_channel_marker(self):
+        assert classify_reasoning_template("...<|channel>thought\n...\n<channel|>...") == "gemma4"
+
 
 class TestResolveReasoningParsers:
     def test_explicit_parser_stored(self):
@@ -120,6 +126,83 @@ class TestResolveReasoningParsers:
         cfg = _make_cfg(vllm_engine_kwargs=VllmEngineConfig(reasoning_parser="not-a-real-parser"))
         with pytest.raises(ValueError, match="not-a-real-parser"):
             resolve_reasoning_parser(cfg, None)
+
+    def test_does_not_mutate_chat_template_kwargs(self):
+        # Toggle defaults are pinned by detect_template_toggle_defaults at init,
+        # not here — the resolver is pure name resolution.
+        cfg = _make_cfg(vllm_engine_kwargs=VllmEngineConfig(reasoning_parser="gemma4"))
+        resolve_reasoning_parser(cfg, None)
+        assert cfg.chat_template_kwargs == {}
+
+
+class TestDiscoverTemplateVars:
+    def test_finds_undeclared_vars(self):
+        src = "{% if enable_thinking %}x{% endif %}{{ messages }}"
+        assert discover_template_vars(src) == {"enable_thinking", "messages"}
+
+    def test_plain_string_has_no_vars(self):
+        assert discover_template_vars("just some text") == set()
+
+
+class TestDetectBooleanDefaults:
+    """A chat template's own default for a boolean toggle is recovered by rendering
+    it forced on vs off and seeing which the no-kwarg base render matches. This is
+    the generic replacement for the old hardcoded parser-name list: it derives each
+    template's intent behaviorally, so Gemma (thinking opt-in) and Qwen (opt-out)
+    are handled by the same code with no per-model knowledge."""
+
+    @staticmethod
+    def _render_for(src: str):
+        import jinja2
+
+        template = jinja2.Environment().from_string(src)
+        return lambda **kw: template.render(**kw)
+
+    def test_opt_in_toggle_defaults_false(self):
+        # Gemma shape: primer only when explicitly enabled -> default False.
+        render = self._render_for("{% if enable_thinking %}<think>{% endif %}A")
+        assert detect_boolean_defaults({"enable_thinking"}, render) == {"enable_thinking": False}
+
+    def test_opt_out_toggle_defaults_true(self):
+        # Qwen shape: thinking on unless explicitly disabled -> default True.
+        render = self._render_for("{% if enable_thinking is not defined or enable_thinking %}<think>{% endif %}A")
+        assert detect_boolean_defaults({"enable_thinking"}, render) == {"enable_thinking": True}
+
+    def test_non_boolean_var_is_ambiguous_and_skipped(self):
+        render = self._render_for("{{ bos_token }}A")
+        assert detect_boolean_defaults({"bos_token"}, render) == {}
+
+    def test_inert_var_skipped(self):
+        render = self._render_for("{% if foo %}{% endif %}A")
+        assert detect_boolean_defaults({"foo"}, render) == {}
+
+    def test_raising_var_skipped_without_crashing(self):
+        render = self._render_for("{{ fn() }}")
+        assert detect_boolean_defaults({"fn"}, render) == {}
+
+    def test_multiple_toggles_each_detected(self):
+        render = self._render_for("{% if a %}A{% endif %}{% if b is not defined or b %}B{% endif %}")
+        assert detect_boolean_defaults({"a", "b"}, render) == {"a": False, "b": True}
+
+
+class TestDetectTemplateToggleDefaults:
+    """Orchestrator: renders through a tokenizer-like ``apply_chat_template`` and
+    must exclude that method's own signature params — pinning e.g.
+    ``add_generation_prompt`` into ``chat_template_kwargs`` would collide with
+    vLLM's explicit argument at request time (``TypeError: multiple values``)."""
+
+    def test_signature_params_are_excluded(self):
+        class FakeTokenizer:
+            # add_generation_prompt is a real branch AND a signature param -> must not be pinned.
+            def apply_chat_template(self, conversation, tokenize=False, add_generation_prompt=True, **kw):
+                thinking = "<think>" if kw.get("enable_thinking") else ""
+                gen = "<gen>" if add_generation_prompt else ""
+                return f"{gen}{thinking}A"
+
+        src = "{% if add_generation_prompt %}<gen>{% endif %}{% if enable_thinking %}<think>{% endif %}A"
+        result = detect_template_toggle_defaults(src, FakeTokenizer())
+        assert "add_generation_prompt" not in result
+        assert result == {"enable_thinking": False}
 
 
 class TestResolveToolParsersStoresExplicit:


### PR DESCRIPTION
…g field

Reasoning-capable models on the vllm loader could return their whole reply in `reasoning` with empty `content`. Two independent causes, both fixed here.

1. Template/parser default mismatch. vLLM parsers read `chat_template_kwargs["enable_thinking"]` and default it to True when absent (gemma4.py:439), which feeds `is_reasoning_end()` -> at a `<|turn>` boundary it returns `not _thinking_enabled` (gemma4.py:531-534), so `adjust_initial_state_from_prompt` primes the parser into REASONING. But a template commonly defaults thinking off, so the model was never primed to think and its plain answer got classified as reasoning.

   `detect_template_toggle_defaults` now discovers each template's own default for every boolean toggle it reads (jinja2 var discovery + behavioural render-diff) and pins it into the model config at init, so both sides agree. Fully generic: no hardcoded parser or key names, and user/config values still win. Parameters of `apply_chat_template` (e.g. `add_generation_prompt`) are excluded -- pinning them would collide with vLLM's own explicit argument at request time.

2. Streaming never reconciles unclosed reasoning. vLLM's streaming parser engine starts in REASONING when thinking is primed and its `finish()` only marks REASONING_END -- it never reclassifies chunks it already emitted (streaming_parser_engine.py:212). A model that ends a turn without its close marker therefore leaves everything in `reasoning`, while the non-streaming `parse()` reads the same tokens as `content`. Same tokens, two different splits.

   `stream_chat_completion` now detects a reasoning-only stream (no content, no tool calls) and re-runs the authoritative full parse -- the same call `build_choices` uses -- attaching any recovered content to the finish chunk. The flags are a cheap pre-filter; the re-parse decides, so a genuinely answer-less turn is untouched. Costs nothing on the common path. Fixes both endpoints at once (chat and responses share this function).

   The parse is fed the engine's own streamed text, not a re-decode of the token ids: the engine drops the stop token from its text while the ids retain it, and `parse()` does not strip trailing sentinels. The text is accumulated alongside the ids (parsers return None while deferring text, and that branch continues) and dropped as soon as a choice streams content, since it can no longer be reconciled.

This is a known, recurring vLLM defect filed per-parser (gemma4 #39885, GLM-4.5 #29763, MiniMax #38212/#45687) and is not gemma-specific -- qwen3, glm47_moe, minimax_m2 and nemotron_v3 share the same engine. We are pinned to vllm==0.24.0 and reproduced it there, so the fix lives in the calling layer and is parser- and version-agnostic. Disabling reasoning in config was rejected: modelship wraps inference frameworks and must not handicap a model that supports reasoning.

Also adds, both of which made the above diagnosable:
- `usage.completion_tokens_details.reasoning_tokens` via vLLM's own `count_reasoning_tokens`, on the streaming and non-streaming paths.
- TRACE request/response payload logging for the vllm loader, covering all four chat/responses seams. Previously only the chat stream logged, and it captured content only -- exactly the field that is empty when this bug hits.


