### PR TITLE
fix: make memory:// state store cluster-scoped via a detached Ray actor

### DIFF
--- a/docs/model-configuration.md
+++ b/docs/model-configuration.md
@@ -514,7 +514,7 @@ connection URI — the scheme picks the backend, the rest carries its connection
 
 | URI | Backend | Durability |
 |---|---|---|
-| `memory://` (default) | in-process dict | none — lost on restart (fine self-hosted: a restart replaces the config anyway) |
+| `memory://` (default) | dict shared cluster-wide by a detached Ray actor | survives a deploy re-run / coordinator restart, but not cluster death (fine self-hosted: a cluster loss replaces the config anyway) |
 | `file:///.cache/state` | one JSON file per key under the path (empty path → `MSHIP_STATE_DIR`) | survives cluster death on a mounted volume / PVC |
 | `redis://[:pw@]host:6379/0` (`rediss://` = TLS) | one JSON value per key in Redis | survives head/coordinator death; the password is parsed from the URL by `redis.from_url` |
 

--- a/modelship/infer/replica_coordinator.py
+++ b/modelship/infer/replica_coordinator.py
@@ -6,8 +6,10 @@ model deployments each gateway owns. `mship_deploy.py` writes to it as models ar
 own routing table from `get_routing` — the driver never pushes to individual
 replicas.
 
-The registry is persisted through `get_state_store()` (file/redis for multi-node
-HA) so a resurrected actor reloads live ownership instead of starting empty. The
+The registry is persisted through `get_state_store()` — cluster-scoped even on the
+default `memory://` (backed by its own detached actor, see `modelship.state.memory`)
+so a resurrected coordinator reloads live ownership instead of starting empty;
+`file://`/`redis://` add survival across a full cluster loss on top of that. The
 per-gateway generation counter and its wakeup `asyncio.Event` are ephemeral: on
 restart the generation resets to 0, which `wait_for_change` already treats as
 "changed" so replicas re-pull and reconcile from the reloaded registry.
@@ -51,14 +53,17 @@ class ReplicaCoordinator:
         # reconcile from the reloaded registry.
         self._store = get_state_store()
         if isinstance(getattr(self._store, "inner", self._store), MemoryStateStore):
-            # A memory store dies with the actor: a restarted coordinator reloads an
-            # empty registry, and the next deploy (gen advances) re-enables removals
-            # against it — dropping still-healthy models from gateway routing. Fine
-            # single-node; for multi-node/HA set MSHIP_STATE_STORE to file:// or redis://.
+            # The memory store is cluster-scoped (a detached actor), so it survives
+            # THIS coordinator's own restart — but it dies with the cluster: a
+            # coordinator resurrected on a fresh cluster reloads an empty registry,
+            # and the next deploy (gen advances) re-enables removals against it —
+            # dropping still-healthy models from gateway routing. Fine single-node;
+            # for survival across cluster loss set MSHIP_STATE_STORE to file:// or
+            # redis://.
             logger.warning(
-                "Replica coordinator is backed by a non-durable memory state store; its routing "
-                "registry will be lost on coordinator restart. Set MSHIP_STATE_STORE to file:// "
-                "or redis:// for multi-node/HA."
+                "Replica coordinator is backed by a cluster-scoped (non-durable) memory state "
+                "store; its routing registry survives coordinator restart but is lost if the "
+                "cluster dies. Set MSHIP_STATE_STORE to file:// or redis:// to survive cluster loss."
             )
         saved = self._store.get(_STATE_KEY)
         saved = saved if isinstance(saved, dict) else {}
@@ -87,14 +92,15 @@ class ReplicaCoordinator:
             old.set()
         self._change[gateway_name] = asyncio.Event()
 
-    def _persist(self) -> None:
-        """Write the durable routing state through the StateStore. A no-op for the
-        memory store; for redis/file this is what survives coordinator death."""
-        self._store.set(_STATE_KEY, {"registry": self._registry, "expected": self._expected})
+    async def _persist(self) -> None:
+        """Write the durable routing state through the StateStore. Async because a
+        memory-backed store is an RPC to another actor — a sync ray.get here would
+        block this actor's own event loop (and thus wait_for_change) on every write."""
+        await self._store.set_async(_STATE_KEY, {"registry": self._registry, "expected": self._expected})
 
     async def register_deployment(self, gateway_name: str, deployment_name: str, model_name: str) -> None:
         self._registry.setdefault(gateway_name, {})[deployment_name] = model_name
