### PR TITLE
fix: close Open Responses conformance gaps in schema, vision input, a…

### DIFF
--- a/modelship/infer/base_infer.py
+++ b/modelship/infer/base_infer.py
@@ -275,6 +275,7 @@ class BaseInfer[Prepared](ABC):
                 return
             for event in translator.finish():
                 yield event
+            yield "data: [DONE]\n\n"
         finally:
             await chunks.aclose()
 

--- a/modelship/openai/protocol/responses/adapter.py
+++ b/modelship/openai/protocol/responses/adapter.py
@@ -163,7 +163,7 @@ def _messages_from_input(input_: str | list[dict[str, Any]], instructions: str |
             messages.append(
                 {
                     "role": item.get("role", "user"),
-                    "content": _text_of(item.get("content")),
+                    "content": _content_to_chat(item.get("content")),
                 }
             )
         else:
@@ -173,13 +173,53 @@ def _messages_from_input(input_: str | list[dict[str, Any]], instructions: str |
 
 
 def _text_of(content: Any) -> str | None:
-    """Reduce a Responses content value to plain text (Phase A is text-only)."""
+    """Reduce a Responses content value to plain text (used for tool-result content,
+    which is always text)."""
     if content is None or isinstance(content, str):
         return content
     if isinstance(content, list):
         parts = [p["text"] for p in content if isinstance(p, dict) and isinstance(p.get("text"), str)]
         return "".join(parts) if parts else None
     return str(content)
+
+
+_CONTENT_TEXT_TYPES = frozenset({"input_text", "output_text", "text"})
+_CONTENT_IMAGE_TYPES = frozenset({"input_image", "image_url"})
+
+
+def _content_to_chat(content: Any) -> str | list[dict[str, Any]] | None:
+    """Translate a Responses message ``content`` value into chat message content.
+
+    Unlike ``_text_of`` (tool-result text), a message's content can carry images —
+    dropping them here was silently discarding vision input. Text parts become chat's
+    ``{"type": "text", ...}`` shape; ``input_image`` becomes chat's ``image_url`` shape,
+    which ``normalize_chat_messages``/``_validate_part`` already fully validates
+    (``modelship.openai.utils.chat``). Unknown part types are rejected rather than
+    silently dropped.
+    """
+    if content is None or isinstance(content, str):
+        return content
+    if not isinstance(content, list):
+        return str(content)
+
+    parts: list[dict[str, Any]] = []
+    for p in content:
+        if not isinstance(p, dict):
+            raise UnsupportedResponsesFeatureError(f"unsupported content part {p!r}.")
+        ptype = p.get("type")
+        if ptype in _CONTENT_TEXT_TYPES:
+            parts.append({"type": "text", "text": p.get("text")})
+        elif ptype in _CONTENT_IMAGE_TYPES:
+            # Both the Responses `input_image` and chat's own `image_url` part types
+            # carry the URL/data-URI under an `image_url` key (string or {"url": ...}).
+            url = p.get("image_url")
+            parts.append({"type": "image_url", "image_url": {"url": url} if isinstance(url, str) else url})
+        else:
+            raise UnsupportedResponsesFeatureError(f"unsupported content part type {ptype!r}.")
+
+    if all(part["type"] == "text" for part in parts):
+        return "".join(part["text"] or "" for part in parts)
+    return parts
 
 
 def _tools_to_chat(tools: list[dict[str, Any]] | None) -> list[dict[str, Any]] | None:
@@ -243,6 +283,7 @@ def build_response_object(
     model: str | None = None,
     response_id: str | None = None,
     created_at: int | None = None,
+    completed_at: int | None = None,
     error: Any | None = None,
 ) -> ResponseObject:
     """Build a ``ResponseObject``, echoing the request settings OpenAI returns.
@@ -251,8 +292,10 @@ def build_response_object(
     ``response.created`` / ``response.completed`` envelopes and the
     non-streaming body carry an identical shape. ``response_id`` / ``created_at``
     let the streaming translator keep one stable id across all of its events.
-    ``error`` is set only for a ``status="failed"`` terminal event (see
-    ``ResponsesStreamTranslator.fail``); every other caller leaves it ``None``.
+    ``completed_at`` is only meaningful on a terminal (``completed``) envelope;
+    every other caller leaves it ``None``. ``error`` is set only for a
+    ``status="failed"`` terminal event (see ``ResponsesStreamTranslator.fail``);
+    every other caller leaves it ``None``.
     """
     kwargs: dict[str, Any] = {
         "model": model or request.model or "",
@@ -262,12 +305,14 @@ def build_response_object(
         "incomplete_details": incomplete,
         "instructions": request.instructions,
         "max_output_tokens": request.max_output_tokens,
-        "temperature": request.temperature,
-        "top_p": request.top_p,
-        "tools": request.tools or [],
+        # OpenAI reports the *effective* sampling values used, not a bare echo —
+        # these are its own defaults when the request left them unset.
+        "temperature": request.temperature if request.temperature is not None else 1.0,
+        "top_p": request.top_p if request.top_p is not None else 1.0,
+        "tools": _echo_tools(request.tools),
         "tool_choice": request.tool_choice if request.tool_choice is not None else "auto",
         "parallel_tool_calls": request.parallel_tool_calls if request.parallel_tool_calls is not None else True,
-        "text": request.text,
+        "text": request.text if request.text else {"format": {"type": "text"}},
         "reasoning": request.reasoning,
         "metadata": request.metadata or {},
         # OpenAI stores by default; only an explicit `store: false` opts out. The
@@ -280,9 +325,38 @@ def build_response_object(
         kwargs["id"] = response_id
     if created_at is not None:
         kwargs["created_at"] = created_at
+    if completed_at is not None:
+        kwargs["completed_at"] = completed_at
     if error is not None:
         kwargs["error"] = error
     return ResponseObject(**kwargs)
+
+
+def _echo_tools(tools: list[dict[str, Any]] | None) -> list[dict[str, Any]]:
+    """Backfill echoed ``tools[]`` so every ``FunctionTool`` carries all five spec keys.
+
+    Clients routinely omit optional keys (``description``/``parameters``/``strict``)
+    on the request; the spec requires them present (nullable) on the echo. Non-function
+    tool shapes are passed through untouched — the request side already rejects them
+    before a response is ever built, so this only defends against an unexpected shape.
+    """
+    if not tools:
+        return []
+    out: list[dict[str, Any]] = []
+    for tool in tools:
+        if tool.get("type") != "function":
+            out.append(tool)
+            continue
+        out.append(
+            {
+                "type": "function",
+                "name": tool.get("name"),
+                "description": tool.get("description"),
+                "parameters": tool.get("parameters"),
+                "strict": tool.get("strict"),
+            }
+        )
+    return out
 
 
 def _usage_from_chat(usage: UsageInfo) -> ResponseUsage:

--- a/modelship/openai/protocol/responses/adapter.py
+++ b/modelship/openai/protocol/responses/adapter.py
@@ -180,7 +180,7 @@ def _text_of(content: Any) -> str | None:
     if isinstance(content, list):
         parts = [p["text"] for p in content if isinstance(p, dict) and isinstance(p.get("text"), str)]
         return "".join(parts) if parts else None
-    return str(content)
+    raise UnsupportedResponsesFeatureError(f"unsupported content shape {content!r}.")
 
 
 _CONTENT_TEXT_TYPES = frozenset({"input_text", "output_text", "text"})
@@ -200,7 +200,7 @@ def _content_to_chat(content: Any) -> str | list[dict[str, Any]] | None:
     if content is None or isinstance(content, str):
         return content
     if not isinstance(content, list):
-        return str(content)
+        raise UnsupportedResponsesFeatureError(f"unsupported content shape {content!r}.")
 
     parts: list[dict[str, Any]] = []
     for p in content:

--- a/modelship/openai/protocol/responses/schemas.py
+++ b/modelship/openai/protocol/responses/schemas.py
@@ -14,7 +14,7 @@ so the adapter, not pydantic, owns the role/content/typed-item translation.
 import time
 from typing import Any, Literal
 
-from pydantic import Field
+from pydantic import Field, model_serializer
 
 from modelship.openai.protocol.base import OpenAIBaseModel, random_uuid
 
@@ -86,6 +86,15 @@ class ResponseReasoningItem(OpenAIBaseModel):
     content: list[ResponseReasoningText] = Field(default_factory=list)
     encrypted_content: str | None = None
 
+    @model_serializer(mode="wrap")
+    def _omit_unset_encrypted_content(self, handler: Any) -> dict[str, Any]:
+        # Spec types encrypted_content as a plain (non-nullable) string that's not
+        # required — the key must be absent, not null, when there's no value.
+        dumped = handler(self)
+        if dumped.get("encrypted_content") is None:
+            dumped.pop("encrypted_content", None)
+        return dumped
+
 
 class ResponseFunctionToolCall(OpenAIBaseModel):
     type: Literal["function_call"] = "function_call"
@@ -131,6 +140,7 @@ class ResponseObject(OpenAIBaseModel):
     id: str = Field(default_factory=lambda: f"resp_{random_uuid()}")
     object: Literal["response"] = "response"
     created_at: int = Field(default_factory=lambda: int(time.time()))
+    completed_at: int | None = None
     status: Literal["completed", "failed", "incomplete", "in_progress"] = "completed"
     model: str
     output: list[ResponseOutputItem] = Field(default_factory=list)
@@ -138,13 +148,22 @@ class ResponseObject(OpenAIBaseModel):
     # Echoed request settings (OpenAI returns these on the response object).
     instructions: str | None = None
     max_output_tokens: int | None = None
+    max_tool_calls: int | None = None
     temperature: float | None = None
     top_p: float | None = None
+    top_logprobs: int = 0
+    presence_penalty: float = 0.0
+    frequency_penalty: float = 0.0
     tools: list[dict[str, Any]] = Field(default_factory=list)
     tool_choice: str | dict[str, Any] = "auto"
     parallel_tool_calls: bool = True
     text: dict[str, Any] | None = None
     reasoning: dict[str, Any] | None = None
+    truncation: str = "disabled"
+    background: bool = False
+    service_tier: str = "default"
+    safety_identifier: str | None = None
+    prompt_cache_key: str | None = None
     metadata: dict[str, Any] = Field(default_factory=dict)
     previous_response_id: str | None = None
     store: bool = False

--- a/modelship/openai/protocol/responses/streaming.py
+++ b/modelship/openai/protocol/responses/streaming.py
@@ -32,6 +32,7 @@ cycle (that package imports this one).
 from __future__ import annotations
 
 import json
+import time
 from collections.abc import Iterator
 from typing import Any
 
@@ -128,7 +129,14 @@ class ResponsesStreamTranslator:
         return oi
 
     def _envelope(
-        self, event_type: str, status: str, output: list[Any], usage, incomplete, error: Any | None = None
+        self,
+        event_type: str,
+        status: str,
+        output: list[Any],
+        usage,
+        incomplete,
+        error: Any | None = None,
+        completed_at: int | None = None,
     ) -> str:
         response = build_response_object(
             self.request,
@@ -139,6 +147,7 @@ class ResponsesStreamTranslator:
             model=self.model,
             response_id=self.response_id,
             created_at=self.created_at,
+            completed_at=completed_at,
             error=error,
         )
         # Pin created_at after the first build so every envelope is identical.
@@ -190,7 +199,8 @@ class ResponsesStreamTranslator:
         status, incomplete = _status_for(self.finish_reason)
         usage = _usage_from_chat(self.usage) if self.usage is not None else None
         terminal = "response.incomplete" if status == "incomplete" else "response.completed"
-        yield self._envelope(terminal, status, output, usage, incomplete)
+        completed_at = int(time.time()) if status == "completed" else None
+        yield self._envelope(terminal, status, output, usage, incomplete, completed_at=completed_at)
 
     def fail(self, message: str) -> Iterator[str]:
         """Terminal ``response.failed`` event for a mid-stream error (a loader

--- a/modelship/openai/utils/responses.py
+++ b/modelship/openai/utils/responses.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 import json
 import re
+import time
 from http import HTTPStatus
 from typing import Any
 
@@ -91,6 +92,8 @@ def build_response_from_parsed(
         usage=_usage_from_chat(usage),
         incomplete=incomplete,
         model=model,
+        # Only a `completed` response is actually done; `incomplete`/`failed` aren't.
+        completed_at=int(time.time()) if status == "completed" else None,
     )
 
 

--- a/tests/test_responses_adapter.py
+++ b/tests/test_responses_adapter.py
@@ -8,7 +8,8 @@ from modelship.openai.protocol.responses import (
     UnsupportedResponsesFeatureError,
     responses_request_to_chat,
 )
-from modelship.openai.protocol.responses.adapter import build_response_object
+from modelship.openai.protocol.responses.adapter import _content_to_chat, build_response_object
+from modelship.openai.protocol.responses.schemas import ResponseReasoningItem
 
 
 def _req(**overrides) -> ResponsesRequest:
@@ -42,6 +43,33 @@ class TestRequestInputTranslation:
             )
         )
         assert chat.messages == [{"role": "user", "content": "ab"}]
+
+    def test_message_with_image_part_reaches_chat_as_image_url(self):
+        chat = responses_request_to_chat(
+            _req(
+                input=[
+                    {
+                        "type": "message",
+                        "role": "user",
+                        "content": [
+                            {"type": "input_text", "text": "what is this?"},
+                            {"type": "input_image", "image_url": "https://example.com/cat.png"},
+                        ],
+                    },
+                ]
+            )
+        )
+        content = chat.messages[0]["content"]
+        assert content == [
+            {"type": "text", "text": "what is this?"},
+            {"type": "image_url", "image_url": {"url": "https://example.com/cat.png"}},
+        ]
+
+    def test_unknown_content_part_type_rejected(self):
+        with pytest.raises(UnsupportedResponsesFeatureError, match="content part"):
+            responses_request_to_chat(
+                _req(input=[{"role": "user", "content": [{"type": "input_audio", "input_audio": {}}]}])
+            )
 
     def test_role_shorthand_without_type_is_a_message(self):
         chat = responses_request_to_chat(_req(input=[{"role": "user", "content": "yo"}]))
@@ -126,8 +154,8 @@ class TestResponseEnvelopeEcho:
     the same `store` field to decide whether to persist, so the response can't claim
     one thing while the store did another."""
 
-    def _build(self, request):
-        return build_response_object(request, status="completed", output=[], usage=None, incomplete=None)
+    def _build(self, request, **kwargs):
+        return build_response_object(request, status="completed", output=[], usage=None, incomplete=None, **kwargs)
 
     def test_store_defaults_to_true_when_unset(self):
         # OpenAI stores by default; a client that never sends the field still expects
@@ -145,6 +173,109 @@ class TestResponseEnvelopeEcho:
 
     def test_previous_response_id_absent_is_none(self):
         assert self._build(_req()).previous_response_id is None
+
+
+class TestResponseResourceRequiredFields:
+    """The Open Responses conformance suite validates against `ResponseResource`'s
+    required-field list; these were previously missing or sent as `null`."""
+
+    def _build(self, request, **kwargs):
+        return build_response_object(request, status="completed", output=[], usage=None, incomplete=None, **kwargs)
+
+    def test_static_defaults_for_previously_missing_fields(self):
+        dumped = self._build(_req()).model_dump(mode="json")
+        assert dumped["truncation"] == "disabled"
+        assert dumped["presence_penalty"] == 0.0
+        assert dumped["frequency_penalty"] == 0.0
+        assert dumped["top_logprobs"] == 0
+        assert dumped["max_tool_calls"] is None
+        assert dumped["background"] is False
+        assert dumped["service_tier"] == "default"
+        assert dumped["safety_identifier"] is None
+        assert dumped["prompt_cache_key"] is None
+
+    def test_temperature_and_top_p_resolve_to_openai_defaults_when_unset(self):
+        resp = self._build(_req())
+        assert resp.temperature == 1.0
+        assert resp.top_p == 1.0
+
+    def test_explicit_temperature_and_top_p_are_preserved(self):
+        resp = self._build(_req(temperature=0.2, top_p=0.5))
+        assert resp.temperature == 0.2
+        assert resp.top_p == 0.5
+
+    def test_text_defaults_to_plain_text_format_when_unset(self):
+        resp = self._build(_req())
+        assert resp.text == {"format": {"type": "text"}}
+
+    def test_explicit_text_is_preserved(self):
+        resp = self._build(_req(text={"format": {"type": "json_object"}}))
+        assert resp.text == {"format": {"type": "json_object"}}
+
+    def test_completed_at_absent_by_default(self):
+        assert self._build(_req()).completed_at is None
+
+    def test_completed_at_set_when_passed(self):
+        resp = self._build(_req(), completed_at=1234)
+        assert resp.completed_at == 1234
+
+
+class TestEchoedTools:
+    def _tools_on(self, request):
+        return build_response_object(request, status="completed", output=[], usage=None, incomplete=None).tools
+
+    def test_partial_tool_backfilled_with_all_five_keys(self):
+        tools = self._tools_on(_req(tools=[{"type": "function", "name": "f"}]))
+        assert tools == [{"type": "function", "name": "f", "description": None, "parameters": None, "strict": None}]
+
+    def test_fully_specified_tool_unchanged(self):
+        tool = {"type": "function", "name": "f", "description": "d", "parameters": {"type": "object"}, "strict": True}
+        assert self._tools_on(_req(tools=[tool])) == [tool]
+
+    def test_no_tools_echoes_empty_list(self):
+        assert self._tools_on(_req()) == []
+
+
+class TestReasoningItemSerialization:
+    def test_encrypted_content_omitted_when_unset(self):
+        dumped = ResponseReasoningItem().model_dump(mode="json")
+        assert "encrypted_content" not in dumped
+
+    def test_encrypted_content_present_when_set(self):
+        dumped = ResponseReasoningItem(encrypted_content="abc").model_dump(mode="json")
+        assert dumped["encrypted_content"] == "abc"
+
+
+class TestContentToChat:
+    def test_plain_string_passes_through(self):
+        assert _content_to_chat("hi") == "hi"
+
+    def test_none_passes_through(self):
+        assert _content_to_chat(None) is None
+
+    def test_text_only_parts_collapse_to_string(self):
+        assert _content_to_chat([{"type": "input_text", "text": "a"}, {"type": "text", "text": "b"}]) == "ab"
+
+    def test_image_part_produces_parts_list(self):
+        result = _content_to_chat([{"type": "input_image", "image_url": "https://x/y.png"}])
+        assert result == [{"type": "image_url", "image_url": {"url": "https://x/y.png"}}]
+
+    def test_mixed_text_and_image_produces_parts_list(self):
+        result = _content_to_chat(
+            [{"type": "input_text", "text": "look"}, {"type": "input_image", "image_url": "https://x/y.png"}]
+        )
+        assert result == [
+            {"type": "text", "text": "look"},
+            {"type": "image_url", "image_url": {"url": "https://x/y.png"}},
+        ]
+
+    def test_unknown_part_type_rejected(self):
+        with pytest.raises(UnsupportedResponsesFeatureError, match="content part type"):
+            _content_to_chat([{"type": "input_audio", "input_audio": {}}])
+
+    def test_non_dict_part_rejected(self):
+        with pytest.raises(UnsupportedResponsesFeatureError, match="content part"):
+            _content_to_chat(["oops"])
 
 
 class TestRequestRejections:

--- a/tests/test_responses_adapter.py
+++ b/tests/test_responses_adapter.py
@@ -102,6 +102,12 @@ class TestRequestInputTranslation:
         with pytest.raises(UnsupportedResponsesFeatureError, match="function_call_output"):
             responses_request_to_chat(_req(input=[{"type": "function_call_output", "output": "sunny"}]))
 
+    def test_function_call_output_with_non_text_output_rejected(self):
+        with pytest.raises(UnsupportedResponsesFeatureError, match="content shape"):
+            responses_request_to_chat(
+                _req(input=[{"type": "function_call_output", "call_id": "call_1", "output": {"bad": "shape"}}])
+            )
+
     def test_reasoning_input_item_is_dropped(self):
         chat = responses_request_to_chat(
             _req(
@@ -276,6 +282,10 @@ class TestContentToChat:
     def test_non_dict_part_rejected(self):
         with pytest.raises(UnsupportedResponsesFeatureError, match="content part"):
             _content_to_chat(["oops"])
+
+    def test_non_list_non_string_content_rejected(self):
+        with pytest.raises(UnsupportedResponsesFeatureError, match="content shape"):
+            _content_to_chat({"type": "input_text", "text": "not wrapped in a list"})
 
 
 class TestRequestRejections:

--- a/tests/test_responses_streaming.py
+++ b/tests/test_responses_streaming.py
@@ -125,6 +125,17 @@ class TestTextStream:
         assert resp["usage"]["input_tokens"] == 4
         assert resp["usage"]["output_tokens"] == 6
 
+    def test_completed_response_has_completed_at(self):
+        translator = ResponsesStreamTranslator(_req())
+        events = _events(translator, [_chunk(DeltaMessage(content="x"), finish_reason="stop")])
+        assert isinstance(events[-1]["response"]["completed_at"], int)
+
+    def test_created_and_in_progress_envelopes_have_no_completed_at(self):
+        translator = ResponsesStreamTranslator(_req())
+        events = _events(translator, [_chunk(DeltaMessage(content="x"), finish_reason="stop")])
+        assert events[0]["response"]["completed_at"] is None
+        assert events[1]["response"]["completed_at"] is None
+
     def test_item_id_is_stable_across_events(self):
         translator = ResponsesStreamTranslator(_req())
         events = _events(translator, [_chunk(DeltaMessage(content="x"), finish_reason="stop")])
@@ -227,6 +238,8 @@ class TestTerminalStatus:
         assert events[-1]["type"] == "response.incomplete"
         assert events[-1]["response"]["status"] == "incomplete"
         assert events[-1]["response"]["incomplete_details"] == {"reason": "max_output_tokens"}
+        # incomplete isn't "done" — completed_at stays unset.
+        assert events[-1]["response"]["completed_at"] is None
 
     def test_content_filter_finish_reason_is_incomplete(self):
         translator = ResponsesStreamTranslator(_req())

--- a/tests/test_responses_utils.py
+++ b/tests/test_responses_utils.py
@@ -1,8 +1,8 @@
 """Tests for modelship.openai.utils.responses's parsed-output shaping."""
 
-from modelship.openai.protocol import FunctionCall, ToolCall
+from modelship.openai.protocol import FunctionCall, ResponsesRequest, ToolCall, UsageInfo
 from modelship.openai.utils.chat import ParsedChatOutput
-from modelship.openai.utils.responses import build_responses_items_from_parsed
+from modelship.openai.utils.responses import build_response_from_parsed, build_responses_items_from_parsed
 
 
 def test_build_responses_items_from_parsed_orders_reasoning_message_tools():
@@ -26,3 +26,27 @@ def test_build_responses_items_from_parsed_skips_empty_fields():
     parsed = ParsedChatOutput(content=None, reasoning=None, tool_calls=[])
 
     assert build_responses_items_from_parsed(parsed) == []
+
+
+def _usage() -> UsageInfo:
+    return UsageInfo(prompt_tokens=1, completion_tokens=2, total_tokens=3)
+
+
+def test_build_response_from_parsed_sets_completed_at_when_completed():
+    request = ResponsesRequest(model="m", input="hi")
+    parsed = ParsedChatOutput(content="hi", reasoning=None, tool_calls=[])
+
+    resp = build_response_from_parsed(parsed, request, usage=_usage(), finish_reason="stop", model="m")
+
+    assert resp.status == "completed"
+    assert isinstance(resp.completed_at, int)
+
+
+def test_build_response_from_parsed_leaves_completed_at_none_when_incomplete():
+    request = ResponsesRequest(model="m", input="hi")
+    parsed = ParsedChatOutput(content="hi", reasoning=None, tool_calls=[])
+
+    resp = build_response_from_parsed(parsed, request, usage=_usage(), finish_reason="length", model="m")
+
+    assert resp.status == "incomplete"
+    assert resp.completed_at is None

--- a/tests/test_vllm_responses.py
+++ b/tests/test_vllm_responses.py
@@ -127,6 +127,7 @@ async def test_stream_success_produces_native_responses_events():
     assert "event: response.created" in body
     assert "event: response.output_text.delta" in body
     assert "event: response.completed" in body
+    assert body.endswith("data: [DONE]\n\n")
 
 
 @pytest.mark.asyncio
@@ -149,3 +150,6 @@ async def test_stream_mid_stream_exception_emits_failed_event():
 
     assert "event: response.failed" in body
     assert "event: response.completed" not in body
+    # A failed stream still terminates the SSE connection on its own; no [DONE]
+    # sentinel follows (that's only emitted on the clean-finish path).
+    assert "[DONE]" not in body


### PR DESCRIPTION
…nd SSE termination

Vision content parts (input_image) in Responses message input were silently dropped in translation to chat messages; adds required ResponseObject fields (completed_at, truncation, service_tier, etc.) with spec-correct defaults, backfills echoed tools/text/temperature/top_p to match OpenAI's effective values, omits encrypted_content when unset, and emits the SSE [DONE] sentinel on clean stream completion.

