### PR TITLE
docs: reposition README around the self-hosted agent backend

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -23,7 +23,7 @@ jobs:
         uses: astral-sh/setup-uv@v6
 
       - name: Set up Python
-        run: uv python install 3.12
+        run: uv python install 3.12.10
 
       - name: Install dependencies
         run: uv sync --extra docs

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,37 @@
+name: Docs
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "docs/**"
+      - "mkdocs.yml"
+      - "pyproject.toml"
+      - ".github/workflows/docs.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v6
+
+      - name: Set up Python
+        run: uv python install 3.12
+
+      - name: Install dependencies
+        run: uv sync --extra docs
+
+      - name: Configure git identity
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Deploy docs to GitHub Pages
+        run: uv run mkdocs gh-deploy --force --clean

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ __pycache__
 *.DS_Store
 .cache
 .build
+site
 local_models
 models-cache
 config/models.yaml

--- a/README.md
+++ b/README.md
@@ -12,11 +12,11 @@
 [![License: Apache 2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 [![Python 3.12+](https://img.shields.io/badge/python-3.12+-blue.svg)](https://www.python.org/downloads/)
 
-Modelship runs the AI stack your agents call — chat, the **Responses API** with durable server-side conversation state, universal **tool calling**, and **reasoning**, alongside embeddings, speech, and image generation — behind one OpenAI-compatible endpoint on your own GPUs (or CPU). Built on [Ray Serve](https://docs.ray.io/en/latest/serve/index.html): state survives gateway replicas and cluster nodes, deploys are declarative, and everything is observable. Point the OpenAI SDK at it and your agent runs unchanged — private, with no per-token bill.
+Modelship runs the AI stack your agents call — chat, the **Responses API** with server-side conversation state (durable with Redis), universal **tool calling**, and **reasoning**, alongside embeddings, speech, and image generation — behind one OpenAI-compatible endpoint on your own GPUs (or CPU). Built on [Ray Serve](https://docs.ray.io/en/latest/serve/index.html): state is shared across gateway replicas, deploys are declarative, and everything is observable. Point the OpenAI SDK at it and your agent runs unchanged — private, with no per-token bill.
 
 ## Why Modelship?
 
-- **Agent state that survives production** — the `/v1/responses` API with reasoning, universal tool/function calling, and server-side conversation state (`previous_response_id`) live in a pluggable store (in-memory by default, or Redis), shared across every gateway replica and cluster node — not just kept in-process. Works across both the vLLM and llama.cpp (`llama_server`) loaders.
+- **Agent state that isn't siloed per replica** — the `/v1/responses` API with reasoning, universal tool/function calling, and server-side conversation state (`previous_response_id`) live in one pluggable store shared by every gateway replica — in-memory by default, or Redis for durability across restarts and node failure. Works across both the vLLM and llama.cpp (`llama_server`) loaders.
 - **Everything an agent app calls, one endpoint** — chat, embeddings for RAG, speech-to-text, text-to-speech, and image generation, all behind a single OpenAI-compatible `/v1` surface. No juggling separate services for each modality.
 - **Drop-in OpenAI, on your hardware** — any OpenAI SDK client works out of the box. Point it at Modelship instead of the OpenAI API and your agent code doesn't change — it just runs privately, on infrastructure you control.
 - **GPU memory control** — allocate exact GPU fractions per model (e.g. 70% for the LLM, 5% for TTS) so a full stack fits on hardware you already own

--- a/README.md
+++ b/README.md
@@ -12,52 +12,23 @@
 [![License: Apache 2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 [![Python 3.12+](https://img.shields.io/badge/python-3.12+-blue.svg)](https://www.python.org/downloads/)
 
-Self-hosted, OpenAI-compatible inference for the agentic era. Modelship runs your whole AI stack — reasoning LLMs with universal tool calling and the Responses API, plus embeddings, speech-to-text, text-to-speech, and image generation — as many models sharing your GPUs (or CPU) behind a single gateway. Built on [Ray Serve](https://docs.ray.io/en/latest/serve/index.html) with pluggable inference backends: [vLLM](https://github.com/vllm-project/vllm) for high-throughput GPU or CPU inference, [llama.cpp](https://github.com/ggml-org/llama.cpp) for high-efficiency GGUF models on CPU or GPU, [Diffusers](https://github.com/huggingface/diffusers) for image generation, and a plugin system for custom backends.
+Modelship runs the AI stack your agents call — chat, the **Responses API** with durable server-side conversation state, universal **tool calling**, and **reasoning**, alongside embeddings, speech, and image generation — behind one OpenAI-compatible endpoint on your own GPUs (or CPU). Built on [Ray Serve](https://docs.ray.io/en/latest/serve/index.html): state survives gateway replicas and cluster nodes, deploys are declarative, and everything is observable. Point the OpenAI SDK at it and your agent runs unchanged — private, with no per-token bill.
 
 ## Why Modelship?
 
-Most self-hosted inference tools focus on running a single model. Modelship is for when you need **multiple models running simultaneously** — an LLM, a TTS engine, a speech-to-text model, an embedding model, and an image generator — all behind a single OpenAI-compatible API, with fine-grained control over GPU memory allocation across them.
-
-- **One server, many models** — run a full AI stack (chat + TTS + STT + embeddings + image gen) on a single machine instead of juggling separate services
-- **GPU memory control** — allocate exact GPU fractions per model (e.g. 70% for the LLM, 5% for TTS) so everything fits on your hardware
-- **Mix and match backends** — use vLLM for high-throughput GPU inference, vLLM or llama.cpp for CPU-only workloads, Diffusers for images, and plugins for custom backends — in the same deployment
-- **Agentic-ready** — reasoning (`<think>` → `reasoning_content`), universal tool/function calling, and the `/v1/responses` API — including server-side conversation state (`previous_response_id`), shared across every gateway replica — work across the vLLM and llama.cpp (`llama_server`) loaders, the OpenAI-spec surface agents already target
-- **Drop-in OpenAI replacement** — any OpenAI SDK client works out of the box, making it easy to integrate with existing apps and tools
+- **Agent state that survives production** — the `/v1/responses` API with reasoning, universal tool/function calling, and server-side conversation state (`previous_response_id`) live in a pluggable store (in-memory by default, or Redis), shared across every gateway replica and cluster node — not just kept in-process. Works across both the vLLM and llama.cpp (`llama_server`) loaders.
+- **Everything an agent app calls, one endpoint** — chat, embeddings for RAG, speech-to-text, text-to-speech, and image generation, all behind a single OpenAI-compatible `/v1` surface. No juggling separate services for each modality.
+- **Drop-in OpenAI, on your hardware** — any OpenAI SDK client works out of the box. Point it at Modelship instead of the OpenAI API and your agent code doesn't change — it just runs privately, on infrastructure you control.
+- **GPU memory control** — allocate exact GPU fractions per model (e.g. 70% for the LLM, 5% for TTS) so a full stack fits on hardware you already own
+- **Mix and match backends** — vLLM for high-throughput GPU or CPU inference, llama.cpp for efficient quantized GGUF models, Diffusers for images, and a plugin system for custom backends — in the same deployment
 
 ## Architecture
 
-```mermaid
-graph TD
-    Client["Client (OpenAI SDK / curl)"]
-    API["FastAPI Gateway<br/>OpenAI-compatible API<br/>:8000"]
-
-    Client -->|HTTP| API
-    API -->|round-robin| LLM_GPU
-    API -->|round-robin| LLM_CPU
-    API -->|round-robin| TTS
-    API -->|round-robin| STT
-    API -->|round-robin| EMB
-    API -->|round-robin| IMG
-
-    subgraph GPU0["GPU 0 — vLLM"]
-        LLM_GPU["LLM Deployment<br/>e.g. Llama 3.1 8B<br/>70% GPU"]
-        TTS["TTS Deployment<br/>e.g. Kokoro 82M<br/>5% GPU"]
-    end
-
-    subgraph GPU1["GPU 1 — Mixed backends"]
-        STT["STT Deployment (vLLM)<br/>e.g. Whisper Large<br/>50% GPU"]
-        EMB["Embedding Deployment<br/>e.g. Nomic Embed<br/>50% GPU"]
-    end
-
-    subgraph CPU["CPU — vLLM / llama-server"]
-        LLM_CPU["LLM Deployment<br/>e.g. Qwen3-0.6B<br/>CPU-only"]
-        STT_CPU["STT Deployment<br/>e.g. Whisper Small<br/>CPU-only"]
-    end
-
-    subgraph GPU2["GPU 2 — Diffusers"]
-        IMG["Image Generation<br/>e.g. SDXL Turbo<br/>35% GPU"]
-    end
-```
+<picture>
+  <source media="(prefers-color-scheme: dark)" srcset="docs/assets/architecture-dark.svg">
+  <source media="(prefers-color-scheme: light)" srcset="docs/assets/architecture-light.svg">
+  <img alt="Modelship architecture: an agent app calls the Modelship gateway's OpenAI-compatible API, which exposes chat, embeddings, audio, and image endpoints plus a Responses API backed by a shared conversation-state store, routing round-robin to Ray Serve deployments across GPU and CPU cluster nodes." src="docs/assets/architecture-light.svg">
+</picture>
 
 Each model runs as an isolated [Ray Serve](https://docs.ray.io/en/latest/serve/index.html) deployment with its own lifecycle, health checks, and resource budget. Four inference backends are available:
 
@@ -69,7 +40,6 @@ Each model runs as an isolated [Ray Serve](https://docs.ray.io/en/latest/serve/i
 | **Custom (plugins)** | TTS backends (Kokoro ONNX, Orpheus), STT backends (whisper.cpp) | No |
 
 Models can be deployed across multiple GPUs, run on CPU-only, or both — multiple deployments of the same model (e.g. one on GPU via vLLM, one on CPU via vLLM or llama.cpp) are load-balanced with round-robin routing. Each deployment can also scale horizontally with `num_replicas`.
-...
 
 ## Requirements
 
@@ -91,6 +61,7 @@ Models can be deployed across multiple GPUs, run on CPU-only, or both — multip
 - **Plugin system** — opt-in TTS and STT backends installed as isolated uv workspace packages
 - **Multi-GPU & hybrid routing** — assign models to specific GPUs or run them on CPU-only; deploy the same model on both GPU and CPU and requests are load-balanced via round-robin; full tensor parallelism support for large models spanning multiple GPUs
 - **Client disconnect detection** — cancels in-flight inference when the client disconnects, freeing GPU resources immediately
+- **Security** — gateway API-key authentication (`MSHIP_API_KEYS`), Ray cluster token auth (`--ray-auth=token`), and configurable request payload/concurrency limits
 - **Built-in observability** — Prometheus metrics, custom `modelship:*` metrics, vLLM engine stats, Ray cluster metrics, structured JSON logging, and OpenTelemetry log export; pre-built Grafana dashboard and alerting rules included
 
 ## Supported OpenAI Endpoints
@@ -132,16 +103,18 @@ docker run --rm --shm-size=8g \
 
 Images are multi-arch (amd64 + arm64), so this works on Apple Silicon and ARM Linux hosts too.
 
-Once the server is up (look for `Deployed app 'modelship api' successfully`), call it and watch the model think:
+Once the server is up (look for `Deployed app 'modelship api' successfully`), call the **Responses API** and watch the model think:
 
 ```bash
-curl http://localhost:8000/v1/chat/completions \
+curl http://localhost:8000/v1/responses \
   -H "Content-Type: application/json" \
   -d '{
     "model": "reasoning-qwen",
-    "messages": [{"role": "user", "content": "Which is larger, 9.11 or 9.9?"}]
+    "input": "Which is larger, 9.11 or 9.9?"
   }'
 ```
+
+The response includes both `output_text` and a first-class `reasoning` output item — the same server-side conversation state (`previous_response_id`) and tool-calling support work here as they do on GPU-backed models. `/v1/chat/completions` remains available too, if that's what your client speaks.
 
 ### GPU (vLLM, Diffusers)
 
@@ -209,8 +182,8 @@ Modelship is actively used and designed for stability in multi-tenant setups. Ke
 
 - **Mutex-backed deployments:** A cluster-wide deploy coordinator prevents VRAM exhaustion by ensuring models are never loaded concurrently if resources are tight.
 - **Comprehensive HTTP-level tests:** The `tests/test_integration.py` suite validates chat, reasoning, tool-calling, and streaming across all loaders using real (small) models.
-- **Payload & concurrency limits:** Built-in safeguards against large payloads (`MSHIP_MAX_REQUEST_BODY_BYTES`) and configurable limits per backend.
-- **Observability:** Deep integration with Prometheus, OpenTelemetry, and structured logging.
+- **Security:** Gateway API-key auth, opt-in Ray cluster token auth, and payload/concurrency limits (`MSHIP_MAX_REQUEST_BODY_BYTES`) guard against unauthenticated or oversized requests.
+- **Observability:** Deep integration with Prometheus, OpenTelemetry, and structured logging, with a pre-built Grafana dashboard and Prometheus alerting rules included.
 
 We are currently hardening the Kubernetes/KubeRay path (a Helm chart ships in [`helm/`](helm/modelship/); GPU-aware probes and gateway-level rate-limiting are next). See the full [Production Readiness Plan](docs/production-readiness.md) for the scorecard and roadmap.
 

--- a/docs/CNAME
+++ b/docs/CNAME
@@ -1,1 +1,1 @@
-model-ship.ai
+docs.model-ship.ai

--- a/docs/CNAME
+++ b/docs/CNAME
@@ -1,0 +1,1 @@
+model-ship.ai

--- a/docs/assets/architecture-dark.svg
+++ b/docs/assets/architecture-dark.svg
@@ -1,0 +1,111 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1180 620" width="1180" height="620" role="img" aria-label="Modelship architecture diagram" font-family="Helvetica, Arial, sans-serif">
+  <title>Modelship architecture</title>
+  <desc>An agent app calls the Modelship gateway's OpenAI-compatible API. The gateway exposes chat, embeddings, audio, and image endpoints plus a highlighted Responses API with reasoning, tool calling, and streaming, backed by a shared conversation-state store and gateway/cluster auth. Requests are routed round-robin to Ray Serve deployments running across multiple cluster nodes on GPU or CPU.</desc>
+  <defs>
+    <marker id="arrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M0,0 L10,5 L0,10 z" fill="#EAF0F7"/>
+    </marker>
+    <marker id="arrow-accent" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M0,0 L10,5 L0,10 z" fill="#4FD3DE"/>
+    </marker>
+  </defs>
+
+  <!-- Client -->
+  <rect x="20" y="260" width="170" height="100" rx="10" fill="none" stroke="#EAF0F7" stroke-width="2"/>
+  <text x="105" y="302" text-anchor="middle" font-size="18" font-weight="700" fill="#EAF0F7">Agent App</text>
+  <text x="105" y="326" text-anchor="middle" font-size="12" fill="#9FB3C8">OpenAI SDK / curl</text>
+
+  <!-- Arrow client -> gateway -->
+  <line x1="190" y1="310" x2="250" y2="310" stroke="#EAF0F7" stroke-width="2" marker-end="url(#arrow)"/>
+  <text x="220" y="300" text-anchor="middle" font-size="11" fill="#9FB3C8">HTTP</text>
+
+  <!-- Gateway outer -->
+  <rect x="255" y="40" width="440" height="380" rx="14" fill="none" stroke="#EAF0F7" stroke-width="2"/>
+  <text x="475" y="72" text-anchor="middle" font-size="21" font-weight="700" fill="#EAF0F7">Modelship Gateway</text>
+  <text x="475" y="92" text-anchor="middle" font-size="12" fill="#9FB3C8">:8000 · OpenAI-compatible /v1</text>
+
+  <!-- Endpoint chips -->
+  <rect x="275" y="112" width="195" height="32" rx="6" fill="none" stroke="#9FB3C8" stroke-width="1.5"/>
+  <text x="372" y="132" text-anchor="middle" font-size="12.5" fill="#EAF0F7">/v1/chat/completions</text>
+
+  <rect x="275" y="150" width="195" height="32" rx="6" fill="none" stroke="#9FB3C8" stroke-width="1.5"/>
+  <text x="372" y="170" text-anchor="middle" font-size="12.5" fill="#EAF0F7">/v1/embeddings</text>
+
+  <rect x="275" y="188" width="195" height="32" rx="6" fill="none" stroke="#9FB3C8" stroke-width="1.5"/>
+  <text x="372" y="208" text-anchor="middle" font-size="12.5" fill="#EAF0F7">/v1/audio/*</text>
+
+  <rect x="275" y="226" width="195" height="32" rx="6" fill="none" stroke="#9FB3C8" stroke-width="1.5"/>
+  <text x="372" y="246" text-anchor="middle" font-size="12.5" fill="#EAF0F7">/v1/images/*</text>
+
+  <!-- Responses highlight -->
+  <rect x="480" y="112" width="195" height="146" rx="8" fill="#4FD3DE" fill-opacity="0.12" stroke="#4FD3DE" stroke-width="2.5"/>
+  <text x="577" y="136" text-anchor="middle" font-size="14.5" font-weight="700" fill="#4FD3DE">/v1/responses</text>
+  <text x="498" y="160" font-size="12.5" fill="#EAF0F7">• reasoning</text>
+  <text x="498" y="182" font-size="12.5" fill="#EAF0F7">• tool calling</text>
+  <text x="498" y="204" font-size="12.5" fill="#EAF0F7">• stored state</text>
+  <text x="498" y="226" font-size="12.5" fill="#EAF0F7">• streaming</text>
+
+  <!-- connector responses -> state -->
+  <line x1="577" y1="258" x2="577" y2="270" stroke="#4FD3DE" stroke-width="2" marker-end="url(#arrow-accent)"/>
+
+  <!-- Conversation state -->
+  <rect x="275" y="272" width="400" height="64" rx="8" fill="none" stroke="#EAF0F7" stroke-width="1.75" stroke-dasharray="5 4"/>
+  <text x="475" y="296" text-anchor="middle" font-size="14" font-weight="600" fill="#EAF0F7">Conversation State</text>
+  <text x="475" y="316" text-anchor="middle" font-size="10.5" fill="#9FB3C8">Ray actor or Redis — shared across replicas &amp; nodes</text>
+
+  <!-- Auth row -->
+  <rect x="275" y="352" width="195" height="34" rx="6" fill="none" stroke="#9FB3C8" stroke-width="1.5"/>
+  <text x="372" y="373" text-anchor="middle" font-size="12" fill="#EAF0F7">API-key auth</text>
+
+  <rect x="480" y="352" width="195" height="34" rx="6" fill="none" stroke="#9FB3C8" stroke-width="1.5"/>
+  <text x="577" y="373" text-anchor="middle" font-size="12" fill="#EAF0F7">Cluster token auth</text>
+
+  <!-- Arrows gateway -> nodes -->
+  <line x1="695" y1="170" x2="758" y2="140" stroke="#EAF0F7" stroke-width="2" marker-end="url(#arrow)"/>
+  <line x1="695" y1="380" x2="758" y2="410" stroke="#EAF0F7" stroke-width="2" marker-end="url(#arrow)"/>
+  <text x="718" y="270" text-anchor="middle" font-size="11" fill="#9FB3C8">round-robin</text>
+
+  <!-- Node A -->
+  <rect x="760" y="40" width="380" height="230" rx="12" fill="none" stroke="#EAF0F7" stroke-width="2"/>
+  <text x="950" y="68" text-anchor="middle" font-size="16" font-weight="700" fill="#EAF0F7">Node · GPU</text>
+  <text x="950" y="86" text-anchor="middle" font-size="11" fill="#9FB3C8">Ray Serve deployments</text>
+
+  <rect x="780" y="100" width="165" height="60" rx="6" fill="none" stroke="#9FB3C8" stroke-width="1.5"/>
+  <text x="862" y="124" text-anchor="middle" font-size="12.5" fill="#EAF0F7">LLM · vLLM</text>
+  <text x="862" y="144" text-anchor="middle" font-size="11" fill="#9FB3C8">70% GPU</text>
+
+  <rect x="955" y="100" width="165" height="60" rx="6" fill="none" stroke="#9FB3C8" stroke-width="1.5"/>
+  <text x="1037" y="124" text-anchor="middle" font-size="12.5" fill="#EAF0F7">TTS</text>
+  <text x="1037" y="144" text-anchor="middle" font-size="11" fill="#9FB3C8">5% GPU</text>
+
+  <rect x="780" y="170" width="165" height="60" rx="6" fill="none" stroke="#9FB3C8" stroke-width="1.5"/>
+  <text x="862" y="194" text-anchor="middle" font-size="12.5" fill="#EAF0F7">Embeddings</text>
+  <text x="862" y="214" text-anchor="middle" font-size="11" fill="#9FB3C8">vLLM</text>
+
+  <rect x="955" y="170" width="165" height="60" rx="6" fill="none" stroke="#9FB3C8" stroke-width="1.5"/>
+  <text x="1037" y="194" text-anchor="middle" font-size="12.5" fill="#EAF0F7">STT</text>
+  <text x="1037" y="214" text-anchor="middle" font-size="11" fill="#9FB3C8">llama.cpp</text>
+
+  <!-- Node B -->
+  <rect x="760" y="300" width="380" height="230" rx="12" fill="none" stroke="#EAF0F7" stroke-width="2"/>
+  <text x="950" y="328" text-anchor="middle" font-size="16" font-weight="700" fill="#EAF0F7">Node · CPU (or GPU)</text>
+  <text x="950" y="346" text-anchor="middle" font-size="11" fill="#9FB3C8">Ray Serve deployments</text>
+
+  <rect x="780" y="360" width="165" height="60" rx="6" fill="none" stroke="#9FB3C8" stroke-width="1.5"/>
+  <text x="862" y="384" text-anchor="middle" font-size="12.5" fill="#EAF0F7">LLM · llama.cpp</text>
+  <text x="862" y="404" text-anchor="middle" font-size="11" fill="#9FB3C8">CPU-only</text>
+
+  <rect x="955" y="360" width="165" height="60" rx="6" fill="none" stroke="#9FB3C8" stroke-width="1.5"/>
+  <text x="1037" y="384" text-anchor="middle" font-size="12.5" fill="#EAF0F7">Image gen</text>
+  <text x="1037" y="404" text-anchor="middle" font-size="11" fill="#9FB3C8">Diffusers</text>
+
+  <rect x="780" y="430" width="165" height="60" rx="6" fill="none" stroke="#9FB3C8" stroke-width="1.5"/>
+  <text x="862" y="454" text-anchor="middle" font-size="12.5" fill="#EAF0F7">Embeddings</text>
+  <text x="862" y="474" text-anchor="middle" font-size="11" fill="#9FB3C8">CPU</text>
+
+  <rect x="955" y="430" width="165" height="60" rx="6" fill="none" stroke="#9FB3C8" stroke-width="1.5" stroke-dasharray="4 3"/>
+  <text x="1037" y="464" text-anchor="middle" font-size="12" fill="#9FB3C8">+ more nodes…</text>
+
+  <!-- caption -->
+  <text x="600" y="580" text-anchor="middle" font-size="13" fill="#9FB3C8">One gateway. One state store. Any number of Ray Serve nodes — GPU or CPU.</text>
+</svg>

--- a/docs/assets/architecture-dark.svg
+++ b/docs/assets/architecture-dark.svg
@@ -107,5 +107,5 @@
   <text x="1037" y="464" text-anchor="middle" font-size="12" fill="#9FB3C8">+ more nodes…</text>
 
   <!-- caption -->
-  <text x="600" y="580" text-anchor="middle" font-size="13" fill="#9FB3C8">One gateway. One state store. Any number of Ray Serve nodes — GPU or CPU.</text>
+  <text x="600" y="580" text-anchor="middle" font-size="13" fill="#9FB3C8">One API, horizontally scalable. Shared state, not siloed per replica. Any number of nodes — GPU or CPU.</text>
 </svg>

--- a/docs/assets/architecture-light.svg
+++ b/docs/assets/architecture-light.svg
@@ -1,0 +1,111 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1180 620" width="1180" height="620" role="img" aria-label="Modelship architecture diagram" font-family="Helvetica, Arial, sans-serif">
+  <title>Modelship architecture</title>
+  <desc>An agent app calls the Modelship gateway's OpenAI-compatible API. The gateway exposes chat, embeddings, audio, and image endpoints plus a highlighted Responses API with reasoning, tool calling, and streaming, backed by a shared conversation-state store and gateway/cluster auth. Requests are routed round-robin to Ray Serve deployments running across multiple cluster nodes on GPU or CPU.</desc>
+  <defs>
+    <marker id="arrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M0,0 L10,5 L0,10 z" fill="#0B2545"/>
+    </marker>
+    <marker id="arrow-accent" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M0,0 L10,5 L0,10 z" fill="#0E7C86"/>
+    </marker>
+  </defs>
+
+  <!-- Client -->
+  <rect x="20" y="260" width="170" height="100" rx="10" fill="none" stroke="#0B2545" stroke-width="2"/>
+  <text x="105" y="302" text-anchor="middle" font-size="18" font-weight="700" fill="#0B2545">Agent App</text>
+  <text x="105" y="326" text-anchor="middle" font-size="12" fill="#4A6B8A">OpenAI SDK / curl</text>
+
+  <!-- Arrow client -> gateway -->
+  <line x1="190" y1="310" x2="250" y2="310" stroke="#0B2545" stroke-width="2" marker-end="url(#arrow)"/>
+  <text x="220" y="300" text-anchor="middle" font-size="11" fill="#4A6B8A">HTTP</text>
+
+  <!-- Gateway outer -->
+  <rect x="255" y="40" width="440" height="380" rx="14" fill="none" stroke="#0B2545" stroke-width="2"/>
+  <text x="475" y="72" text-anchor="middle" font-size="21" font-weight="700" fill="#0B2545">Modelship Gateway</text>
+  <text x="475" y="92" text-anchor="middle" font-size="12" fill="#4A6B8A">:8000 · OpenAI-compatible /v1</text>
+
+  <!-- Endpoint chips -->
+  <rect x="275" y="112" width="195" height="32" rx="6" fill="none" stroke="#4A6B8A" stroke-width="1.5"/>
+  <text x="372" y="132" text-anchor="middle" font-size="12.5" fill="#0B2545">/v1/chat/completions</text>
+
+  <rect x="275" y="150" width="195" height="32" rx="6" fill="none" stroke="#4A6B8A" stroke-width="1.5"/>
+  <text x="372" y="170" text-anchor="middle" font-size="12.5" fill="#0B2545">/v1/embeddings</text>
+
+  <rect x="275" y="188" width="195" height="32" rx="6" fill="none" stroke="#4A6B8A" stroke-width="1.5"/>
+  <text x="372" y="208" text-anchor="middle" font-size="12.5" fill="#0B2545">/v1/audio/*</text>
+
+  <rect x="275" y="226" width="195" height="32" rx="6" fill="none" stroke="#4A6B8A" stroke-width="1.5"/>
+  <text x="372" y="246" text-anchor="middle" font-size="12.5" fill="#0B2545">/v1/images/*</text>
+
+  <!-- Responses highlight -->
+  <rect x="480" y="112" width="195" height="146" rx="8" fill="#0E7C86" fill-opacity="0.07" stroke="#0E7C86" stroke-width="2.5"/>
+  <text x="577" y="136" text-anchor="middle" font-size="14.5" font-weight="700" fill="#0E7C86">/v1/responses</text>
+  <text x="498" y="160" font-size="12.5" fill="#0B2545">• reasoning</text>
+  <text x="498" y="182" font-size="12.5" fill="#0B2545">• tool calling</text>
+  <text x="498" y="204" font-size="12.5" fill="#0B2545">• stored state</text>
+  <text x="498" y="226" font-size="12.5" fill="#0B2545">• streaming</text>
+
+  <!-- connector responses -> state -->
+  <line x1="577" y1="258" x2="577" y2="270" stroke="#0E7C86" stroke-width="2" marker-end="url(#arrow-accent)"/>
+
+  <!-- Conversation state -->
+  <rect x="275" y="272" width="400" height="64" rx="8" fill="none" stroke="#0B2545" stroke-width="1.75" stroke-dasharray="5 4"/>
+  <text x="475" y="296" text-anchor="middle" font-size="14" font-weight="600" fill="#0B2545">Conversation State</text>
+  <text x="475" y="316" text-anchor="middle" font-size="10.5" fill="#4A6B8A">Ray actor or Redis — shared across replicas &amp; nodes</text>
+
+  <!-- Auth row -->
+  <rect x="275" y="352" width="195" height="34" rx="6" fill="none" stroke="#4A6B8A" stroke-width="1.5"/>
+  <text x="372" y="373" text-anchor="middle" font-size="12" fill="#0B2545">API-key auth</text>
+
+  <rect x="480" y="352" width="195" height="34" rx="6" fill="none" stroke="#4A6B8A" stroke-width="1.5"/>
+  <text x="577" y="373" text-anchor="middle" font-size="12" fill="#0B2545">Cluster token auth</text>
+
+  <!-- Arrows gateway -> nodes -->
+  <line x1="695" y1="170" x2="758" y2="140" stroke="#0B2545" stroke-width="2" marker-end="url(#arrow)"/>
+  <line x1="695" y1="380" x2="758" y2="410" stroke="#0B2545" stroke-width="2" marker-end="url(#arrow)"/>
+  <text x="718" y="270" text-anchor="middle" font-size="11" fill="#4A6B8A">round-robin</text>
+
+  <!-- Node A -->
+  <rect x="760" y="40" width="380" height="230" rx="12" fill="none" stroke="#0B2545" stroke-width="2"/>
+  <text x="950" y="68" text-anchor="middle" font-size="16" font-weight="700" fill="#0B2545">Node · GPU</text>
+  <text x="950" y="86" text-anchor="middle" font-size="11" fill="#4A6B8A">Ray Serve deployments</text>
+
+  <rect x="780" y="100" width="165" height="60" rx="6" fill="none" stroke="#4A6B8A" stroke-width="1.5"/>
+  <text x="862" y="124" text-anchor="middle" font-size="12.5" fill="#0B2545">LLM · vLLM</text>
+  <text x="862" y="144" text-anchor="middle" font-size="11" fill="#4A6B8A">70% GPU</text>
+
+  <rect x="955" y="100" width="165" height="60" rx="6" fill="none" stroke="#4A6B8A" stroke-width="1.5"/>
+  <text x="1037" y="124" text-anchor="middle" font-size="12.5" fill="#0B2545">TTS</text>
+  <text x="1037" y="144" text-anchor="middle" font-size="11" fill="#4A6B8A">5% GPU</text>
+
+  <rect x="780" y="170" width="165" height="60" rx="6" fill="none" stroke="#4A6B8A" stroke-width="1.5"/>
+  <text x="862" y="194" text-anchor="middle" font-size="12.5" fill="#0B2545">Embeddings</text>
+  <text x="862" y="214" text-anchor="middle" font-size="11" fill="#4A6B8A">vLLM</text>
+
+  <rect x="955" y="170" width="165" height="60" rx="6" fill="none" stroke="#4A6B8A" stroke-width="1.5"/>
+  <text x="1037" y="194" text-anchor="middle" font-size="12.5" fill="#0B2545">STT</text>
+  <text x="1037" y="214" text-anchor="middle" font-size="11" fill="#4A6B8A">llama.cpp</text>
+
+  <!-- Node B -->
+  <rect x="760" y="300" width="380" height="230" rx="12" fill="none" stroke="#0B2545" stroke-width="2"/>
+  <text x="950" y="328" text-anchor="middle" font-size="16" font-weight="700" fill="#0B2545">Node · CPU (or GPU)</text>
+  <text x="950" y="346" text-anchor="middle" font-size="11" fill="#4A6B8A">Ray Serve deployments</text>
+
+  <rect x="780" y="360" width="165" height="60" rx="6" fill="none" stroke="#4A6B8A" stroke-width="1.5"/>
+  <text x="862" y="384" text-anchor="middle" font-size="12.5" fill="#0B2545">LLM · llama.cpp</text>
+  <text x="862" y="404" text-anchor="middle" font-size="11" fill="#4A6B8A">CPU-only</text>
+
+  <rect x="955" y="360" width="165" height="60" rx="6" fill="none" stroke="#4A6B8A" stroke-width="1.5"/>
+  <text x="1037" y="384" text-anchor="middle" font-size="12.5" fill="#0B2545">Image gen</text>
+  <text x="1037" y="404" text-anchor="middle" font-size="11" fill="#4A6B8A">Diffusers</text>
+
+  <rect x="780" y="430" width="165" height="60" rx="6" fill="none" stroke="#4A6B8A" stroke-width="1.5"/>
+  <text x="862" y="454" text-anchor="middle" font-size="12.5" fill="#0B2545">Embeddings</text>
+  <text x="862" y="474" text-anchor="middle" font-size="11" fill="#4A6B8A">CPU</text>
+
+  <rect x="955" y="430" width="165" height="60" rx="6" fill="none" stroke="#4A6B8A" stroke-width="1.5" stroke-dasharray="4 3"/>
+  <text x="1037" y="464" text-anchor="middle" font-size="12" fill="#4A6B8A">+ more nodes…</text>
+
+  <!-- caption -->
+  <text x="600" y="580" text-anchor="middle" font-size="13" fill="#4A6B8A">One gateway. One state store. Any number of Ray Serve nodes — GPU or CPU.</text>
+</svg>

--- a/docs/assets/architecture-light.svg
+++ b/docs/assets/architecture-light.svg
@@ -107,5 +107,5 @@
   <text x="1037" y="464" text-anchor="middle" font-size="12" fill="#4A6B8A">+ more nodes…</text>
 
   <!-- caption -->
-  <text x="600" y="580" text-anchor="middle" font-size="13" fill="#4A6B8A">One gateway. One state store. Any number of Ray Serve nodes — GPU or CPU.</text>
+  <text x="600" y="580" text-anchor="middle" font-size="13" fill="#4A6B8A">One API, horizontally scalable. Shared state, not siloed per replica. Any number of nodes — GPU or CPU.</text>
 </svg>

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,82 @@
+# Modelship
+
+Modelship runs the AI stack your agents call — chat, the **Responses API** with
+server-side conversation state (durable with Redis), universal **tool calling**,
+and **reasoning**, alongside embeddings, speech, and image generation — behind
+one OpenAI-compatible endpoint on your own GPUs (or CPU).
+
+Built on [Ray Serve](https://docs.ray.io/en/latest/serve/index.html): state is
+shared across gateway replicas, deploys are declarative, and everything is
+observable. Point the OpenAI SDK at it and your agent runs unchanged — private,
+with no per-token bill.
+
+[Get started :material-arrow-right:](quickstart.md){ .md-button .md-button--primary }
+[View on GitHub :fontawesome-brands-github:](https://github.com/alez007/modelship){ .md-button }
+
+## Why Modelship?
+
+- **Agent state that isn't siloed per replica** — the `/v1/responses` API with
+  reasoning, universal tool/function calling, and server-side conversation
+  state (`previous_response_id`) live in one pluggable store shared by every
+  gateway replica — in-memory by default, or Redis for durability across
+  restarts and node failure. Works across both the vLLM and llama.cpp
+  (`llama_server`) loaders.
+- **Everything an agent app calls, one endpoint** — chat, embeddings for RAG,
+  speech-to-text, text-to-speech, and image generation, all behind a single
+  OpenAI-compatible `/v1` surface. No juggling separate services for each
+  modality.
+- **Drop-in OpenAI, on your hardware** — any OpenAI SDK client works out of
+  the box. Point it at Modelship instead of the OpenAI API and your agent
+  code doesn't change — it just runs privately, on infrastructure you
+  control.
+- **GPU memory control** — allocate exact GPU fractions per model (e.g. 70%
+  for the LLM, 5% for TTS) so a full stack fits on hardware you already own.
+- **Mix and match backends** — vLLM for high-throughput GPU or CPU inference,
+  llama.cpp for efficient quantized GGUF models, Diffusers for images, and a
+  plugin system for custom backends — in the same deployment.
+
+## Architecture
+
+<picture>
+  <source media="(prefers-color-scheme: dark)" srcset="assets/architecture-dark.svg">
+  <source media="(prefers-color-scheme: light)" srcset="assets/architecture-light.svg">
+  <img alt="Modelship architecture: an agent app calls the Modelship gateway's OpenAI-compatible API, which exposes chat, embeddings, audio, and image endpoints plus a Responses API backed by a shared conversation-state store, routing round-robin to Ray Serve deployments across GPU and CPU cluster nodes." src="assets/architecture-light.svg">
+</picture>
+
+Each model runs as an isolated [Ray Serve](https://docs.ray.io/en/latest/serve/index.html)
+deployment with its own lifecycle, health checks, and resource budget.
+
+| Backend | Best for | GPU required |
+|---|---|---|
+| **vLLM** | High-throughput chat, embeddings, transcription | No — installs on GPU or CPU |
+| **llama.cpp** (`llama_server`) | High-efficiency quantized GGUF models (chat, embeddings, vision) | No |
+| **Diffusers** | Image generation | Yes |
+| **Custom (plugins)** | TTS backends (Kokoro ONNX, Orpheus), STT backends (whisper.cpp) | No |
+
+Models can be deployed across multiple GPUs, run on CPU-only, or both —
+multiple deployments of the same model (e.g. one on GPU via vLLM, one on CPU
+via vLLM or llama.cpp) are load-balanced with round-robin routing. Each
+deployment can also scale horizontally with `num_replicas`, and the gateway
+itself scales with `--gateway-replicas`. See [Architecture](architecture.md)
+for the full request lifecycle and design.
+
+## Supported OpenAI Endpoints
+
+| Endpoint | Usecase |
+|---|---|
+| `POST /v1/chat/completions` | Chat / text generation (streaming and non-streaming) |
+| `POST /v1/responses` | Responses API — text, reasoning, client-driven tool calls, and stored conversations (streaming and non-streaming) |
+| `GET`/`DELETE /v1/responses/{id}` | Fetch or drop a stored response (`/input_items` lists its input) |
+| `POST /v1/embeddings` | Text embeddings |
+| `POST /v1/audio/transcriptions` | Speech-to-text |
+| `POST /v1/audio/translations` | Audio translation |
+| `POST /v1/audio/speech` | Text-to-speech (SSE streaming or single-response) |
+| `POST /v1/images/generations` | Image generation |
+| `GET /v1/models` | List available models |
+
+## Next steps
+
+- [Quickstart](quickstart.md) — a tiny reasoning model running in a few minutes, no GPU required
+- [Installation](installation.md) — requirements, image variants, and running with a GPU
+- [Model Configuration](model-configuration.md) — the full `models.yaml` reference
+- [Integrations](integrations/index.md) — connecting the OpenAI SDK, Open WebUI, Dify, n8n, and Responses-speaking agents

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -2,7 +2,8 @@
 
 ## Requirements
 
-- **Docker** (or Python 3.12+ with `uv` for local development)
+- **Docker** (or Python 3.12.10 with `uv` for local development — `uv` fetches this
+  exact version automatically, matching the repo's pinned `requires-python`)
 - **NVIDIA GPU** (optional) — 16 GB+ VRAM recommended for a full stack (LLM +
   TTS + STT + embeddings) via vLLM; 8 GB is sufficient for lighter setups.
   Not required when using the vLLM or llama.cpp backends on CPU
@@ -19,7 +20,7 @@ Three images are published from a single `Dockerfile`, all under
 |---|---|---|---|
 | Thin | *(none)* — bare tag | amd64, arm64 | Control/coordinator image, no torch/vllm. Runs the driver/head role only — cannot serve models by itself |
 | CUDA | `-cuda` | amd64 | GPU node image (vLLM, Diffusers, llama.cpp GPU offload) |
-| CPU | `-cpu` | amd64, arm64 | CPU node image (vLLM CPU backend, llama.cpp, Diffusers CPU) |
+| CPU | `-cpu` | amd64, arm64 | CPU node image (vLLM CPU backend, llama.cpp, stable_diffusion_cpp) |
 
 Floating tags (`:latest`, `:latest-cuda`, `:latest-cpu`) are single-node
 only — multi-node deployments must pin every node to the same `X.Y.Z`

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,0 +1,71 @@
+# Installation
+
+## Requirements
+
+- **Docker** (or Python 3.12+ with `uv` for local development)
+- **NVIDIA GPU** (optional) — 16 GB+ VRAM recommended for a full stack (LLM +
+  TTS + STT + embeddings) via vLLM; 8 GB is sufficient for lighter setups.
+  Not required when using the vLLM or llama.cpp backends on CPU
+- **[NVIDIA Container Toolkit](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/install-guide.html)**
+  — required only when running GPU models in Docker
+- **HuggingFace token** for gated models
+
+## Image variants
+
+Three images are published from a single `Dockerfile`, all under
+`ghcr.io/alez007/modelship`:
+
+| Variant | Tag suffix | Platforms | Purpose |
+|---|---|---|---|
+| Thin | *(none)* — bare tag | amd64, arm64 | Control/coordinator image, no torch/vllm. Runs the driver/head role only — cannot serve models by itself |
+| CUDA | `-cuda` | amd64 | GPU node image (vLLM, Diffusers, llama.cpp GPU offload) |
+| CPU | `-cpu` | amd64, arm64 | CPU node image (vLLM CPU backend, llama.cpp, Diffusers CPU) |
+
+Floating tags (`:latest`, `:latest-cuda`, `:latest-cpu`) are single-node
+only — multi-node deployments must pin every node to the same `X.Y.Z`
+(`-cuda`/`-cpu`) tag, or Ray refuses to form the cluster across mismatched
+versions.
+
+## Running a single node
+
+CPU, no GPU required:
+
+```bash
+docker run --rm --shm-size=8g \
+  -v ./models.yaml:/modelship/config/models.yaml \
+  -v ./models-cache:/.cache \
+  -p 8000:8000 \
+  ghcr.io/alez007/modelship:latest-cpu
+```
+
+GPU, with the NVIDIA Container Toolkit installed:
+
+```bash
+docker run --rm --shm-size=8g --gpus all \
+  -e HF_TOKEN=your_token_here \
+  -v ./models.yaml:/modelship/config/models.yaml \
+  -v ./models-cache:/.cache \
+  -p 8000:8000 \
+  ghcr.io/alez007/modelship:latest-cuda
+```
+
+See [Quickstart](quickstart.md) for a full copy-pasteable `models.yaml` and
+walkthrough.
+
+!!! tip
+    Always set `--shm-size=8g` (or higher) — Ray falls back to slower
+    disk-backed storage instead of `/dev/shm` if the container's shared
+    memory is too small for the object store.
+
+## Local development
+
+For building from source, running inside the dev container, or a manual
+`uv sync` + `mship_deploy.py` workflow (including the full CLI/env var
+reference and port list), see [Development Setup](development.md).
+
+## Scaling beyond one node
+
+To join multiple hosts into one Ray cluster with plain `docker run` (no
+Kubernetes), see [Multi-node without Kubernetes](multi-node-docker.md). For a
+Kubernetes/KubeRay deployment, see the
+[Helm chart](https://github.com/alez007/modelship/tree/main/helm/modelship).

--- a/docs/integrations/dify.md
+++ b/docs/integrations/dify.md
@@ -1,0 +1,20 @@
+# Dify
+
+[Dify](https://github.com/langgenius/dify) supports adding a custom
+**OpenAI-API-compatible** model provider, which is how it talks to Modelship.
+
+1. In Dify, go to **Settings → Model Provider** and add an
+   **OpenAI-API-compatible** provider (Dify lists this as a distinct provider
+   type from "OpenAI").
+2. Set the **API Base** to `http://<modelship-host>:8000/v1`.
+3. Set the **API Key** to a real key if `MSHIP_API_KEYS` is configured, or any
+   non-empty placeholder if not.
+4. Add a model entry for each model name in your `models.yaml` (Dify needs
+   the model registered explicitly per provider — it doesn't auto-discover
+   via `GET /v1/models`), matching its type (chat, embeddings, etc.) to the
+   corresponding Modelship deployment.
+
+Once registered, use that model like any other inside Dify's chatflow/agent
+builder. Streaming, embeddings (for Dify's knowledge-base retrieval), and
+tool calling all route through the same `/v1` endpoints Modelship already
+exposes.

--- a/docs/integrations/index.md
+++ b/docs/integrations/index.md
@@ -1,0 +1,20 @@
+# Integrations
+
+Modelship speaks the OpenAI API (`/v1/chat/completions`, `/v1/responses`,
+`/v1/embeddings`, `/v1/audio/*`, `/v1/images/generations`), so anything that
+already talks to OpenAI — an SDK, a chat UI, a low-code agent builder — can
+point at Modelship instead by changing its base URL.
+
+All of these guides assume a running Modelship gateway reachable at
+`http://<host>:8000` (see [Quickstart](../quickstart.md) if you don't have
+one yet), and use `Authorization: Bearer <key>` for auth if `MSHIP_API_KEYS`
+is set — otherwise any non-empty string works as the API key, since most
+OpenAI-compatible clients require *some* value in that field even when the
+server doesn't check it.
+
+- [OpenAI SDK](openai-sdk.md) — Python and JS/TS, the direct integration path
+- [Open WebUI](open-webui.md) — a self-hosted chat UI
+- [Dify](dify.md) — a low-code agent/app builder
+- [n8n](n8n.md) — workflow automation
+- [Responses-speaking agents](responses-agents.md) — agent frameworks and
+  custom loops built on `/v1/responses` specifically

--- a/docs/integrations/n8n.md
+++ b/docs/integrations/n8n.md
@@ -1,0 +1,43 @@
+# n8n
+
+[n8n](https://github.com/n8n-io/n8n) can call Modelship two ways: through its
+built-in OpenAI-shaped nodes, or directly via HTTP.
+
+## Option 1 — OpenAI Chat Model node
+
+n8n's **OpenAI Chat Model** node (used by its AI Agent / LangChain nodes)
+takes an OpenAI credential with a configurable **Base URL**:
+
+1. Create a new credential of type **OpenAI API**.
+2. Set **Base URL** to `http://<modelship-host>:8000/v1`.
+3. Set **API Key** to a real key if `MSHIP_API_KEYS` is configured, or any
+   non-empty placeholder if not.
+4. Use that credential in the **OpenAI Chat Model** node and set **Model** to
+   a name from your `models.yaml`.
+
+This is the fastest path if you're building with n8n's AI Agent nodes and
+want tool calling handled by n8n's own agent loop.
+
+## Option 2 — HTTP Request node
+
+For direct control over the request (e.g. to call `/v1/responses` for
+server-side conversation state, which n8n's built-in node doesn't expose),
+use the **HTTP Request** node:
+
+- **Method:** `POST`
+- **URL:** `http://<modelship-host>:8000/v1/responses`
+- **Authentication:** Generic → Header Auth, header `Authorization` = `Bearer
+  <key>` (if `MSHIP_API_KEYS` is set)
+- **Body (JSON):**
+
+```json
+{
+  "model": "reasoning-qwen",
+  "input": "{{ $json.userMessage }}",
+  "previous_response_id": "{{ $json.previousResponseId }}"
+}
+```
+
+Feed `resp.id` from the response back into the next call's
+`previous_response_id` to keep a conversation going across workflow runs
+without re-sending history.

--- a/docs/integrations/open-webui.md
+++ b/docs/integrations/open-webui.md
@@ -1,0 +1,30 @@
+# Open WebUI
+
+[Open WebUI](https://github.com/open-webui/open-webui) connects to any
+OpenAI-compatible backend through its **Connections** settings — Modelship
+qualifies without any special support on either side.
+
+1. In Open WebUI, go to **Settings → Admin Settings → Connections → OpenAI
+   API**.
+2. Set the **API Base URL** to `http://<modelship-host>:8000/v1`.
+3. Set the **API Key** to a real key if `MSHIP_API_KEYS` is configured, or any
+   non-empty placeholder if not.
+4. Save — Open WebUI queries `GET /v1/models` to populate the model picker
+   with whatever is in your `models.yaml`.
+
+Or via environment variables if you're running Open WebUI in Docker:
+
+```bash
+docker run -d \
+  -e OPENAI_API_BASE_URL=http://<modelship-host>:8000/v1 \
+  -e OPENAI_API_KEY=your-key-or-placeholder \
+  -p 3000:8080 \
+  ghcr.io/open-webui/open-webui:main
+```
+
+Chat, streaming, and image generation all work through the standard
+`/v1/chat/completions` and `/v1/images/generations` endpoints. Which
+higher-level Open WebUI features (e.g. its own tool-calling UI) light up
+depends on Open WebUI's own client-side detection of what the connected
+backend supports — that behavior is Open WebUI's, not something Modelship
+controls or has specifically verified feature-by-feature.

--- a/docs/integrations/openai-sdk.md
+++ b/docs/integrations/openai-sdk.md
@@ -1,0 +1,67 @@
+# OpenAI SDK
+
+Any OpenAI SDK client works against Modelship unchanged — point `base_url` at
+your gateway and use the model name from your `models.yaml`.
+
+## Python
+
+```python
+from openai import OpenAI
+
+client = OpenAI(
+    base_url="http://localhost:8000/v1",
+    api_key="not-needed",  # or a real key if MSHIP_API_KEYS is set
+)
+
+# Chat Completions
+chat = client.chat.completions.create(
+    model="reasoning-qwen",
+    messages=[{"role": "user", "content": "Which is larger, 9.11 or 9.9?"}],
+)
+print(chat.choices[0].message.content)
+
+# Responses API — reasoning, tool calling, and stored conversation state
+resp = client.responses.create(
+    model="reasoning-qwen",
+    input="Which is larger, 9.11 or 9.9?",
+)
+print(resp.output_text)
+
+# Continue the conversation server-side, no need to resend prior turns
+follow_up = client.responses.create(
+    model="reasoning-qwen",
+    input="Why?",
+    previous_response_id=resp.id,
+)
+print(follow_up.output_text)
+```
+
+## JavaScript / TypeScript
+
+```ts
+import OpenAI from "openai";
+
+const client = new OpenAI({
+  baseURL: "http://localhost:8000/v1",
+  apiKey: "not-needed", // or a real key if MSHIP_API_KEYS is set
+});
+
+const resp = await client.responses.create({
+  model: "reasoning-qwen",
+  input: "Which is larger, 9.11 or 9.9?",
+});
+console.log(resp.output_text);
+```
+
+## Embeddings, audio, and images
+
+```python
+client.embeddings.create(model="embed-model", input="hello world")
+client.audio.transcriptions.create(model="stt-model", file=open("audio.wav", "rb"))
+client.audio.speech.create(model="tts-model", voice="default", input="hello world")
+client.images.generate(model="image-model", prompt="a red bicycle")
+```
+
+See [Supported OpenAI Endpoints](../index.md#supported-openai-endpoints) for
+the full list, and [Responses-speaking agents](responses-agents.md) for the
+tool-calling round trip.

--- a/docs/integrations/responses-agents.md
+++ b/docs/integrations/responses-agents.md
@@ -1,0 +1,96 @@
+# Responses-speaking agents
+
+Any agent framework or custom loop built against the OpenAI **Responses API**
+(`/v1/responses`) works against Modelship directly — this is the primary
+surface Modelship is built around, not a translation layer bolted on top of
+chat completions.
+
+## Support matrix
+
+`/v1/responses` is implemented on the **vLLM** and **llama.cpp**
+(`llama_server`) loaders. It 404s on `diffusers` and `custom` (TTS/STT
+plugin) deployments, since those don't have a text generation loop to attach
+it to.
+
+Supported on both loaders:
+
+- Text output and first-class **reasoning** output items
+- Client-driven **tool/function calling** (`function_call` /
+  `function_call_output` round-trip)
+- **Server-side conversation state** — `store`, `previous_response_id`,
+  `GET`/`DELETE /v1/responses/{id}`, and `/input_items`
+- Streaming and non-streaming
+
+Not supported: `background` mode, hosted built-in tools (e.g. `web_search`),
+and encrypted reasoning (`reasoning.encrypted_content`) — server-side state
+is how Modelship carries reasoning across turns instead. All of these are
+rejected with a clear `400` rather than silently dropped.
+
+## Continuing a conversation
+
+Each call to `/v1/responses` returns an `id`. Pass it back as
+`previous_response_id` on the next call and Modelship resolves the prior
+turn's state server-side before the request ever reaches the model — your
+agent loop doesn't need to keep its own transcript:
+
+```python
+resp = client.responses.create(model="reasoning-qwen", input="Plan a trip to Lisbon.")
+follow_up = client.responses.create(
+    model="reasoning-qwen",
+    input="Make it 4 days instead.",
+    previous_response_id=resp.id,
+)
+```
+
+State lives in a pluggable store (`MSHIP_STATE_STORE`) — in-memory by default
+(shared across gateway replicas, not durable across full cluster loss), or
+`redis://` for durability across restarts and node failure. See
+[Architecture — Conversation state](../architecture.md#conversation-state).
+
+## Tool calling loop
+
+Tool execution itself is client-driven: Modelship returns `function_call`
+output items, your agent runs the tool, and you send the result back as a
+`function_call_output` input item (optionally with `previous_response_id` to
+keep the rest of the conversation server-side):
+
+```python
+resp = client.responses.create(
+    model="reasoning-qwen",
+    input="What's the weather in Lisbon?",
+    tools=[{
+        "type": "function",
+        "name": "get_weather",
+        "parameters": {"type": "object", "properties": {"city": {"type": "string"}}},
+    }],
+)
+
+call = next(item for item in resp.output if item.type == "function_call")
+result = get_weather(**json.loads(call.arguments))
+
+final = client.responses.create(
+    model="reasoning-qwen",
+    previous_response_id=resp.id,
+    input=[{
+        "type": "function_call_output",
+        "call_id": call.call_id,
+        "output": json.dumps(result),
+    }],
+)
+```
+
+## Streaming
+
+Streaming responses emit the standard named Responses events
+(`response.created`, `response.output_item.added`,
+`response.output_text.delta`, `response.reasoning_summary_text.delta`,
+`response.function_call_arguments.delta`, `response.output_item.done`,
+`response.completed`) — reasoning and tool-call argument deltas stream live,
+independent of how a given model interleaves them:
+
+```python
+with client.responses.stream(model="reasoning-qwen", input="Explain briefly.") as stream:
+    for event in stream:
+        if event.type == "response.output_text.delta":
+            print(event.delta, end="", flush=True)
+```

--- a/docs/model-configuration.md
+++ b/docs/model-configuration.md
@@ -437,9 +437,9 @@ models:
 The `custom` loader delegates to a plugin module. The `plugin` field is required and must match an installed plugin package. Plugin-specific options are passed via `plugin_config`.
 
 See each plugin's README for configuration details:
-- [Kokoro ONNX TTS](../plugins/kokoroonnx/README.md)
-- [Orpheus TTS](../plugins/orpheus/README.md)
-- [whisper.cpp STT](../plugins/whispercpp/README.md)
+- [Kokoro ONNX TTS](https://github.com/alez007/modelship/blob/main/plugins/kokoroonnx/README.md)
+- [Orpheus TTS](https://github.com/alez007/modelship/blob/main/plugins/orpheus/README.md)
+- [whisper.cpp STT](https://github.com/alez007/modelship/blob/main/plugins/whispercpp/README.md)
 
 For writing your own plugin, see [Plugin Development](plugins.md).
 

--- a/docs/multi-node-docker.md
+++ b/docs/multi-node-docker.md
@@ -1,7 +1,7 @@
 # Multi-node without Kubernetes
 
 Modelship has two well-worn rungs: one container running its own Ray head, or full
-Kubernetes via the [Helm chart](../helm/modelship/README.md). This page covers the
+Kubernetes via the [Helm chart](https://github.com/alez007/modelship/blob/main/helm/modelship/README.md). This page covers the
 rung in between — a handful of plain `docker run` VMs, no cluster orchestrator,
 joined into one Ray cluster via `--address`/`--token`.
 
@@ -137,7 +137,7 @@ below are deliberate ways to pack more onto hardware you already have. What
 *is* still your responsibility: fencing which physical resources each container
 gets, so two containers on one box don't both believe they own the same
 hardware. See [AGENTS.md's co-location
-note](../AGENTS.md#gotchas) for the full fencing discipline
+note](https://github.com/alez007/modelship/blob/main/AGENTS.md#gotchas) for the full fencing discipline
 (`--gpus device=N`, `--node-memory` + `--shm-size`, `--cpuset-cpus` +
 `--node-num-cpus`) — this page only covers the two topologies it unlocks.
 Reserving more GPUs than a container can actually see is refused at startup
@@ -196,7 +196,7 @@ together on the card.
 
 ## See also
 
-- [helm/modelship/README.md](../helm/modelship/README.md) — the Kubernetes rung:
+- [helm/modelship/README.md](https://github.com/alez007/modelship/blob/main/helm/modelship/README.md) — the Kubernetes rung:
   same image variants and version-pinning rule, but autoscaling, self-healing
   pod scheduling, and (unlike this page's manual token setup) no Ray
   cluster-auth wiring yet.

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -189,7 +189,7 @@ Every plugin must include a `README.md` in its package root (`plugins/myplugin/R
 - **Voices / options** — any model-specific choices (voice presets, providers, etc.)
 - **Example request** — a working `curl` command
 
-See the built-in plugins for reference: [Kokoro ONNX](../plugins/kokoroonnx/README.md), [Orpheus](../plugins/orpheus/README.md), [whisper.cpp](../plugins/whispercpp/README.md).
+See the built-in plugins for reference: [Kokoro ONNX](https://github.com/alez007/modelship/blob/main/plugins/kokoroonnx/README.md), [Orpheus](https://github.com/alez007/modelship/blob/main/plugins/orpheus/README.md), [whisper.cpp](https://github.com/alez007/modelship/blob/main/plugins/whispercpp/README.md).
 
 ## Submitting to this repo
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -1,0 +1,84 @@
+# Quickstart
+
+The fastest way to try Modelship: run a tiny reasoning model on a laptop — no
+GPU required. Copy-paste this block and you'll have an OpenAI-compatible API
+on `http://localhost:8000` in a few minutes.
+
+```bash
+mkdir -p models-cache && cat > models.yaml <<'EOF'
+models:
+  - name: reasoning-qwen
+    model: "lmstudio-community/Qwen3-0.6B-GGUF:*Q4_K_M.gguf"
+    usecase: generate
+    loader: llama_server
+    num_cpus: 3
+    llama_server_config:
+      n_ctx: 4096  # Give reasoning space to think
+EOF
+
+docker run --rm --shm-size=8g \
+  -v ./models.yaml:/modelship/config/models.yaml \
+  -v ./models-cache:/.cache \
+  -p 8000:8000 \
+  ghcr.io/alez007/modelship:latest-cpu
+```
+
+Images are multi-arch (amd64 + arm64), so this works on Apple Silicon and ARM
+Linux hosts too.
+
+Once the server is up (look for `Deployed app 'modelship api' successfully`),
+call the **Responses API** and watch the model think:
+
+```bash
+curl http://localhost:8000/v1/responses \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "reasoning-qwen",
+    "input": "Which is larger, 9.11 or 9.9?"
+  }'
+```
+
+The response includes both `output_text` and a first-class `reasoning` output
+item — the same server-side conversation state (`previous_response_id`) and
+tool-calling support work here as they do on GPU-backed models.
+`/v1/chat/completions` remains available too, if that's what your client
+speaks.
+
+## GPU (vLLM, Diffusers)
+
+For high-throughput GPU inference, use the `-cuda` image and add `--gpus
+all`. You'll also need the
+[NVIDIA Container Toolkit](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/install-guide.html)
+and an `HF_TOKEN` for gated models. Example `models.yaml` entries for vLLM,
+Diffusers, and multi-GPU setups live in
+[Model Configuration](model-configuration.md); ready-to-run configs are in
+[`config/examples/`](https://github.com/alez007/modelship/tree/main/config/examples).
+
+```bash
+docker run --rm --shm-size=8g --gpus all \
+  -e HF_TOKEN=your_token_here \
+  -v ./models.yaml:/modelship/config/models.yaml \
+  -v ./models-cache:/.cache \
+  -p 8000:8000 \
+  ghcr.io/alez007/modelship:latest-cuda
+```
+
+!!! note
+    `ghcr.io/alez007/modelship:latest` (bare tag, no suffix) is the **thin**
+    control/coordinator image — no torch/vllm, for a driver/head role only.
+    It cannot serve models by itself; always use `-cuda` or `-cpu` to
+    actually run inference. See [Installation](installation.md) for the full
+    three-image breakdown.
+
+!!! tip
+    Always set `--shm-size=8g` (or higher) when running the docker container
+    to prevent PyTorch from hitting shared memory limits during
+    multi-process operations.
+
+Hitting an error? Check [Troubleshooting](troubleshooting.md).
+
+## Next up
+
+Point an OpenAI SDK client at it — see [Integrations](integrations/index.md)
+— or scale it out across a cluster with
+[Multi-node without Kubernetes](multi-node-docker.md).

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -1,0 +1,15 @@
+:root {
+  --md-primary-fg-color: #0b2545;
+  --md-primary-fg-color--light: #4a6b8a;
+  --md-primary-fg-color--dark: #081b33;
+  --md-primary-bg-color: #eaf0f7;
+  --md-accent-fg-color: #0e7c86;
+}
+
+[data-md-color-scheme="slate"] {
+  --md-primary-fg-color: #0b2545;
+  --md-primary-fg-color--light: #4a6b8a;
+  --md-primary-fg-color--dark: #081b33;
+  --md-primary-bg-color: #eaf0f7;
+  --md-accent-fg-color: #4fd3de;
+}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,79 @@
+site_name: Modelship
+site_description: >-
+  The production backend for self-hosted agents — the OpenAI Responses API,
+  universal tool calling, and reasoning, alongside embeddings, speech, and
+  image generation, behind one OpenAI-compatible endpoint. Built on Ray Serve.
+site_url: https://model-ship.ai/
+repo_url: https://github.com/alez007/modelship
+repo_name: alez007/modelship
+edit_uri: edit/main/docs/
+docs_dir: docs
+site_dir: site
+
+theme:
+  name: material
+  logo: assets/logo-dark.svg
+  favicon: assets/logo-dark.svg
+  palette:
+    - media: "(prefers-color-scheme: light)"
+      scheme: default
+      primary: custom
+      accent: custom
+      toggle:
+        icon: material/weather-night
+        name: Switch to dark mode
+    - media: "(prefers-color-scheme: dark)"
+      scheme: slate
+      primary: custom
+      accent: custom
+      toggle:
+        icon: material/weather-sunny
+        name: Switch to light mode
+  features:
+    - navigation.tabs
+    - navigation.sections
+    - navigation.top
+    - navigation.indexes
+    - toc.follow
+    - content.code.copy
+    - content.action.edit
+    - search.suggest
+    - search.highlight
+
+extra_css:
+  - stylesheets/extra.css
+
+markdown_extensions:
+  - admonition
+  - tables
+  - def_list
+  - attr_list
+  - md_in_html
+  - toc:
+      permalink: true
+  - pymdownx.highlight:
+      anchor_linenums: true
+  - pymdownx.inlinehilite
+  - pymdownx.superfences
+  - pymdownx.snippets
+
+nav:
+  - Overview: index.md
+  - Quickstart: quickstart.md
+  - Installation: installation.md
+  - Model Configuration: model-configuration.md
+  - Guides:
+      - Production Readiness: production-readiness.md
+      - Multi-node without Kubernetes: multi-node-docker.md
+      - Plugin Development: plugins.md
+      - Development Setup: development.md
+  - Integrations:
+      - Overview: integrations/index.md
+      - OpenAI SDK: integrations/openai-sdk.md
+      - Open WebUI: integrations/open-webui.md
+      - Dify: integrations/dify.md
+      - n8n: integrations/n8n.md
+      - Responses-speaking agents: integrations/responses-agents.md
+  - Architecture: architecture.md
+  - Monitoring: monitoring.md
+  - Troubleshooting: troubleshooting.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -3,7 +3,7 @@ site_description: >-
   The production backend for self-hosted agents — the OpenAI Responses API,
   universal tool calling, and reasoning, alongside embeddings, speech, and
   image generation, behind one OpenAI-compatible endpoint. Built on Ray Serve.
-site_url: https://model-ship.ai/
+site_url: https://docs.model-ship.ai/
 repo_url: https://github.com/alez007/modelship
 repo_name: alez007/modelship
 edit_uri: edit/main/docs/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "modelship"
 version = "0.6.5"
-description = "Self-hosted, OpenAI-compatible multi-model inference for the agentic era — reasoning LLMs, tool calling, and the Responses API alongside embeddings, speech-to-text, text-to-speech, and image generation, all sharing your GPUs behind one gateway. Built on Ray Serve."
+description = "The production backend for self-hosted agents — the OpenAI Responses API with durable conversation state, universal tool calling, and reasoning, alongside embeddings, speech, and image generation, behind one OpenAI-compatible endpoint. Built on Ray Serve."
 authors = [
     { name = "Alex Margarit" }
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,6 +71,9 @@ otel = [
     "opentelemetry-sdk>=1.20.0",
     "opentelemetry-exporter-otlp>=1.20.0",
 ]
+docs = [
+    "mkdocs-material>=9.6.0",
+]
 dev = [
     "ruff>=0.11.0",
     "pyright>=1.1.400",
@@ -82,7 +85,7 @@ dev = [
 
 [project.urls]
 Homepage = "https://github.com/alez007/modelship"
-Documentation = "https://github.com/alez007/modelship/tree/main/docs"
+Documentation = "https://model-ship.ai/"
 Issues = "https://github.com/alez007/modelship/issues"
 Changelog = "https://github.com/alez007/modelship/blob/main/CHANGELOG.md"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,7 +85,7 @@ dev = [
 
 [project.urls]
 Homepage = "https://github.com/alez007/modelship"
-Documentation = "https://model-ship.ai/"
+Documentation = "https://docs.model-ship.ai/"
 Issues = "https://github.com/alez007/modelship/issues"
 Changelog = "https://github.com/alez007/modelship/blob/main/CHANGELOG.md"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "modelship"
 version = "0.6.5"
-description = "The production backend for self-hosted agents — the OpenAI Responses API with durable conversation state, universal tool calling, and reasoning, alongside embeddings, speech, and image generation, behind one OpenAI-compatible endpoint. Built on Ray Serve."
+description = "The production backend for self-hosted agents — the OpenAI Responses API with server-side conversation state (durable with Redis), universal tool calling, and reasoning, alongside embeddings, speech, and image generation, behind one OpenAI-compatible endpoint. Built on Ray Serve."
 authors = [
     { name = "Alex Margarit" }
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -243,6 +243,17 @@ wheels = [
 ]
 
 [[package]]
+name = "backrefs"
+version = "7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5e/a7/a7dd63622beef68cc0d3c3c36d472e143dd95443d5ebf14cd1a5b4dfbf11/backrefs-7.0.tar.gz", hash = "sha256:4989bb9e1e99eb23647c7160ed51fb21d0b41b5d200f2d3017da41e023097e82", size = 7012453, upload-time = "2026-04-28T16:28:04.215Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d4/39/39a31d7eae729ea14ed10c3ccef79371197177b9355a86cb3525709e8502/backrefs-7.0-py310-none-any.whl", hash = "sha256:b57cd227ea556b0aed3dc9b8da4628db4eabc0402c6d7fcfc69283a93955f7e9", size = 380824, upload-time = "2026-04-28T16:27:55.647Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/b5/9302644225ba7dfa934a2ff2b9c7bb85701313a90dddb3dfaf693fa5bae2/backrefs-7.0-py311-none-any.whl", hash = "sha256:a0fa7360c63509e9e077e174ef4e6d3c21c8db94189b9d957289ae6d794b9475", size = 392626, upload-time = "2026-04-28T16:27:57.42Z" },
+    { url = "https://files.pythonhosted.org/packages/36/da/87912ddec6e06feffbaa3d7aa18fc6352bee2e8f1fee185d7d1690f8f4e8/backrefs-7.0-py312-none-any.whl", hash = "sha256:ca42ce6a49ace3d75684dfa9937f3373902a63284ecb385ce36d15e5dcb41c12", size = 398537, upload-time = "2026-04-28T16:27:58.913Z" },
+]
+
+[[package]]
 name = "bitsandbytes"
 version = "0.49.2"
 source = { registry = "https://pypi.org/simple" }
@@ -955,6 +966,18 @@ wheels = [
 ]
 
 [[package]]
+name = "ghp-import"
+version = "2.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "python-dateutil" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d9/29/d40217cbe2f6b1359e00c6c307bb3fc876ba74068cbab3dde77f03ca0dc4/ghp-import-2.1.0.tar.gz", hash = "sha256:9c535c4c61193c2df8871222567d7fd7e5014d835f97dc7b7439069e2413d343", size = 10943, upload-time = "2022-05-02T15:47:16.11Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f7/ec/67fbef5d497f86283db54c22eec6f6140243aae73265799baaaa19cd17fb/ghp_import-2.1.0-py3-none-any.whl", hash = "sha256:8337dd7b50877f163d4c0289bc1f1c7f127550241988d568c1db512c4324a619", size = 11034, upload-time = "2022-05-02T15:47:14.552Z" },
+]
+
+[[package]]
 name = "google-api-core"
 version = "2.30.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1449,6 +1472,15 @@ wheels = [
 ]
 
 [[package]]
+name = "markdown"
+version = "3.10.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/2b/f4/69fa6ed85ae003c2378ffa8f6d2e3234662abd02c10d216c0ba96081a238/markdown-3.10.2.tar.gz", hash = "sha256:994d51325d25ad8aa7ce4ebaec003febcce822c3f8c911e3b17c52f7f589f950", size = 368805, upload-time = "2026-02-09T14:57:26.942Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/de/1f/77fa3081e4f66ca3576c896ae5d31c3002ac6607f9747d2e3aa49227e464/markdown-3.10.2-py3-none-any.whl", hash = "sha256:e91464b71ae3ee7afd3017d9f358ef0baf158fd9a298db92f1d4761133824c36", size = 108180, upload-time = "2026-02-09T14:57:25.787Z" },
+]
+
+[[package]]
 name = "markdown-it-py"
 version = "4.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1514,6 +1546,15 @@ wheels = [
 ]
 
 [[package]]
+name = "mergedeep"
+version = "1.3.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/3a/41/580bb4006e3ed0361b8151a01d324fb03f420815446c7def45d02f74c270/mergedeep-1.3.4.tar.gz", hash = "sha256:0096d52e9dad9939c3d975a774666af186eda617e6ca84df4c94dec30004f2a8", size = 4661, upload-time = "2021-02-05T18:55:30.623Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2c/19/04f9b178c2d8a15b076c8b5140708fa6ffc5601fb6f1e975537072df5b2a/mergedeep-1.3.4-py3-none-any.whl", hash = "sha256:70775750742b25c0d8f36c55aed03d24c3384d17c951b3175d898bd778ef0307", size = 6354, upload-time = "2021-02-05T18:55:29.583Z" },
+]
+
+[[package]]
 name = "mistral-common"
 version = "1.11.5"
 source = { registry = "https://pypi.org/simple" }
@@ -1539,6 +1580,75 @@ audio = [
 ]
 image = [
     { name = "opencv-python-headless" },
+]
+
+[[package]]
+name = "mkdocs"
+version = "1.6.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "colorama", marker = "sys_platform == 'win32' or (extra == 'extra-9-modelship-cpu' and extra == 'extra-9-modelship-cuda')" },
+    { name = "ghp-import" },
+    { name = "jinja2" },
+    { name = "markdown" },
+    { name = "markupsafe" },
+    { name = "mergedeep" },
+    { name = "mkdocs-get-deps" },
+    { name = "packaging" },
+    { name = "pathspec" },
+    { name = "pyyaml" },
+    { name = "pyyaml-env-tag" },
+    { name = "watchdog" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/bc/c6/bbd4f061bd16b378247f12953ffcb04786a618ce5e904b8c5a01a0309061/mkdocs-1.6.1.tar.gz", hash = "sha256:7b432f01d928c084353ab39c57282f29f92136665bdd6abf7c1ec8d822ef86f2", size = 3889159, upload-time = "2024-08-30T12:24:06.899Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/22/5b/dbc6a8cddc9cfa9c4971d59fb12bb8d42e161b7e7f8cc89e49137c5b279c/mkdocs-1.6.1-py3-none-any.whl", hash = "sha256:db91759624d1647f3f34aa0c3f327dd2601beae39a366d6e064c03468d35c20e", size = 3864451, upload-time = "2024-08-30T12:24:05.054Z" },
+]
+
+[[package]]
+name = "mkdocs-get-deps"
+version = "0.2.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mergedeep" },
+    { name = "platformdirs" },
+    { name = "pyyaml" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ce/25/b3cccb187655b9393572bde9b09261d267c3bf2f2cdabe347673be5976a6/mkdocs_get_deps-0.2.2.tar.gz", hash = "sha256:8ee8d5f316cdbbb2834bc1df6e69c08fe769a83e040060de26d3c19fad3599a1", size = 11047, upload-time = "2026-03-10T02:46:33.632Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/88/29/744136411e785c4b0b744d5413e56555265939ab3a104c6a4b719dad33fd/mkdocs_get_deps-0.2.2-py3-none-any.whl", hash = "sha256:e7878cbeac04860b8b5e0ca31d3abad3df9411a75a32cde82f8e44b6c16ff650", size = 9555, upload-time = "2026-03-10T02:46:32.256Z" },
+]
+
+[[package]]
+name = "mkdocs-material"
+version = "9.7.7"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "babel" },
+    { name = "backrefs" },
+    { name = "colorama" },
+    { name = "jinja2" },
+    { name = "markdown" },
+    { name = "mkdocs" },
+    { name = "mkdocs-material-extensions" },
+    { name = "paginate" },
+    { name = "pygments" },
+    { name = "pymdown-extensions" },
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f1/cd/c05d3a530ba7934f144fb45f7203cd236adc25c7bdcc34673d202f4b0278/mkdocs_material-9.7.7.tar.gz", hash = "sha256:c0649c065b1b0512d60aad8c10f947f8e455284475239b364b610f2deb4d0855", size = 4097923, upload-time = "2026-07-17T16:21:33.156Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ad/21/17c1bc9e6f47c972ad66fb2ac2568f99f90f1207eeb6fc3b34d094dba7b5/mkdocs_material-9.7.7-py3-none-any.whl", hash = "sha256:8ea9bb1737a5b524a5f9dcf2e1b4ebda8274ae3008aa7845720a97083bef708f", size = 9305438, upload-time = "2026-07-17T16:21:30.017Z" },
+]
+
+[[package]]
+name = "mkdocs-material-extensions"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/79/9b/9b4c96d6593b2a541e1cb8b34899a6d021d208bb357042823d4d2cabdbe7/mkdocs_material_extensions-1.3.1.tar.gz", hash = "sha256:10c9511cea88f568257f960358a467d12b970e1f7b2c0e5fb2bb48cab1928443", size = 11847, upload-time = "2023-11-22T19:09:45.208Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5b/54/662a4743aa81d9582ee9339d4ffa3c8fd40a4965e033d77b9da9774d3960/mkdocs_material_extensions-1.3.1-py3-none-any.whl", hash = "sha256:adff8b62700b25cb77b53358dad940f3ef973dd6db797907c49e3c2ef3ab4e31", size = 8728, upload-time = "2023-11-22T19:09:43.465Z" },
 ]
 
 [[package]]
@@ -1635,6 +1745,9 @@ dev = [
     { name = "pytest-asyncio" },
     { name = "ruff" },
 ]
+docs = [
+    { name = "mkdocs-material" },
+]
 kokoroonnx = [
     { name = "kokoroonnx" },
 ]
@@ -1664,6 +1777,7 @@ requires-dist = [
     { name = "kokoroonnx", marker = "extra == 'kokoroonnx'", editable = "plugins/kokoroonnx" },
     { name = "librosa", marker = "extra == 'cpu'", specifier = ">=0.11.0" },
     { name = "librosa", marker = "extra == 'cuda'", specifier = ">=0.11.0" },
+    { name = "mkdocs-material", marker = "extra == 'docs'", specifier = ">=9.6.0" },
     { name = "numpy", specifier = ">=2.2.6" },
     { name = "nvidia-ml-py", marker = "extra == 'cuda'" },
     { name = "onnxruntime", marker = "extra == 'cpu'", specifier = ">=1.20.1" },
@@ -1702,7 +1816,7 @@ requires-dist = [
     { name = "vllm", extras = ["audio"], marker = "extra == 'cuda'", specifier = "==0.24.0" },
     { name = "whispercpp", marker = "extra == 'whispercpp'", editable = "plugins/whispercpp" },
 ]
-provides-extras = ["thin", "cuda", "cpu", "kokoroonnx", "orpheus", "whispercpp", "otel", "dev"]
+provides-extras = ["thin", "cuda", "cpu", "kokoroonnx", "orpheus", "whispercpp", "otel", "docs", "dev"]
 
 [[package]]
 name = "mpmath"
@@ -2430,6 +2544,15 @@ wheels = [
 ]
 
 [[package]]
+name = "paginate"
+version = "0.5.7"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ec/46/68dde5b6bc00c1296ec6466ab27dddede6aec9af1b99090e1107091b3b84/paginate-0.5.7.tar.gz", hash = "sha256:22bd083ab41e1a8b4f3690544afb2c60c25e5c9a63a30fa2f483f6c60c8e5945", size = 19252, upload-time = "2024-08-25T14:17:24.139Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/90/96/04b8e52da071d28f5e21a805b19cb9390aa17a47462ac87f5e2696b9566d/paginate-0.5.7-py2.py3-none-any.whl", hash = "sha256:b885e2af73abcf01d9559fd5216b57ef722f8c42affbb63942377668e35c7591", size = 13746, upload-time = "2024-08-25T14:17:22.55Z" },
+]
+
+[[package]]
 name = "pandas"
 version = "3.0.2"
 source = { registry = "https://pypi.org/simple" }
@@ -2457,6 +2580,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/6a/6d/eed37d7ebc1e0bcd27b831c0cf1fe94881934316187c4b30d23f29ea0bd4/partial_json_parser-0.2.1.1.post7.tar.gz", hash = "sha256:86590e1ba6bcb6739a2dfc17d2323f028cb5884f4c6ce23db376999132c9a922", size = 10296, upload-time = "2025-11-17T07:27:41.202Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/42/32/658973117bf0fd82a24abbfb94fe73a5e86216e49342985e10acce54775a/partial_json_parser-0.2.1.1.post7-py3-none-any.whl", hash = "sha256:145119e5eabcf80cbb13844a6b50a85c68bf99d376f8ed771e2a3c3b03e653ae", size = 10877, upload-time = "2025-11-17T07:27:40.457Z" },
+]
+
+[[package]]
+name = "pathspec"
+version = "1.1.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5a/82/42f767fc1c1143d6fd36efb827202a2d997a375e160a71eb2888a925aac1/pathspec-1.1.1.tar.gz", hash = "sha256:17db5ecd524104a120e173814c90367a96a98d07c45b2e10c2f3919fff91bf5a", size = 135180, upload-time = "2026-04-27T01:46:08.907Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f1/d9/7fb5aa316bc299258e68c73ba3bddbc499654a07f151cba08f6153988714/pathspec-1.1.1-py3-none-any.whl", hash = "sha256:a00ce642f577bf7f473932318056212bc4f8bfdf53128c78bbd5af0b9b20b189", size = 57328, upload-time = "2026-04-27T01:46:07.06Z" },
 ]
 
 [[package]]
@@ -2878,6 +3010,19 @@ crypto = [
 ]
 
 [[package]]
+name = "pymdown-extensions"
+version = "11.0.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markdown" },
+    { name = "pyyaml" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/21/a9/5f0c535ba3b08fe09270c16808e053a968868242ecbd5676d4e3a488bf28/pymdown_extensions-11.0.1.tar.gz", hash = "sha256:dd2905ae6fc5b75582fafb139a1266ffc754705efa902aa50067fa7ff4f94ec0", size = 857113, upload-time = "2026-07-02T17:59:22.955Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d6/54/da572c98c0b77626a91b5d3b89f0231d8bff5125c225420908632f8b342d/pymdown_extensions-11.0.1-py3-none-any.whl", hash = "sha256:db3943a62bab7e03af1364f0c4083e64b91fb097675a4b6cceccfbe9a77e5eb2", size = 269455, upload-time = "2026-07-02T17:59:21.271Z" },
+]
+
+[[package]]
 name = "pyopenssl"
 version = "26.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -3027,6 +3172,18 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/74/93/7baea19427dcfbe1e5a372d81473250b379f04b1bd3c4c5ff825e2327202/pyyaml-6.0.3-cp312-cp312-win32.whl", hash = "sha256:96b533f0e99f6579b3d4d4995707cf36df9100d67e0c8303a0c55b27b5f99bc5", size = 137658, upload-time = "2025-09-25T21:32:20.209Z" },
     { url = "https://files.pythonhosted.org/packages/86/bf/899e81e4cce32febab4fb42bb97dcdf66bc135272882d1987881a4b519e9/pyyaml-6.0.3-cp312-cp312-win_amd64.whl", hash = "sha256:5fcd34e47f6e0b794d17de1b4ff496c00986e1c83f7ab2fb8fcfe9616ff7477b", size = 154003, upload-time = "2025-09-25T21:32:21.167Z" },
     { url = "https://files.pythonhosted.org/packages/1a/08/67bd04656199bbb51dbed1439b7f27601dfb576fb864099c7ef0c3e55531/pyyaml-6.0.3-cp312-cp312-win_arm64.whl", hash = "sha256:64386e5e707d03a7e172c0701abfb7e10f0fb753ee1d773128192742712a98fd", size = 140344, upload-time = "2025-09-25T21:32:22.617Z" },
+]
+
+[[package]]
+name = "pyyaml-env-tag"
+version = "1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyyaml" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/eb/2e/79c822141bfd05a853236b504869ebc6b70159afc570e1d5a20641782eaa/pyyaml_env_tag-1.1.tar.gz", hash = "sha256:2eb38b75a2d21ee0475d6d97ec19c63287a7e140231e4214969d0eac923cd7ff", size = 5737, upload-time = "2025-05-13T15:24:01.64Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/11/432f32f8097b03e3cd5fe57e88efb685d964e2e5178a48ed61e841f7fdce/pyyaml_env_tag-1.1-py3-none-any.whl", hash = "sha256:17109e1a528561e32f026364712fee1264bc2ea6715120891174ed1b980d2e04", size = 4722, upload-time = "2025-05-13T15:23:59.629Z" },
 ]
 
 [[package]]
@@ -4349,6 +4506,27 @@ audio = [
     { name = "scipy" },
     { name = "soundfile" },
     { name = "soxr" },
+]
+
+[[package]]
+name = "watchdog"
+version = "6.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/db/7d/7f3d619e951c88ed75c6037b246ddcf2d322812ee8ea189be89511721d54/watchdog-6.0.0.tar.gz", hash = "sha256:9ddf7c82fda3ae8e24decda1338ede66e1c99883db93711d8fb941eaa2d8c282", size = 131220, upload-time = "2024-11-01T14:07:13.037Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/39/ea/3930d07dafc9e286ed356a679aa02d777c06e9bfd1164fa7c19c288a5483/watchdog-6.0.0-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:bdd4e6f14b8b18c334febb9c4425a878a2ac20efd1e0b231978e7b150f92a948", size = 96471, upload-time = "2024-11-01T14:06:37.745Z" },
+    { url = "https://files.pythonhosted.org/packages/12/87/48361531f70b1f87928b045df868a9fd4e253d9ae087fa4cf3f7113be363/watchdog-6.0.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:c7c15dda13c4eb00d6fb6fc508b3c0ed88b9d5d374056b239c4ad1611125c860", size = 88449, upload-time = "2024-11-01T14:06:39.748Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/7e/8f322f5e600812e6f9a31b75d242631068ca8f4ef0582dd3ae6e72daecc8/watchdog-6.0.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:6f10cb2d5902447c7d0da897e2c6768bca89174d0c6e1e30abec5421af97a5b0", size = 89054, upload-time = "2024-11-01T14:06:41.009Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/c7/ca4bf3e518cb57a686b2feb4f55a1892fd9a3dd13f470fca14e00f80ea36/watchdog-6.0.0-py3-none-manylinux2014_aarch64.whl", hash = "sha256:7607498efa04a3542ae3e05e64da8202e58159aa1fa4acddf7678d34a35d4f13", size = 79079, upload-time = "2024-11-01T14:06:59.472Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/51/d46dc9332f9a647593c947b4b88e2381c8dfc0942d15b8edc0310fa4abb1/watchdog-6.0.0-py3-none-manylinux2014_armv7l.whl", hash = "sha256:9041567ee8953024c83343288ccc458fd0a2d811d6a0fd68c4c22609e3490379", size = 79078, upload-time = "2024-11-01T14:07:01.431Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/57/04edbf5e169cd318d5f07b4766fee38e825d64b6913ca157ca32d1a42267/watchdog-6.0.0-py3-none-manylinux2014_i686.whl", hash = "sha256:82dc3e3143c7e38ec49d61af98d6558288c415eac98486a5c581726e0737c00e", size = 79076, upload-time = "2024-11-01T14:07:02.568Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/cc/da8422b300e13cb187d2203f20b9253e91058aaf7db65b74142013478e66/watchdog-6.0.0-py3-none-manylinux2014_ppc64.whl", hash = "sha256:212ac9b8bf1161dc91bd09c048048a95ca3a4c4f5e5d4a7d1b1a7d5752a7f96f", size = 79077, upload-time = "2024-11-01T14:07:03.893Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/3b/b8964e04ae1a025c44ba8e4291f86e97fac443bca31de8bd98d3263d2fcf/watchdog-6.0.0-py3-none-manylinux2014_ppc64le.whl", hash = "sha256:e3df4cbb9a450c6d49318f6d14f4bbc80d763fa587ba46ec86f99f9e6876bb26", size = 79078, upload-time = "2024-11-01T14:07:05.189Z" },
+    { url = "https://files.pythonhosted.org/packages/62/ae/a696eb424bedff7407801c257d4b1afda455fe40821a2be430e173660e81/watchdog-6.0.0-py3-none-manylinux2014_s390x.whl", hash = "sha256:2cce7cfc2008eb51feb6aab51251fd79b85d9894e98ba847408f662b3395ca3c", size = 79077, upload-time = "2024-11-01T14:07:06.376Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/e8/dbf020b4d98251a9860752a094d09a65e1b436ad181faf929983f697048f/watchdog-6.0.0-py3-none-manylinux2014_x86_64.whl", hash = "sha256:20ffe5b202af80ab4266dcd3e91aae72bf2da48c0d33bdb15c66658e685e94e2", size = 79078, upload-time = "2024-11-01T14:07:07.547Z" },
+    { url = "https://files.pythonhosted.org/packages/07/f6/d0e5b343768e8bcb4cda79f0f2f55051bf26177ecd5651f84c07567461cf/watchdog-6.0.0-py3-none-win32.whl", hash = "sha256:07df1fdd701c5d4c8e55ef6cf55b8f0120fe1aef7ef39a1c6fc6bc2e606d517a", size = 79065, upload-time = "2024-11-01T14:07:09.525Z" },
+    { url = "https://files.pythonhosted.org/packages/db/d9/c495884c6e548fce18a8f40568ff120bc3a4b7b99813081c8ac0c936fa64/watchdog-6.0.0-py3-none-win_amd64.whl", hash = "sha256:cbafb470cf848d93b5d013e2ecb245d4aa1c8fd0504e863ccefa32445359d680", size = 79070, upload-time = "2024-11-01T14:07:10.686Z" },
+    { url = "https://files.pythonhosted.org/packages/33/e8/e40370e6d74ddba47f002a32919d91310d6074130fe4e17dabcafc15cbf1/watchdog-6.0.0-py3-none-win_ia64.whl", hash = "sha256:a1914259fa9e1454315171103c6a30961236f508b9b623eae470268bbcc6a22f", size = 79067, upload-time = "2024-11-01T14:07:11.845Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Rewrite the hero, "Why Modelship", and Quick Start around a single positioning: durable server-side Responses state, tool calling, and reasoning behind one OpenAI-compatible endpoint. Add a hand-authored architecture diagram (light/dark SVG) as the at-a-glance summary, and elevate security (API-key + Ray token auth) alongside observability as first-class production-readiness signals.