-        self._persist()
+        await self._persist()
         self._bump(gateway_name)
 
     async def unregister_deployment(self, gateway_name: str, deployment_name: str) -> None:
@@ -103,13 +109,13 @@ class ReplicaCoordinator:
             gw.pop(deployment_name, None)
             if not gw:
                 del self._registry[gateway_name]
-        self._persist()
+        await self._persist()
         self._bump(gateway_name)
 
     async def set_expected(self, gateway_name: str, names: list[str]) -> None:
         """Record the desired model set for readiness; bumps so replicas adopt it."""
         self._expected[gateway_name] = list(names)
-        self._persist()
+        await self._persist()
         self._bump(gateway_name)
 
     async def get_routing(self, gateway_name: str) -> dict:

--- a/modelship/state/__init__.py
+++ b/modelship/state/__init__.py
@@ -3,7 +3,7 @@
 A store is selected by a connection URI whose **scheme** picks the backend and
 whose body carries that backend's connection:
 
-    memory://                     in-process dict (default)
+    memory://                     dict shared cluster-wide via a Ray actor (default)
     file:///.cache/state          one JSON file per key under a directory
     redis://[:pw@]host:6379/0      one JSON value per key in Redis (rediss:// = TLS)
 
@@ -22,12 +22,13 @@ from urllib.parse import ParseResult, urlparse
 from modelship.metrics import STATE_STORE_OPERATION_DURATION_SECONDS, STATE_STORE_OPERATIONS_TOTAL
 from modelship.state.base import JsonValue, StateStore, StateStoreUnavailableError
 from modelship.state.file import FileStateStore
-from modelship.state.memory import MemoryStateStore
+from modelship.state.memory import MemoryStateStore, MemoryStoreActor
 
 __all__ = [
     "FileStateStore",
     "JsonValue",
     "MemoryStateStore",
+    "MemoryStoreActor",
     "StateStore",
     "StateStoreUnavailableError",
     "get_state_store",
@@ -129,7 +130,11 @@ def _default_file_dir() -> Path:
     return Path(base)
 
 
-def _build_memory(_: ParseResult) -> StateStore:
+def _build_memory(parsed: ParseResult) -> StateStore:
+    # No connection body: memory:// always names the one cluster-wide actor. Any
+    # netloc (e.g. memory://foo) is rejected rather than silently ignored.
+    if parsed.netloc:
+        raise ValueError(f"memory:// URI takes no host/path: {parsed.geturl()!r} parses host {parsed.netloc!r}.")
     return MemoryStateStore()
 
 

--- a/modelship/state/__init__.py
+++ b/modelship/state/__init__.py
@@ -132,9 +132,14 @@ def _default_file_dir() -> Path:
 
 def _build_memory(parsed: ParseResult) -> StateStore:
     # No connection body: memory:// always names the one cluster-wide actor. Any
-    # netloc (e.g. memory://foo) is rejected rather than silently ignored.
-    if parsed.netloc:
-        raise ValueError(f"memory:// URI takes no host/path: {parsed.geturl()!r} parses host {parsed.netloc!r}.")
+    # host or path (memory://foo, memory:///foo) is rejected rather than silently
+    # ignored. Gate on parsed.scheme too: the bare "memory" form (no "://") is
+    # parsed as an empty scheme with the word itself sitting in .path, and that
+    # form must still be accepted.
+    if parsed.scheme and (parsed.netloc or parsed.path):
+        raise ValueError(
+            f"memory:// URI takes no host/path: {parsed.geturl()!r} parses host {parsed.netloc!r} path {parsed.path!r}."
+        )
     return MemoryStateStore()
 
 

--- a/modelship/state/memory.py
+++ b/modelship/state/memory.py
@@ -1,9 +1,11 @@
-"""In-memory StateStore — a process-local dict.
+"""In-memory StateStore — a dict shared cluster-wide through a detached Ray actor.
 
-The default backend. Holds nothing across process death, so it suits self-hosted
-/ Docker deployments where a restart replaces the config anyway, and any actor
-that wants the StateStore interface without durable infra. Selected by the
-``memory://`` URI scheme.
+The default backend. Every process and gateway replica in the cluster shares one
+``MemoryStoreActor``, so writes from one process (e.g. the deploy driver) are
+visible to another (e.g. a re-run of the driver, or a gateway replica) — unlike a
+plain process-local dict. It survives the actor being restarted (``max_restarts``)
+but NOT the cluster dying, which is what distinguishes it from the durable
+``file://``/``redis://`` backends. Selected by the ``memory://`` URI scheme.
 """
 
 from __future__ import annotations
@@ -11,10 +13,28 @@ from __future__ import annotations
 import copy
 import time
 
-from modelship.state.base import JsonValue, StateStore, normalize_prefix
+import ray
+from ray import exceptions as ray_exceptions
+
+from modelship.state.base import JsonValue, StateStore, StateStoreUnavailableError, normalize_prefix
+
+# Detached-actor identity: same namespace as the other cluster-wide coordinators
+# (modelship.infer.deploy_coordinator.COORDINATOR_NAMESPACE / replica_coordinator).
+# Not imported from there — modelship.state is the generic lower layer and infer
+# depends on it, not the reverse.
+_ACTOR_NAME = "modelship-memory-store"
+_ACTOR_NAMESPACE = "modelship"
 
 
-class MemoryStateStore(StateStore):
+@ray.remote(num_cpus=0)
+class MemoryStoreActor(StateStore):
+    """Holds the dict. One actor for the whole cluster — memory:// targets
+    small-traffic single-node deployments, so a single actor is the design point,
+    not a stopgap. A restart returns an empty store: this fails safe for both
+    current callers (the replica coordinator's in-RAM registry is untouched and
+    write-through repopulates it; an empty effective config makes the deploy
+    driver's reconcile remove nothing rather than remove wrongly)."""
+
     def __init__(self) -> None:
         # key -> (value, expires_at epoch | None). Expiry is enforced lazily on read.
         self._data: dict[str, tuple[JsonValue, float | None]] = {}
@@ -46,7 +66,8 @@ class MemoryStateStore(StateStore):
             if (not prefix or k == prefix or k.startswith(f"{prefix}/")) and (expires_at is None or now < expires_at)
         ]
 
-    # In-process: no thread needed, so skip the base's to_thread hop.
+    # In-process (this runs as the actor body itself, not over RPC from within):
+    # no thread needed, so skip the base's to_thread hop.
     async def get_async(self, key: str) -> JsonValue | None:
         return self.get(key)
 
@@ -58,3 +79,82 @@ class MemoryStateStore(StateStore):
 
     async def list_async(self, prefix: str) -> list[str]:
         return self.list(prefix)
+
+
+def get_or_create_memory_store_actor():
+    """Return the cluster-wide memory-store actor handle, creating it if absent.
+    Mirrors deploy_coordinator.get_or_create_coordinator's race-safe pattern."""
+    try:
+        return ray.get_actor(_ACTOR_NAME, namespace=_ACTOR_NAMESPACE)
+    except ValueError:
+        pass
+    try:
+        return MemoryStoreActor.options(
+            name=_ACTOR_NAME,
+            namespace=_ACTOR_NAMESPACE,
+            lifetime="detached",
+            num_cpus=0,
+            max_restarts=-1,
+        ).remote()
+    except ValueError:
+        return ray.get_actor(_ACTOR_NAME, namespace=_ACTOR_NAMESPACE)
+
+
+class MemoryStateStore(StateStore):
+    """Client for the cluster-wide MemoryStoreActor. Construction is inert (no Ray
+    call) so it can be built before/without a cluster, matching RedisStateStore's
+    lazy-client pattern; the actor handle is resolved on first use."""
+
+    def __init__(self) -> None:
+        self._handle = None
+
+    def _actor(self):
+        if self._handle is None:
+            if not ray.is_initialized():
+                raise StateStoreUnavailableError(
+                    "memory:// requires an initialized Ray cluster (no ray.init() has run in this process)."
+                )
+            self._handle = get_or_create_memory_store_actor()
+        return self._handle
+
+    def _call(self, method: str, *args, **kwargs):
+        try:
+            return ray.get(getattr(self._actor(), method).remote(*args, **kwargs))
+        except ray_exceptions.RayActorError as exc:
+            # The actor died and won't come back reachable via this stale handle
+            # (max_restarts keeps the same actor id alive, but a fresh
+            # ray.get_actor() re-resolves it) — drop the cache and let the next
+            # call re-resolve.
+            self._handle = None
+            raise StateStoreUnavailableError(f"memory:// store actor unreachable: {exc}") from exc
+
+    async def _acall(self, method: str, *args, **kwargs):
+        try:
+            return await getattr(self._actor(), method).remote(*args, **kwargs)
+        except ray_exceptions.RayActorError as exc:
+            self._handle = None
+            raise StateStoreUnavailableError(f"memory:// store actor unreachable: {exc}") from exc
+
+    def get(self, key: str) -> JsonValue | None:
+        return self._call("get", key)
+
+    def set(self, key: str, value: JsonValue, *, ttl_seconds: float | None = None) -> None:
+        self._call("set", key, value, ttl_seconds=ttl_seconds)
+
+    def delete(self, key: str) -> None:
+        self._call("delete", key)
+
+    def list(self, prefix: str) -> list[str]:
+        return self._call("list", prefix)
+
+    async def get_async(self, key: str) -> JsonValue | None:
+        return await self._acall("get", key)
+
+    async def set_async(self, key: str, value: JsonValue, *, ttl_seconds: float | None = None) -> None:
+        await self._acall("set", key, value, ttl_seconds=ttl_seconds)
+
+    async def delete_async(self, key: str) -> None:
+        await self._acall("delete", key)
+
+    async def list_async(self, prefix: str) -> list[str]:
+        return await self._acall("list", prefix)

--- a/mship_deploy.py
+++ b/mship_deploy.py
@@ -63,7 +63,7 @@ from modelship.infer.deploy_coordinator import OperatorProbe, get_or_create_coor
 from modelship.infer.replica_coordinator import get_or_create_replica_coordinator  # noqa: E402
 from modelship.logging import configure_logging, get_lib_log_config, get_logger  # noqa: E402
 from modelship.metrics import DEPLOY_DURATION_SECONDS, DEPLOY_MODELS_CHANGED_TOTAL  # noqa: E402
-from modelship.state import get_state_store  # noqa: E402
+from modelship.state import MemoryStateStore, get_state_store  # noqa: E402
 from modelship.utils.cli import apply_args_to_env, parse_args  # noqa: E402
 
 logger = get_logger("startup")
@@ -108,6 +108,15 @@ def main(argv: list[str] | None = None) -> None:
     # (it reads the persisted effective set and reconciles onto an empty cluster).
     mode = resolve_mode(reconcile=args.reconcile)
     store = get_state_store()
+    if isinstance(getattr(store, "inner", store), MemoryStateStore):
+        # Cluster-scoped (a detached actor), so effective config now survives
+        # across deploy invocations and coordinator restarts — but it dies with
+        # the cluster, unlike file:// (on a PVC) or redis://.
+        logger.warning(
+            "Effective config is backed by a cluster-scoped (non-durable) memory state store; it "
+            "survives deploys and coordinator restarts but NOT cluster loss. Set MSHIP_STATE_STORE "
+            "to file:// or redis:// for self-heal after cluster loss."
+        )
     effective_raw = read_effective(store, gateway_name)
 
     # --reconcile with no --config is the self-heal path: there's no user input, so

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -194,12 +194,6 @@ class _Deployer:
 
     def __init__(self, tmp_dir: Path) -> None:
         self._tmp = tmp_dir
-        # A per-session file:// state store, shared with the operator (see
-        # mship_cluster). The default is now memory://, which is per-process — but
-        # each reconcile runs in its OWN subprocess and must read the effective set
-        # the prior deploy wrote to tear down models that dropped out, so the
-        # integration tests opt into a shared cross-process file store under tmp.
-        self._state_store = f"file://{tmp_dir / 'state'}"
         self._current: frozenset[str] = frozenset()
 
     def deploy(self, *model_names: str) -> None:
@@ -221,8 +215,6 @@ class _Deployer:
                     "mship_deploy.py",
                     "--config",
                     str(config_path),
-                    "--state-store",
-                    self._state_store,
                     "--reconcile",
                     "--replace-strategy",
                     "stop_start",
@@ -252,12 +244,6 @@ def mship_cluster(tmp_path_factory):
     tmp_dir = tmp_path_factory.mktemp("mship_integration")
     empty_config = tmp_dir / "empty-models.yaml"
     log_path = tmp_dir / "mship_deploy.log"
-    # Per-session file:// state store, shared with every _Deployer reconcile via
-    # --state-store. memory:// (the default) is per-process, so reconcile in a
-    # separate subprocess couldn't read this operator's effective set; a shared
-    # file store under tmp keeps that cross-process sharing without touching the
-    # /.cache/state default.
-    state_store = f"file://{tmp_dir / 'state'}"
 
     subprocess.run(["ray", "stop", "--force"], check=False)
     subprocess.run(["ray", "start", "--head", "--dashboard-host=0.0.0.0", "--disable-usage-stats"], check=True)
@@ -277,8 +263,6 @@ def mship_cluster(tmp_path_factory):
             "mship_deploy.py",
             "--config",
             str(empty_config),
-            "--state-store",
-            state_store,
             "--gateway-replicas",
             "2",
             "--prune-ray-sessions",

--- a/tests/test_replica_coordinator.py
+++ b/tests/test_replica_coordinator.py
@@ -9,15 +9,21 @@ import pytest
 
 from modelship.infer import replica_coordinator
 from modelship.infer.replica_coordinator import ReplicaCoordinator
-from modelship.state import MemoryStateStore
+from modelship.state import MemoryStoreActor
 
-# The plain class behind @ray.remote — its async methods are ordinary coroutines.
+# The plain classes behind @ray.remote — their async methods are ordinary
+# coroutines, so both can be exercised in-process without a Ray cluster.
 _Coord = ReplicaCoordinator.__ray_metadata__.modified_class
+_MemoryStore = MemoryStoreActor.__ray_metadata__.modified_class
 
 
 @pytest.fixture
 def coord():
-    return _Coord()
+    # get_state_store() now returns a Ray-actor-backed client that requires a live
+    # cluster; patch it to the plain in-process dict so these tests stay
+    # cluster-free, matching every other test in this file.
+    with patch.object(replica_coordinator, "get_state_store", return_value=_MemoryStore()):
+        yield _Coord()
 
 
 class TestRoutingRegistry:
@@ -100,7 +106,7 @@ class TestDurableState:
 
     @pytest.mark.asyncio
     async def test_reloads_registry_and_expected_from_shared_store(self):
-        store = MemoryStateStore()  # stand-in for a redis:// store across restarts
+        store = _MemoryStore()  # stand-in for a redis:// store across restarts
         with patch.object(replica_coordinator, "get_state_store", return_value=store):
             first = _Coord()
             await first.register_deployment("gw", "qwen-aaaa", "qwen")
@@ -117,7 +123,7 @@ class TestDurableState:
 
     @pytest.mark.asyncio
     async def test_unregister_persists_removal(self):
-        store = MemoryStateStore()
+        store = _MemoryStore()
         with patch.object(replica_coordinator, "get_state_store", return_value=store):
             first = _Coord()
             await first.register_deployment("gw", "qwen-aaaa", "qwen")

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -3,17 +3,25 @@ sync and async paths, TTL, prefix listing, and availability-vs-absent semantics.
 """
 
 import json
+from unittest.mock import MagicMock
 
 import pytest
+from ray import exceptions as ray_exceptions
 
 from modelship.state import (
     FileStateStore,
     MemoryStateStore,
+    MemoryStoreActor,
     StateStoreUnavailableError,
     get_state_store,
     state_store_from_uri,
 )
+from modelship.state import memory as memory_module
 from modelship.state.redis import RedisStateStore
+
+# The plain class behind @ray.remote — its dict logic is tested in-process,
+# without a Ray cluster, the same pattern test_replica_coordinator.py uses.
+_MemoryStore = MemoryStoreActor.__ray_metadata__.modified_class
 
 
 def _fake_redis_store():
@@ -31,7 +39,7 @@ def _fake_redis_store():
 @pytest.fixture(params=["memory", "file", "redis"])
 def store(request, tmp_path):
     if request.param == "memory":
-        return MemoryStateStore()
+        return _MemoryStore()
     if request.param == "file":
         return FileStateStore(tmp_path)
     return _fake_redis_store()
@@ -88,9 +96,12 @@ class TestBackends:
         assert await store.get_async("k") is None
 
 
-class TestMemoryStateStore:
+class TestMemoryStoreActor:
+    """The dict logic that lives inside MemoryStoreActor, exercised via the plain
+    class (no Ray cluster needed)."""
+
     def test_isolates_stored_value_from_caller_mutation(self):
-        store = MemoryStateStore()
+        store = _MemoryStore()
         payload = {"x": 1}
         store.set("k", payload)
         payload["x"] = 999  # mutate the original after storing
@@ -103,12 +114,65 @@ class TestMemoryStateStore:
     def test_ttl_expires(self, monkeypatch):
         clock = {"t": 1000.0}
         monkeypatch.setattr("time.time", lambda: clock["t"])
-        store = MemoryStateStore()
+        store = _MemoryStore()
         store.set("k", {"x": 1}, ttl_seconds=10)
         assert store.get("k") == {"x": 1}
         clock["t"] = 1011.0
         assert store.get("k") is None
         assert store.list("k") == []
+
+
+class TestMemoryStateStoreClient:
+    """The MemoryStateStore client: Ray-availability gating, delegation to the
+    actor handle, and RayActorError -> StateStoreUnavailableError mapping."""
+
+    def test_construction_is_inert(self, monkeypatch):
+        # No ray.is_initialized / get_or_create call until first use.
+        monkeypatch.setattr(memory_module.ray, "is_initialized", MagicMock(side_effect=AssertionError))
+        MemoryStateStore()
+
+    def test_raises_when_ray_not_initialized(self, monkeypatch):
+        monkeypatch.setattr(memory_module.ray, "is_initialized", lambda: False)
+        store = MemoryStateStore()
+        with pytest.raises(StateStoreUnavailableError):
+            store.get("k")
+
+    def test_delegates_get_to_actor_handle(self, monkeypatch):
+        monkeypatch.setattr(memory_module.ray, "is_initialized", lambda: True)
+        fake_handle = MagicMock()
+        fake_handle.get.remote.return_value = "sentinel-ref"
+        monkeypatch.setattr(memory_module, "get_or_create_memory_store_actor", lambda: fake_handle)
+        monkeypatch.setattr(memory_module.ray, "get", lambda ref: {"x": 1} if ref == "sentinel-ref" else None)
+
+        store = MemoryStateStore()
+        assert store.get("k") == {"x": 1}
+        fake_handle.get.remote.assert_called_once_with("k")
+
+    def test_actor_error_raises_unavailable_and_drops_cached_handle(self, monkeypatch):
+        monkeypatch.setattr(memory_module.ray, "is_initialized", lambda: True)
+        fake_handle = MagicMock()
+        fake_handle.get.remote.return_value = "ref"
+        monkeypatch.setattr(memory_module, "get_or_create_memory_store_actor", lambda: fake_handle)
+        monkeypatch.setattr(
+            memory_module.ray,
+            "get",
+            MagicMock(side_effect=ray_exceptions.RayActorError()),
+        )
+
+        store = MemoryStateStore()
+        with pytest.raises(StateStoreUnavailableError):
+            store.get("k")
+        assert store._handle is None  # dropped so the next call re-resolves
+
+    def test_get_or_create_sets_max_restarts(self, monkeypatch):
+        # A restarted actor comes back empty (see MemoryStoreActor's docstring) but
+        # must come back at all — assert the option that makes that happen.
+        monkeypatch.setattr(memory_module.ray, "get_actor", MagicMock(side_effect=ValueError("absent")))
+        options = MagicMock()
+        options.return_value.remote.return_value = MagicMock()
+        monkeypatch.setattr(memory_module.MemoryStoreActor, "options", options)
+        memory_module.get_or_create_memory_store_actor()
+        assert options.call_args.kwargs["max_restarts"] == -1
 
 
 class TestFileStateStore:
@@ -181,6 +245,10 @@ class TestStateStoreFromUri:
 
     def test_bare_value_treated_as_scheme(self):
         assert isinstance(state_store_from_uri("memory").inner, MemoryStateStore)
+
+    def test_memory_scheme_rejects_host(self):
+        with pytest.raises(ValueError, match="takes no host/path"):
+            state_store_from_uri("memory://foo")
 
     def test_file_scheme_uses_uri_path(self):
         store = state_store_from_uri("file:///tmp/mship-state-test").inner

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -250,6 +250,10 @@ class TestStateStoreFromUri:
         with pytest.raises(ValueError, match="takes no host/path"):
             state_store_from_uri("memory://foo")
 
+    def test_memory_scheme_rejects_path(self):
+        with pytest.raises(ValueError, match="takes no host/path"):
+            state_store_from_uri("memory:///foo")
+
     def test_file_scheme_uses_uri_path(self):
         store = state_store_from_uri("file:///tmp/mship-state-test").inner
         assert isinstance(store, FileStateStore)


### PR DESCRIPTION
memory:// was a plain process-local dict, but get_state_store() is called from processes that share no memory: the deploy driver reads/writes the effective config in a fresh process every invocation, and prev_effective_names was therefore always empty, silently degrading --reconcile into additive mode with no removals. The replica coordinator's routing registry had the same problem across its own restarts.

MemoryStateStore now RPCs into a new detached MemoryStoreActor holding the dict, so every process and gateway replica shares one store. Callers, construction, and the memory:// URI are unchanged. ReplicaCoordinator._persist is now async (a sync ray.get would've blocked the coordinator's event loop on every registry write); both its warning and mship_deploy's now say the store survives restarts but not cluster loss.


