### PR TITLE
feat: add /v1/responses/compact endpoint

### DIFF
--- a/modelship/openai/api.py
+++ b/modelship/openai/api.py
@@ -36,6 +36,7 @@ from modelship.openai.auth import ApiKeyMiddleware, get_api_keys, resolve_identi
 from modelship.openai.protocol import (
     ChatCompletionRequest,
     ChatCompletionResponse,
+    CompactRequest,
     EmbeddingRequest,
     EmbeddingResponse,
     ErrorResponse,
@@ -53,6 +54,7 @@ from modelship.openai.protocol import (
     TranslationResponse,
     create_error_response,
 )
+from modelship.openai.protocol.responses.adapter import UnsupportedResponsesFeatureError
 from modelship.openai.utils import responses as responses_utils
 from modelship.state import get_state_store
 from modelship.utils import random_uuid
@@ -383,6 +385,34 @@ class ModelshipAPI:
         self._round_robin[model_name] += 1
         return handles[idx]
 
+    async def _await_first(self, response_gen, model: str, endpoint: str):
+        """Await *response_gen*'s first item, translating a Ray-boundary failure into
+        a clean 4xx/5xx ``JSONResponse``. Shared by ``_handle_response`` and
+        ``compact_response`` — a caller must check ``isinstance(result, JSONResponse)``
+        before treating the result as a payload item."""
+        try:
+            return await response_gen.__anext__()
+        except RayTaskError as e:
+            # Loader code raised across the Ray boundary. Treat ValueError-family
+            # causes (e.g. vLLM's VLLMValidationError on context overflow) as
+            # OpenAI-style 400s rather than masking them as 500s.
+            cause = e.cause if isinstance(e.cause, BaseException) else None
+            if isinstance(cause, ValueError | TypeError | OverflowError):
+                REQUEST_ERRORS_TOTAL.inc(tags={"model": model, "endpoint": endpoint, "error_type": "validation_error"})
+                REQUEST_TOTAL.inc(tags={"model": model, "endpoint": endpoint, "status": "error"})
+                logger.info("Validation error for model=%s: %s", model, cause)
+                return _error_response(_validation_error_from_cause(cause))
+            REQUEST_ERRORS_TOTAL.inc(tags={"model": model, "endpoint": endpoint, "error_type": "unhandled"})
+            REQUEST_TOTAL.inc(tags={"model": model, "endpoint": endpoint, "status": "error"})
+            logger.exception("Initial response generation failed for model=%s", model)
+            return JSONResponse(status_code=500, content={"detail": str(e)})
+        except Exception as e:
+            # Catch failures during initial generator creation or the very first yield
+            REQUEST_ERRORS_TOTAL.inc(tags={"model": model, "endpoint": endpoint, "error_type": "unhandled"})
+            REQUEST_TOTAL.inc(tags={"model": model, "endpoint": endpoint, "status": "error"})
+            logger.exception("Initial response generation failed for model=%s", model)
+            return JSONResponse(status_code=500, content={"detail": str(e)})
+
     async def _handle_response(
         self,
         response_gen,
@@ -395,30 +425,9 @@ class ModelshipAPI:
         streaming = False
         REQUEST_IN_PROGRESS.set(1, tags={"model": model, "endpoint": endpoint})
         try:
-            try:
-                first = await response_gen.__anext__()
-            except RayTaskError as e:
-                # Loader code raised across the Ray boundary. Treat ValueError-family
-                # causes (e.g. vLLM's VLLMValidationError on context overflow) as
-                # OpenAI-style 400s rather than masking them as 500s.
-                cause = e.cause if isinstance(e.cause, BaseException) else None
-                if isinstance(cause, ValueError | TypeError | OverflowError):
-                    REQUEST_ERRORS_TOTAL.inc(
-                        tags={"model": model, "endpoint": endpoint, "error_type": "validation_error"}
-                    )
-                    REQUEST_TOTAL.inc(tags={"model": model, "endpoint": endpoint, "status": "error"})
-                    logger.info("Validation error for model=%s: %s", model, cause)
-                    return _error_response(_validation_error_from_cause(cause))
-                REQUEST_ERRORS_TOTAL.inc(tags={"model": model, "endpoint": endpoint, "error_type": "unhandled"})
-                REQUEST_TOTAL.inc(tags={"model": model, "endpoint": endpoint, "status": "error"})
-                logger.exception("Initial response generation failed for model=%s", model)
-                return JSONResponse(status_code=500, content={"detail": str(e)})
-            except Exception as e:
-                # Catch failures during initial generator creation or the very first yield
-                REQUEST_ERRORS_TOTAL.inc(tags={"model": model, "endpoint": endpoint, "error_type": "unhandled"})
-                REQUEST_TOTAL.inc(tags={"model": model, "endpoint": endpoint, "status": "error"})
-                logger.exception("Initial response generation failed for model=%s", model)
-                return JSONResponse(status_code=500, content={"detail": str(e)})
+            first = await self._await_first(response_gen, model, endpoint)
+            if isinstance(first, JSONResponse):
+                return first
 
             if isinstance(first, ErrorResponse):
                 REQUEST_ERRORS_TOTAL.inc(tags={"model": model, "endpoint": endpoint, "error_type": "inference_error"})
@@ -639,6 +648,67 @@ class ModelshipAPI:
                 "has_more": False,
             }
         )
+
+    @app.post("/v1/responses/compact")
+    async def compact_response(self, request: CompactRequest, raw_request: Request):
+        req_id = random_uuid()
+        self._set_request_id(req_id)
+        identity = self._set_identity(raw_request)
+        model = request.model
+        endpoint = "compact_response"
+        handle = self._get_handle(model)
+        watcher = RequestWatcher(raw_request, req_id, model=model, endpoint=endpoint)
+        headers = dict(raw_request.headers)
+
+        start = time.monotonic()
+        REQUEST_IN_PROGRESS.set(1, tags={"model": model, "endpoint": endpoint})
+        try:
+            items = await responses_utils.resolve_history_items(
+                self._state_store,
+                identity,
+                previous_response_id=request.previous_response_id,
+                input_=request.input,
+            )
+            if not items:
+                raise HTTPException(
+                    status_code=HTTPStatus.BAD_REQUEST.value, detail="cannot compact an empty conversation."
+                )
+
+            logger.info(
+                "compact_response model=%s previous_response_id=%s items=%d",
+                model,
+                request.previous_response_id,
+                len(items),
+            )
+
+            try:
+                chat_request = responses_utils.build_summarization_request(model, items)
+            except UnsupportedResponsesFeatureError as e:
+                REQUEST_ERRORS_TOTAL.inc(tags={"model": model, "endpoint": endpoint, "error_type": "validation_error"})
+                REQUEST_TOTAL.inc(tags={"model": model, "endpoint": endpoint, "status": "error"})
+                return _error_response(create_error_response(str(e), err_type="invalid_request_error"))
+
+            response_gen = handle.generate.options(stream=True).remote(
+                chat_request, headers, watcher.registry, req_id, identity
+            )
+            first = await self._await_first(response_gen, model, endpoint)
+            if isinstance(first, JSONResponse):
+                return first
+            if isinstance(first, ErrorResponse):
+                REQUEST_ERRORS_TOTAL.inc(tags={"model": model, "endpoint": endpoint, "error_type": "inference_error"})
+                REQUEST_TOTAL.inc(tags={"model": model, "endpoint": endpoint, "status": "error"})
+                return _error_response(first)
+
+            assert isinstance(first, ChatCompletionResponse)
+            summary_text = first.choices[0].message.content or ""
+            summary_items = [{"type": "message", "role": "assistant", "content": summary_text}]
+            resource = responses_utils.build_compaction(summary_items=summary_items, usage=first.usage)
+            REQUEST_TOTAL.inc(tags={"model": model, "endpoint": endpoint, "status": "ok"})
+            return JSONResponse(content=resource.model_dump(mode="json"))
+        finally:
+            REQUEST_DURATION_SECONDS.observe(time.monotonic() - start, tags={"model": model, "endpoint": endpoint})
+            REQUEST_IN_PROGRESS.set(0, tags={"model": model, "endpoint": endpoint})
+            watcher.stop()
 
     @app.post("/v1/embeddings")
     async def create_embeddings(self, request: EmbeddingRequest, raw_request: Request):

--- a/modelship/openai/api.py
+++ b/modelship/openai/api.py
@@ -682,7 +682,7 @@ class ModelshipAPI:
             )
 
             try:
-                chat_request = responses_utils.build_summarization_request(model, items)
+                chat_request = responses_utils.build_summarization_request(model, items, request.instructions)
             except UnsupportedResponsesFeatureError as e:
                 REQUEST_ERRORS_TOTAL.inc(tags={"model": model, "endpoint": endpoint, "error_type": "validation_error"})
                 REQUEST_TOTAL.inc(tags={"model": model, "endpoint": endpoint, "status": "error"})

--- a/modelship/openai/compaction_crypto.py
+++ b/modelship/openai/compaction_crypto.py
@@ -1,0 +1,77 @@
+"""Symmetric encryption for ``/v1/responses/compact``'s ``encrypted_content`` blobs.
+
+The compact endpoint returns an opaque, server-produced string that the client
+later replays verbatim as input — nothing about its format is spec'd or tested
+(see the compaction plan). This is one legitimate implementation: real Fernet
+encryption, so the blob is genuinely opaque to whoever holds it and tampering
+is detected rather than silently decoded.
+
+Key resolution is lazy (only at encrypt/decrypt time) so importing the gateway
+without ``MSHIP_COMPACTION_KEY`` set never fails on its own — only a missing key
+at first use does, via a loud warning and an ephemeral per-process fallback.
+That fallback only works single-replica / within one process lifetime: a
+multi-gateway deployment MUST set the same key on every replica, or a blob
+minted on one replica won't decode on another (see ``MSHIP_RESPONSES_TTL_S``
+for the analogous conversation-state sharp edge).
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from typing import Any
+
+from cryptography.fernet import Fernet, InvalidToken
+
+from modelship.logging import get_logger
+
+logger = get_logger("compaction_crypto")
+
+_KEY_ENV = "MSHIP_COMPACTION_KEY"
+
+_ephemeral_key: bytes | None = None
+
+__all__ = ["InvalidToken", "decrypt_items", "encrypt_items"]
+
+
+def _resolve_key() -> bytes:
+    configured = os.environ.get(_KEY_ENV)
+    if configured:
+        return configured.encode("ascii")
+
+    global _ephemeral_key
+    if _ephemeral_key is None:
+        _ephemeral_key = Fernet.generate_key()
+        logger.warning(
+            "%s is not set; using an ephemeral per-process compaction key. Compaction "
+            "blobs will not decode after a gateway restart or on a different replica. "
+            "Set %s (the same value on every replica) for production use.",
+            _KEY_ENV,
+            _KEY_ENV,
+        )
+    return _ephemeral_key
+
+
+def encrypt_items(items: list[Any]) -> str:
+    """Encrypt *items* (a list of Responses input items) into an opaque string."""
+    fernet = Fernet(_resolve_key())
+    plaintext = json.dumps(items).encode("utf-8")
+    return fernet.encrypt(plaintext).decode("ascii")
+
+
+def decrypt_items(blob: str) -> list[Any]:
+    """Inverse of :func:`encrypt_items`.
+
+    Raises :class:`InvalidToken` for a tampered blob, a blob encrypted under a
+    different key, or malformed JSON — callers must map all three to the same
+    clean 400 without revealing which it was.
+    """
+    fernet = Fernet(_resolve_key())
+    plaintext = fernet.decrypt(blob.encode("ascii"))
+    try:
+        items = json.loads(plaintext)
+    except json.JSONDecodeError:
+        raise InvalidToken from None
+    if not isinstance(items, list):
+        raise InvalidToken
+    return items

--- a/modelship/openai/compaction_crypto.py
+++ b/modelship/openai/compaction_crypto.py
@@ -37,7 +37,12 @@ __all__ = ["InvalidToken", "decrypt_items", "encrypt_items"]
 def _resolve_key() -> bytes:
     configured = os.environ.get(_KEY_ENV)
     if configured:
-        return configured.encode("ascii")
+        key = configured.encode("ascii")
+        try:
+            Fernet(key)  # validate eagerly so a bad key fails fast, not mid-request
+        except ValueError as e:
+            raise ValueError(f"{_KEY_ENV} is not a valid Fernet key: {e}") from e
+        return key
 
     global _ephemeral_key
     if _ephemeral_key is None:
@@ -63,11 +68,15 @@ def decrypt_items(blob: str) -> list[Any]:
     """Inverse of :func:`encrypt_items`.
 
     Raises :class:`InvalidToken` for a tampered blob, a blob encrypted under a
-    different key, or malformed JSON — callers must map all three to the same
-    clean 400 without revealing which it was.
+    different key, non-ASCII content, or malformed JSON — callers must map all of
+    these to the same clean 400 without revealing which it was.
     """
     fernet = Fernet(_resolve_key())
-    plaintext = fernet.decrypt(blob.encode("ascii"))
+    try:
+        raw = blob.encode("ascii")
+    except UnicodeEncodeError:
+        raise InvalidToken from None
+    plaintext = fernet.decrypt(raw)
     try:
         items = json.loads(plaintext)
     except json.JSONDecodeError:

--- a/modelship/openai/protocol/__init__.py
+++ b/modelship/openai/protocol/__init__.py
@@ -72,6 +72,9 @@ from modelship.openai.protocol.raw import (
     RawTranslation,
 )
 from modelship.openai.protocol.responses import (
+    CompactionItem,
+    CompactRequest,
+    CompactResource,
     ResponseFunctionToolCall,
     ResponseInputItem,
     ResponseInputTokensDetails,
@@ -100,6 +103,9 @@ __all__ = [
     "ChatCompletionResponseStreamChoice",
     "ChatCompletionStreamResponse",
     "ChatMessage",
+    "CompactRequest",
+    "CompactResource",
+    "CompactionItem",
     "CompletionTokenUsageInfo",
     "DeltaFunctionCall",
     "DeltaMessage",

--- a/modelship/openai/protocol/responses/__init__.py
+++ b/modelship/openai/protocol/responses/__init__.py
@@ -21,6 +21,9 @@ from modelship.openai.protocol.responses.adapter import (
     responses_request_to_chat,
 )
 from modelship.openai.protocol.responses.schemas import (
+    CompactionItem,
+    CompactRequest,
+    CompactResource,
     ResponseFunctionToolCall,
     ResponseInputItem,
     ResponseInputTokensDetails,
@@ -43,6 +46,9 @@ from modelship.openai.protocol.responses.streaming import (
 
 __all__ = [
     "TERMINAL_EVENT_TYPES",
+    "CompactRequest",
+    "CompactResource",
+    "CompactionItem",
     "ResponseFunctionToolCall",
     "ResponseInputItem",
     "ResponseInputTokensDetails",

--- a/modelship/openai/protocol/responses/adapter.py
+++ b/modelship/openai/protocol/responses/adapter.py
@@ -25,6 +25,9 @@ from __future__ import annotations
 
 from typing import Any, Literal
 
+from cryptography.fernet import InvalidToken
+
+from modelship.openai import compaction_crypto
 from modelship.openai.protocol.chat import ChatCompletionRequest, StreamOptions
 from modelship.openai.protocol.responses.schemas import (
     ResponseInputTokensDetails,
@@ -64,7 +67,7 @@ def responses_request_to_chat(request: ResponsesRequest) -> ChatCompletionReques
     if request.background:
         raise UnsupportedResponsesFeatureError("background mode is not supported on /v1/responses.")
 
-    messages = _messages_from_input(request.input, request.instructions)
+    messages = messages_from_input(request.input, request.instructions)
 
     kwargs: dict[str, Any] = {
         "model": request.model,
@@ -106,7 +109,7 @@ def responses_request_to_chat(request: ResponsesRequest) -> ChatCompletionReques
     return ChatCompletionRequest(**kwargs)
 
 
-def _messages_from_input(input_: str | list[dict[str, Any]], instructions: str | None) -> list[dict[str, Any]]:
+def messages_from_input(input_: str | list[dict[str, Any]], instructions: str | None) -> list[dict[str, Any]]:
     messages: list[dict[str, Any]] = []
     if instructions:
         messages.append({"role": "system", "content": instructions})
@@ -159,6 +162,18 @@ def _messages_from_input(input_: str | list[dict[str, Any]], instructions: str |
         elif itype == "reasoning":
             # Don't replay raw chain-of-thought back into the prompt.
             continue
+        elif itype == "compaction":
+            # Round-trip half of /v1/responses/compact: the blob is opaque to the
+            # client, decrypted back into the items it was built from. Recursion is
+            # bounded — a compaction blob never contains another compaction item.
+            encrypted_content = item.get("encrypted_content")
+            if not encrypted_content:
+                raise UnsupportedResponsesFeatureError("compaction input items require 'encrypted_content'.")
+            try:
+                decoded_items = compaction_crypto.decrypt_items(encrypted_content)
+            except InvalidToken:
+                raise UnsupportedResponsesFeatureError("compaction item could not be decoded.") from None
+            messages.extend(messages_from_input(decoded_items, None))
         elif itype == "message" or "role" in item:
             messages.append(
                 {

--- a/modelship/openai/protocol/responses/adapter.py
+++ b/modelship/openai/protocol/responses/adapter.py
@@ -164,8 +164,12 @@ def messages_from_input(input_: str | list[dict[str, Any]], instructions: str | 
             continue
         elif itype == "compaction":
             # Round-trip half of /v1/responses/compact: the blob is opaque to the
-            # client, decrypted back into the items it was built from. Recursion is
-            # bounded — a compaction blob never contains another compaction item.
+            # client, decrypted back into the items it was built from. A blob we mint
+            # ourselves (build_compaction) never nests another compaction item — but
+            # that's an invariant of our own code, not something the crypto layer
+            # enforces, so a forged or future-buggy blob must not be able to recurse
+            # unboundedly. Reject a nested compaction item explicitly instead of
+            # trusting the invariant.
             encrypted_content = item.get("encrypted_content")
             if not encrypted_content:
                 raise UnsupportedResponsesFeatureError("compaction input items require 'encrypted_content'.")
@@ -173,6 +177,8 @@ def messages_from_input(input_: str | list[dict[str, Any]], instructions: str | 
                 decoded_items = compaction_crypto.decrypt_items(encrypted_content)
             except InvalidToken:
                 raise UnsupportedResponsesFeatureError("compaction item could not be decoded.") from None
+            if any(isinstance(d, dict) and d.get("type") == "compaction" for d in decoded_items):
+                raise UnsupportedResponsesFeatureError("compaction items cannot nest another compaction item.")
             messages.extend(messages_from_input(decoded_items, None))
         elif itype == "message" or "role" in item:
             messages.append(

--- a/modelship/openai/protocol/responses/adapter.py
+++ b/modelship/openai/protocol/responses/adapter.py
@@ -1,24 +1,9 @@
-"""Translation between the Responses API and chat completions.
+"""Translation between the Responses API and chat completions: request-side shaping
+(``responses_request_to_chat``) plus the response-envelope helpers every loader's
+native ``create_response`` and the streaming translator share.
 
-:func:`responses_request_to_chat` — ``ResponsesRequest`` → ``ChatCompletionRequest``.
-Translates the structurally different bits (``input``/``instructions`` →
-``messages``, flattened tools → nested, ``text.format`` → ``response_format``,
-``max_output_tokens`` → ``max_completion_tokens``) and rejects features not yet
-supported (``background``, hosted built-in tools) with an explicit error rather
-than dropping them silently. Every loader's
-``create_response`` calls into this for the request side; ``vllm``/``llama_server``
-then shape the response natively from their own parsed output rather than going
-back through a chat-completion object (see ``utils.responses.build_responses_items_from_parsed``)
-— ``build_response_object``/``_usage_from_chat``/``_status_for`` below are the shared
-envelope helpers both that native path and the streaming translator build on.
-
-``store`` and ``previous_response_id`` are acted on by the gateway (it persists the
-snapshot and resolves the history); here they are echoed onto the response object
-only. Image/audio input parts are reduced to their text for now.
-
-Imports come from the sibling ``schemas`` submodule and the ``chat`` submodule,
-never from the top-level ``modelship.openai.protocol`` package — that package
-imports this one, so reaching back into it would create an import cycle.
+Never import from the top-level ``modelship.openai.protocol`` package here — it
+imports this module, so that would be a cycle.
 """
 
 from __future__ import annotations
@@ -40,11 +25,7 @@ from modelship.openai.protocol.usage import UsageInfo
 
 
 class UnsupportedResponsesFeatureError(ValueError):
-    """A Responses request used a feature that is not supported.
-
-    Subclasses ``ValueError`` so ``create_error_response`` maps it to an
-    OpenAI-style 400 ``invalid_request_error``.
-    """
+    """Unsupported Responses feature; subclasses ``ValueError`` so ``create_error_response`` maps it to a 400."""
 
 
 # ---------------------------------------------------------------------------
@@ -55,14 +36,9 @@ class UnsupportedResponsesFeatureError(ValueError):
 def responses_request_to_chat(request: ResponsesRequest) -> ChatCompletionRequest:
     """Translate a ``ResponsesRequest`` into a ``ChatCompletionRequest``.
 
-    ``previous_response_id`` is **already resolved** by the time this runs: the
-    gateway looks the prior snapshot up and prepends its items to ``input`` before
-    the Ray hop, so the field survives here only to be echoed on the response. This
-    contract can't be checked from inside the loader — it holds because
-    ``ModelDeployment`` is reachable only via the gateway, never over HTTP.
-
-    Raises :class:`UnsupportedResponsesFeatureError` for background/hosted-tool
-    features the adapter cannot fulfill.
+    ``previous_response_id`` is already resolved into ``input`` by the gateway before
+    the Ray hop; it survives here only to be echoed back. Raises
+    :class:`UnsupportedResponsesFeatureError` for features the adapter can't fulfill.
     """
     if request.background:
         raise UnsupportedResponsesFeatureError("background mode is not supported on /v1/responses.")
@@ -75,10 +51,8 @@ def responses_request_to_chat(request: ResponsesRequest) -> ChatCompletionReques
         "stream": bool(request.stream),
     }
     if request.stream:
-        # Responses always reports usage on the final event; the streaming
-        # translator only gets a usage-bearing chunk out of the chat pipeline
-        # when this is set (see engine_ops.stream_chat_completion). ChatCompletionRequest
-        # rejects stream_options when stream=False, so this must stay conditional.
+        # Needed for the streaming translator to get a usage-bearing final chunk; only
+        # legal when stream=True, so this must stay conditional.
         kwargs["stream_options"] = StreamOptions(include_usage=True)
     if request.max_output_tokens is not None:
         kwargs["max_completion_tokens"] = request.max_output_tokens
@@ -121,9 +95,7 @@ def messages_from_input(input_: str | list[dict[str, Any]], instructions: str | 
     for item in input_:
         itype = item.get("type")
         if itype == "function_call":
-            # A prior assistant tool call being replayed as context. call_id and
-            # name identify the call; without them the loader's chat-template /
-            # tool-call handling fails downstream, so reject up front with a 400.
+            # call_id and name identify the call; both required or downstream tool-call handling breaks.
             call_id = item.get("call_id") or item.get("id")
             name = item.get("name")
             if not call_id or not name:
@@ -147,8 +119,7 @@ def messages_from_input(input_: str | list[dict[str, Any]], instructions: str | 
                 }
             )
         elif itype == "function_call_output":
-            # call_id ties the result back to its call; a missing one can't be
-            # associated, so reject rather than emit a tool message with no id.
+            # call_id ties the result back to its call; required.
             call_id = item.get("call_id")
             if not call_id:
                 raise UnsupportedResponsesFeatureError("function_call_output input items require 'call_id'.")
@@ -163,13 +134,9 @@ def messages_from_input(input_: str | list[dict[str, Any]], instructions: str | 
             # Don't replay raw chain-of-thought back into the prompt.
             continue
         elif itype == "compaction":
-            # Round-trip half of /v1/responses/compact: the blob is opaque to the
-            # client, decrypted back into the items it was built from. A blob we mint
-            # ourselves (build_compaction) never nests another compaction item — but
-            # that's an invariant of our own code, not something the crypto layer
-            # enforces, so a forged or future-buggy blob must not be able to recurse
-            # unboundedly. Reject a nested compaction item explicitly instead of
-            # trusting the invariant.
+            # Round-trip half of /v1/responses/compact: decrypt the opaque blob back
+            # into the items it was built from. Nesting is rejected below rather than
+            # trusted, since the crypto layer can't tell a forged blob from a real one.
             encrypted_content = item.get("encrypted_content")
             if not encrypted_content:
                 raise UnsupportedResponsesFeatureError("compaction input items require 'encrypted_content'.")
@@ -194,8 +161,7 @@ def messages_from_input(input_: str | list[dict[str, Any]], instructions: str | 
 
 
 def _text_of(content: Any) -> str | None:
-    """Reduce a Responses content value to plain text (used for tool-result content,
-    which is always text)."""
+    """Reduce a Responses content value to plain text (tool-result content, always text)."""
     if content is None or isinstance(content, str):
         return content
     if isinstance(content, list):
@@ -211,12 +177,8 @@ _CONTENT_IMAGE_TYPES = frozenset({"input_image", "image_url"})
 def _content_to_chat(content: Any) -> str | list[dict[str, Any]] | None:
     """Translate a Responses message ``content`` value into chat message content.
 
-    Unlike ``_text_of`` (tool-result text), a message's content can carry images —
-    dropping them here was silently discarding vision input. Text parts become chat's
-    ``{"type": "text", ...}`` shape; ``input_image`` becomes chat's ``image_url`` shape,
-    which ``normalize_chat_messages``/``_validate_part`` already fully validates
-    (``modelship.openai.utils.chat``). Unknown part types are rejected rather than
-    silently dropped.
+    Unlike ``_text_of``, this preserves images: ``input_image`` becomes chat's
+    ``image_url`` shape. Unknown part types are rejected rather than dropped.
     """
     if content is None or isinstance(content, str):
         return content
@@ -231,8 +193,7 @@ def _content_to_chat(content: Any) -> str | list[dict[str, Any]] | None:
         if ptype in _CONTENT_TEXT_TYPES:
             parts.append({"type": "text", "text": p.get("text")})
         elif ptype in _CONTENT_IMAGE_TYPES:
-            # Both the Responses `input_image` and chat's own `image_url` part types
-            # carry the URL/data-URI under an `image_url` key (string or {"url": ...}).
+            # Both part types carry the URL/data-URI under `image_url` (string or {"url": ...}).
             url = p.get("image_url")
             parts.append({"type": "image_url", "image_url": {"url": url} if isinstance(url, str) else url})
         else:
@@ -309,14 +270,9 @@ def build_response_object(
 ) -> ResponseObject:
     """Build a ``ResponseObject``, echoing the request settings OpenAI returns.
 
-    Shared by the non-streaming adapter and the streaming translator so the
-    ``response.created`` / ``response.completed`` envelopes and the
-    non-streaming body carry an identical shape. ``response_id`` / ``created_at``
-    let the streaming translator keep one stable id across all of its events.
-    ``completed_at`` is only meaningful on a terminal (``completed``) envelope;
-    every other caller leaves it ``None``. ``error`` is set only for a
-    ``status="failed"`` terminal event (see ``ResponsesStreamTranslator.fail``);
-    every other caller leaves it ``None``.
+    Shared by the non-streaming adapter and the streaming translator so both produce
+    an identical envelope shape. ``response_id``/``created_at`` let streaming keep one
+    stable id across events; ``completed_at``/``error`` apply only to terminal events.
     """
     kwargs: dict[str, Any] = {
         "model": model or request.model or "",
@@ -326,8 +282,7 @@ def build_response_object(
         "incomplete_details": incomplete,
         "instructions": request.instructions,
         "max_output_tokens": request.max_output_tokens,
-        # OpenAI reports the *effective* sampling values used, not a bare echo —
-        # these are its own defaults when the request left them unset.
+        # Effective values, not a bare echo: OpenAI's own defaults when unset.
         "temperature": request.temperature if request.temperature is not None else 1.0,
         "top_p": request.top_p if request.top_p is not None else 1.0,
         "tools": _echo_tools(request.tools),
@@ -336,9 +291,7 @@ def build_response_object(
         "text": request.text if request.text else {"format": {"type": "text"}},
         "reasoning": request.reasoning,
         "metadata": request.metadata or {},
-        # OpenAI stores by default; only an explicit `store: false` opts out. The
-        # gateway reads the same field to decide whether to persist, so what the
-        # response claims and what was actually stored cannot drift.
+        # OpenAI stores by default; only an explicit `store: false` opts out.
         "store": request.store is not False,
         "previous_response_id": request.previous_response_id,
     }
@@ -354,13 +307,8 @@ def build_response_object(
 
 
 def _echo_tools(tools: list[dict[str, Any]] | None) -> list[dict[str, Any]]:
-    """Backfill echoed ``tools[]`` so every ``FunctionTool`` carries all five spec keys.
-
-    Clients routinely omit optional keys (``description``/``parameters``/``strict``)
-    on the request; the spec requires them present (nullable) on the echo. Non-function
-    tool shapes are passed through untouched — the request side already rejects them
-    before a response is ever built, so this only defends against an unexpected shape.
-    """
+    """Backfill echoed ``tools[]`` so every ``FunctionTool`` carries all five spec keys
+    (the request may omit optional ones, but the echo requires them present, nullable)."""
     if not tools:
         return []
     out: list[dict[str, Any]] = []
@@ -381,14 +329,9 @@ def _echo_tools(tools: list[dict[str, Any]] | None) -> list[dict[str, Any]]:
 
 
 def _usage_from_chat(usage: UsageInfo) -> ResponseUsage:
-    """Remap chat usage to Responses usage, preserving token details.
-
-    ``cached_tokens`` / ``reasoning_tokens`` are surfaced by vLLM (prefix
-    caching / reasoning models) under the OpenAI-standard ``prompt_tokens_details``
-    / ``completion_tokens_details``. Responses uses the same sub-field names, so
-    this is a direct field-to-field copy; loaders that report no details
-    (llama_server/transformers) leave them at the zero default.
-    """
+    """Remap chat usage to Responses usage; a direct field copy since both use the same
+    ``cached_tokens``/``reasoning_tokens`` sub-field names. Loaders reporting no details
+    leave them at the zero default."""
     prompt_details = usage.prompt_tokens_details
     completion_details = usage.completion_tokens_details
     return ResponseUsage(
@@ -408,8 +351,6 @@ def _status_for(
     finish_reason: str | None,
 ) -> tuple[Literal["completed", "incomplete"], dict[str, Any] | None]:
     # chat finish_reason -> Responses status + incomplete_details.reason.
-    # The Responses spec's incomplete_details.reason enum is
-    # {max_output_tokens, content_filter}.
     if finish_reason == "length":
         return "incomplete", {"reason": "max_output_tokens"}
     if finish_reason == "content_filter":

--- a/modelship/openai/protocol/responses/schemas.py
+++ b/modelship/openai/protocol/responses/schemas.py
@@ -50,6 +50,14 @@ class ResponsesRequest(OpenAIBaseModel):
     background: bool | None = None
 
 
+class CompactRequest(OpenAIBaseModel):
+    model: str
+    input: str | list[ResponseInputItem] | None = None
+    previous_response_id: str | None = None
+    instructions: str | None = None
+    prompt_cache_key: str | None = None
+
+
 # ---------------------------------------------------------------------------
 # Output items
 # ---------------------------------------------------------------------------
@@ -132,6 +140,35 @@ class ResponseUsage(OpenAIBaseModel):
 
 
 # ---------------------------------------------------------------------------
+# Compaction (``/v1/responses/compact``)
+# ---------------------------------------------------------------------------
+
+
+class CompactionItem(OpenAIBaseModel):
+    type: Literal["compaction"] = "compaction"
+    id: str = Field(default_factory=lambda: f"cmp_{random_uuid()}")
+    encrypted_content: str
+    created_by: str | None = None
+
+    @model_serializer(mode="wrap")
+    def _omit_unset_created_by(self, handler: Any) -> dict[str, Any]:
+        # Spec types created_by as a plain (non-nullable) string that's not
+        # required — the key must be absent, not null, when there's no value.
+        dumped = handler(self)
+        if dumped.get("created_by") is None:
+            dumped.pop("created_by", None)
+        return dumped
+
+
+class CompactResource(OpenAIBaseModel):
+    id: str = Field(default_factory=lambda: f"resp_{random_uuid()}")
+    object: Literal["response.compaction"] = "response.compaction"
+    output: list[CompactionItem]
+    created_at: int = Field(default_factory=lambda: int(time.time()))
+    usage: ResponseUsage
+
+
+# ---------------------------------------------------------------------------
 # Response object
 # ---------------------------------------------------------------------------
 
@@ -172,6 +209,9 @@ class ResponseObject(OpenAIBaseModel):
 
 
 __all__ = [
+    "CompactRequest",
+    "CompactResource",
+    "CompactionItem",
     "ResponseFunctionToolCall",
     "ResponseInputItem",
     "ResponseInputTokensDetails",

--- a/modelship/openai/protocol/responses/schemas.py
+++ b/modelship/openai/protocol/responses/schemas.py
@@ -55,7 +55,6 @@ class CompactRequest(OpenAIBaseModel):
     input: str | list[ResponseInputItem] | None = None
     previous_response_id: str | None = None
     instructions: str | None = None
-    prompt_cache_key: str | None = None
 
 
 # ---------------------------------------------------------------------------

--- a/modelship/openai/utils/responses.py
+++ b/modelship/openai/utils/responses.py
@@ -20,9 +20,24 @@ from fastapi import HTTPException
 from pydantic import ValidationError
 
 from modelship.logging import get_logger
-from modelship.openai.protocol import ErrorResponse, ResponseObject, ResponsesRequest, UsageInfo, create_error_response
-from modelship.openai.protocol.responses.adapter import _status_for, _usage_from_chat, build_response_object
+from modelship.openai import compaction_crypto
+from modelship.openai.protocol import (
+    ChatCompletionRequest,
+    ErrorResponse,
+    ResponseObject,
+    ResponsesRequest,
+    UsageInfo,
+    create_error_response,
+)
+from modelship.openai.protocol.responses.adapter import (
+    _status_for,
+    _usage_from_chat,
+    build_response_object,
+    messages_from_input,
+)
 from modelship.openai.protocol.responses.schemas import (
+    CompactionItem,
+    CompactResource,
     ResponseFunctionToolCall,
     ResponseOutputItem,
     ResponseOutputMessage,
@@ -97,6 +112,50 @@ def build_response_from_parsed(
     )
 
 
+# Structured rather than a bare "summarize this" — a flat prose summary loses the
+# details a continuation actually needs. Preserve, in this order: the user's
+# explicit intent; key facts, decisions, names, and identifiers; specific file
+# paths, code, and command output already produced; errors hit and how they were
+# resolved (including any correction the user gave); work still pending; and
+# exactly what was in progress, so the next turn picks up without re-deriving it.
+_COMPACTION_SYSTEM_PROMPT = (
+    "Summarize this conversation so it can be continued from a fresh context window "
+    "with nothing essential lost. Structure the summary with these sections, in order: "
+    "(1) the user's explicit requests and intent, verbatim where it matters; "
+    "(2) key facts, decisions, names, and identifiers established so far; "
+    "(3) specific file paths, code, or command output already produced, in enough "
+    "detail to avoid re-deriving them; "
+    "(4) errors encountered and how they were fixed, including any correction the "
+    "user gave about how to approach the task; "
+    "(5) work explicitly still pending; "
+    "(6) exactly what was being worked on immediately before this summary, so the "
+    "next turn picks up from there rather than guessing."
+)
+
+
+def build_summarization_request(model: str, items: list[Any]) -> ChatCompletionRequest:
+    """The internal chat request ``/v1/responses/compact`` issues to summarize *items*.
+
+    Reuses ``messages_from_input`` so a compaction item nested in *items* (a chain
+    that was already compacted once) decodes the same way it would on ``/v1/responses``.
+    May raise ``UnsupportedResponsesFeatureError`` for an item shape it can't translate.
+    """
+    messages = messages_from_input(items, None)
+    messages.insert(0, {"role": "system", "content": _COMPACTION_SYSTEM_PROMPT})
+    return ChatCompletionRequest(model=model, messages=messages, stream=False)
+
+
+def build_compaction(*, summary_items: list[Any], usage: UsageInfo) -> CompactResource:
+    """Build a ``CompactResource`` from a ``/v1/responses/compact`` summarization call.
+
+    ``id``/``created_at`` are freshly minted rather than echoing the request: a
+    compaction result is never persisted under its own id, so there's nothing to key
+    a future GET on (out of scope, see the compaction plan).
+    """
+    encrypted_content = compaction_crypto.encrypt_items(summary_items)
+    return CompactResource(output=[CompactionItem(encrypted_content=encrypted_content)], usage=_usage_from_chat(usage))
+
+
 def responses_validation_error(exc: ValidationError) -> ErrorResponse:
     """400 for a pydantic ``ValidationError`` surfaced by ``responses_request_to_chat``
     (e.g. a bad ``reasoning.effort`` value) — same shape as every other rejection.
@@ -138,20 +197,28 @@ def _terminal_event_payload(chunk: Any) -> dict[str, Any] | None:
     return payload if isinstance(payload, dict) else None
 
 
-async def resolve_history(store: StateStore, identity: str, request: ResponsesRequest) -> list[Any]:
-    """Prepend the conversation stored under ``previous_response_id`` to this
-    turn's input. 404 if unknown, 503 if the store is unreachable — an outage must
-    never masquerade as a legitimately unknown id."""
-    prev_id = request.previous_response_id or ""
-    if not RESPONSE_ID_RE.match(prev_id):
+async def resolve_history_items(
+    store: StateStore, identity: str, *, previous_response_id: str | None, input_: str | list[Any] | None
+) -> list[Any]:
+    """Prepend the conversation stored under ``previous_response_id`` to this turn's
+    input. 404 if unknown, 503 if the store is unreachable — an outage must never
+    masquerade as a legitimately unknown id.
+
+    Field-based (rather than taking a ``ResponsesRequest``) so ``/v1/responses`` and
+    ``/v1/responses/compact`` share this without either faking the other's request type.
+    """
+    this_turn = as_input_items(input_) if input_ is not None else []
+    if previous_response_id is None:
+        return this_turn
+    if not RESPONSE_ID_RE.match(previous_response_id):
         raise HTTPException(
             status_code=HTTPStatus.NOT_FOUND.value,
-            detail=f"Previous response with id '{prev_id}' not found.",
+            detail=f"Previous response with id '{previous_response_id}' not found.",
         )
     try:
-        snapshot = await responses_state.read_async(store, identity, prev_id)
+        snapshot = await responses_state.read_async(store, identity, previous_response_id)
     except StateStoreUnavailableError:
-        logger.exception("State store unavailable resolving previous_response_id=%s", prev_id)
+        logger.exception("State store unavailable resolving previous_response_id=%s", previous_response_id)
         raise HTTPException(
             status_code=HTTPStatus.SERVICE_UNAVAILABLE.value,
             detail="Conversation state store is unavailable; retry shortly.",
@@ -159,9 +226,16 @@ async def resolve_history(store: StateStore, identity: str, request: ResponsesRe
     if snapshot is None:
         raise HTTPException(
             status_code=HTTPStatus.NOT_FOUND.value,
-            detail=f"Previous response with id '{prev_id}' not found.",
+            detail=f"Previous response with id '{previous_response_id}' not found.",
         )
-    return [*responses_state.history_items(snapshot), *as_input_items(request.input)]
+    return [*responses_state.history_items(snapshot), *this_turn]
+
+
+async def resolve_history(store: StateStore, identity: str, request: ResponsesRequest) -> list[Any]:
+    """``resolve_history_items`` for a ``ResponsesRequest``."""
+    return await resolve_history_items(
+        store, identity, previous_response_id=request.previous_response_id, input_=request.input
+    )
 
 
 async def persist_response(gen, store: StateStore, *, identity: str, input_items: list[Any]):

--- a/modelship/openai/utils/responses.py
+++ b/modelship/openai/utils/responses.py
@@ -133,15 +133,19 @@ _COMPACTION_SYSTEM_PROMPT = (
 )
 
 
-def build_summarization_request(model: str, items: list[Any]) -> ChatCompletionRequest:
+def build_summarization_request(model: str, items: list[Any], instructions: str | None = None) -> ChatCompletionRequest:
     """The internal chat request ``/v1/responses/compact`` issues to summarize *items*.
 
     Reuses ``messages_from_input`` so a compaction item nested in *items* (a chain
     that was already compacted once) decodes the same way it would on ``/v1/responses``.
     May raise ``UnsupportedResponsesFeatureError`` for an item shape it can't translate.
+    *instructions*, if given, is inserted as an additional system message alongside
+    the fixed compaction prompt, so a caller can steer what the summary preserves.
     """
     messages = messages_from_input(items, None)
     messages.insert(0, {"role": "system", "content": _COMPACTION_SYSTEM_PROMPT})
+    if instructions:
+        messages.insert(1, {"role": "system", "content": instructions})
     return ChatCompletionRequest(model=model, messages=messages, stream=False)
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ requires-python = "==3.12.10"
 dependencies = [
     "argparse>=1.4.0",
     "asyncio>=4.0.0",
+    "cryptography>=43.0.0",
     "fastapi>=0.116.1",
     "httpx>=0.28.1",
     "huggingface-hub>=1.12.0",

--- a/tests/test_responses_adapter.py
+++ b/tests/test_responses_adapter.py
@@ -153,6 +153,19 @@ class TestCompactionInputDecode:
             {"role": "user", "content": "what's my name?"},
         ]
 
+    def test_nested_compaction_item_is_rejected(self):
+        # A blob we mint ourselves never nests another compaction item — but the
+        # decode path must not simply trust that. Simulates a forged blob (or a
+        # future bug in build_compaction) that decrypts to one anyway: recursing
+        # into it unbounded would be a DoS vector, so it must be a clean rejection.
+        nested_blob = compaction_crypto.encrypt_items(
+            [{"type": "compaction", "id": "cmp_inner", "encrypted_content": "irrelevant"}]
+        )
+        with pytest.raises(UnsupportedResponsesFeatureError, match="nest"):
+            responses_request_to_chat(
+                _req(input=[{"type": "compaction", "id": "cmp_1", "encrypted_content": nested_blob}])
+            )
+
     def test_missing_encrypted_content_rejected(self):
         with pytest.raises(UnsupportedResponsesFeatureError, match="encrypted_content"):
             responses_request_to_chat(_req(input=[{"type": "compaction", "id": "cmp_1"}]))

--- a/tests/test_responses_adapter.py
+++ b/tests/test_responses_adapter.py
@@ -3,6 +3,7 @@ response envelope."""
 
 import pytest
 
+from modelship.openai import compaction_crypto
 from modelship.openai.protocol import ResponsesRequest
 from modelship.openai.protocol.responses import (
     UnsupportedResponsesFeatureError,
@@ -10,6 +11,13 @@ from modelship.openai.protocol.responses import (
 )
 from modelship.openai.protocol.responses.adapter import _content_to_chat, build_response_object
 from modelship.openai.protocol.responses.schemas import ResponseReasoningItem
+
+
+@pytest.fixture(autouse=True)
+def _reset_ephemeral_compaction_key():
+    compaction_crypto._ephemeral_key = None
+    yield
+    compaction_crypto._ephemeral_key = None
 
 
 def _req(**overrides) -> ResponsesRequest:
@@ -122,6 +130,50 @@ class TestRequestInputTranslation:
     def test_unknown_input_item_type_rejected(self):
         with pytest.raises(UnsupportedResponsesFeatureError):
             responses_request_to_chat(_req(input=[{"type": "image_generation_call"}]))
+
+
+class TestCompactionInputDecode:
+    """Round-trip half of ``/v1/responses/compact``: a ``compaction`` input item is
+    decrypted back into the items it was built from and spliced into the message list,
+    exactly as ``websocket-compact-new-chain`` requires."""
+
+    def test_compaction_item_decodes_into_messages(self):
+        summary_items = [{"role": "assistant", "content": "previously: the user is named Alex"}]
+        blob = compaction_crypto.encrypt_items(summary_items)
+        chat = responses_request_to_chat(
+            _req(
+                input=[
+                    {"type": "compaction", "id": "cmp_1", "encrypted_content": blob},
+                    {"role": "user", "content": "what's my name?"},
+                ]
+            )
+        )
+        assert chat.messages == [
+            {"role": "assistant", "content": "previously: the user is named Alex"},
+            {"role": "user", "content": "what's my name?"},
+        ]
+
+    def test_missing_encrypted_content_rejected(self):
+        with pytest.raises(UnsupportedResponsesFeatureError, match="encrypted_content"):
+            responses_request_to_chat(_req(input=[{"type": "compaction", "id": "cmp_1"}]))
+
+    def test_tampered_encrypted_content_is_a_clean_rejection(self):
+        blob = compaction_crypto.encrypt_items([{"role": "assistant", "content": "x"}])
+        tampered = blob[:-4] + ("AAAA" if blob[-4:] != "AAAA" else "BBBB")
+        with pytest.raises(UnsupportedResponsesFeatureError, match="could not be decoded"):
+            responses_request_to_chat(
+                _req(input=[{"type": "compaction", "id": "cmp_1", "encrypted_content": tampered}])
+            )
+
+    def test_wrong_key_is_the_same_clean_rejection_as_tampering(self, monkeypatch):
+        # Both a tampered blob and one encrypted under a different key must produce
+        # the identical error — the message must never reveal which case it was.
+        from cryptography.fernet import Fernet
+
+        blob = compaction_crypto.encrypt_items([{"role": "assistant", "content": "x"}])
+        monkeypatch.setenv("MSHIP_COMPACTION_KEY", Fernet.generate_key().decode("ascii"))
+        with pytest.raises(UnsupportedResponsesFeatureError, match="could not be decoded"):
+            responses_request_to_chat(_req(input=[{"type": "compaction", "id": "cmp_1", "encrypted_content": blob}]))
 
 
 class TestRequestFieldTranslation:

--- a/tests/test_responses_compaction.py
+++ b/tests/test_responses_compaction.py
@@ -1,0 +1,291 @@
+"""Tests for ``/v1/responses/compact``: the Fernet crypto module, the
+``CompactRequest``/``CompactResource``/``CompactionItem`` schemas, the
+``build_summarization_request``/``build_compaction`` builders, and the gateway route.
+
+The route dispatches to the same `handle.generate` a chat-completion request would
+(the summarization pass), then encrypts the result into a ``CompactionItem`` — it
+never persists a snapshot under the compaction id (see the compaction plan).
+"""
+
+import json
+from http import HTTPStatus
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from cryptography.fernet import Fernet, InvalidToken
+from fastapi import FastAPI, HTTPException
+from fastapi.testclient import TestClient
+from pydantic import ValidationError
+
+from modelship.openai import compaction_crypto
+from modelship.openai.api import ModelshipAPI
+from modelship.openai.protocol import ChatCompletionResponse, UsageInfo
+from modelship.openai.protocol.chat import ChatCompletionResponseChoice, ChatMessage
+from modelship.openai.protocol.responses.schemas import CompactionItem, CompactRequest, CompactResource, ResponseUsage
+from modelship.openai.utils.responses import build_compaction, build_summarization_request
+from modelship.state import MemoryStoreActor
+
+_ModelshipAPI = ModelshipAPI.func_or_class
+_MemoryStore = MemoryStoreActor.__ray_metadata__.modified_class
+
+
+@pytest.fixture(autouse=True)
+def _reset_ephemeral_key():
+    """Each test gets a clean slate: no leftover ephemeral key from a previous test
+    leaking in, and none left behind for the next one."""
+    compaction_crypto._ephemeral_key = None
+    yield
+    compaction_crypto._ephemeral_key = None
+
+
+@pytest.fixture
+def compaction_key(monkeypatch):
+    key = Fernet.generate_key().decode("ascii")
+    monkeypatch.setenv("MSHIP_COMPACTION_KEY", key)
+    return key
+
+
+class TestCompactionCrypto:
+    def test_round_trip(self, compaction_key):
+        items = [{"type": "message", "role": "assistant", "content": "a summary"}]
+        blob = compaction_crypto.encrypt_items(items)
+        assert compaction_crypto.decrypt_items(blob) == items
+
+    def test_wrong_key_raises_invalid_token(self, compaction_key):
+        blob = compaction_crypto.encrypt_items([{"a": 1}])
+        other_key = Fernet.generate_key().decode("ascii")
+        with patch.dict("os.environ", {"MSHIP_COMPACTION_KEY": other_key}), pytest.raises(InvalidToken):
+            compaction_crypto.decrypt_items(blob)
+
+    def test_tampered_blob_raises_invalid_token(self, compaction_key):
+        blob = compaction_crypto.encrypt_items([{"a": 1}])
+        tampered = blob[:-4] + ("AAAA" if blob[-4:] != "AAAA" else "BBBB")
+        with pytest.raises(InvalidToken):
+            compaction_crypto.decrypt_items(tampered)
+
+    def test_ephemeral_key_used_and_warns_when_unset(self, monkeypatch, caplog):
+        monkeypatch.delenv("MSHIP_COMPACTION_KEY", raising=False)
+        # Attach caplog's handler directly to this logger: some other test module's
+        # `configure_logging()` call sets `modelship`'s `propagate = False` for the
+        # rest of the process, which would otherwise stop the record from ever
+        # reaching caplog's root-attached handler.
+        compaction_crypto.logger.addHandler(caplog.handler)
+        try:
+            with caplog.at_level("WARNING", logger="modelship.compaction_crypto"):
+                blob = compaction_crypto.encrypt_items([{"a": 1}])
+        finally:
+            compaction_crypto.logger.removeHandler(caplog.handler)
+        assert "ephemeral" in caplog.text
+        assert compaction_crypto.decrypt_items(blob) == [{"a": 1}]
+
+    def test_ephemeral_key_is_stable_within_process(self, monkeypatch):
+        monkeypatch.delenv("MSHIP_COMPACTION_KEY", raising=False)
+        compaction_crypto.encrypt_items([{"a": 1}])
+        key_after_first = compaction_crypto._ephemeral_key
+        # A second call must reuse the same ephemeral key, not mint a new one, or a
+        # blob minted earlier in the same process would stop decoding.
+        compaction_crypto.encrypt_items([{"b": 2}])
+        assert compaction_crypto._ephemeral_key == key_after_first
+
+
+class TestCompactSchemas:
+    def test_model_is_required(self):
+        with pytest.raises(ValidationError, match="model"):
+            CompactRequest()
+
+    def test_created_by_omitted_when_unset(self):
+        # The suite's compactionBodySchema types created_by as optional-but-non-nullable
+        # (z.string().optional()) — sending it as `null` fails validation, only an
+        # absent key passes. Caught by a live compliance-suite run against a real
+        # deploy, where the failure was reported as "output.0: Invalid input".
+        dumped = CompactionItem(encrypted_content="blob").model_dump(mode="json")
+        assert "created_by" not in dumped
+
+    def test_created_by_present_when_set(self):
+        dumped = CompactionItem(encrypted_content="blob", created_by="model").model_dump(mode="json")
+        assert dumped["created_by"] == "model"
+
+    def test_compaction_item_defaults(self):
+        item = CompactionItem(encrypted_content="blob")
+        assert item.type == "compaction"
+        assert item.id.startswith("cmp_")
+        assert item.created_by is None
+
+    def test_compact_resource_shape(self):
+        resource = CompactResource(
+            output=[CompactionItem(encrypted_content="blob")],
+            usage=ResponseUsage(input_tokens=1, output_tokens=2, total_tokens=3),
+        )
+        dumped = resource.model_dump(mode="json")
+        assert dumped["object"] == "response.compaction"
+        assert dumped["output"][0]["type"] == "compaction"
+        assert set(dumped) >= {"id", "object", "output", "created_at", "usage"}
+
+    def test_missing_model_is_422_from_fastapi(self):
+        # The suite's `compact-missing-model` test expects a bare 422/400 with no
+        # loader involved at all — this is FastAPI's own validation on the required
+        # `model` field, exercised end-to-end through a real ASGI request.
+        app = FastAPI()
+
+        @app.post("/v1/responses/compact")
+        async def compact(request: CompactRequest):
+            return {}
+
+        resp = TestClient(app).post("/v1/responses/compact", json={"input": "hi"})
+        assert resp.status_code == 422
+
+
+class TestBuildCompaction:
+    def test_encrypts_summary_into_one_compaction_item(self, compaction_key):
+        summary_items = [{"type": "message", "role": "assistant", "content": "the gist"}]
+        usage = UsageInfo(prompt_tokens=10, completion_tokens=5, total_tokens=15)
+        resource = build_compaction(summary_items=summary_items, usage=usage)
+
+        assert len(resource.output) == 1
+        assert resource.output[0].type == "compaction"
+        assert compaction_crypto.decrypt_items(resource.output[0].encrypted_content) == summary_items
+        assert resource.usage.input_tokens == 10
+        assert resource.usage.output_tokens == 5
+
+
+class TestBuildSummarizationRequest:
+    def test_leads_with_system_instruction(self):
+        chat = build_summarization_request("m", [{"role": "user", "content": "hi"}])
+        assert chat.model == "m"
+        assert chat.stream is False
+        assert chat.messages[0]["role"] == "system"
+        assert "summar" in chat.messages[0]["content"].lower()
+        assert chat.messages[1] == {"role": "user", "content": "hi"}
+
+    def test_bad_item_shape_raises(self):
+        from modelship.openai.protocol.responses import UnsupportedResponsesFeatureError
+
+        with pytest.raises(UnsupportedResponsesFeatureError):
+            build_summarization_request("m", [{"type": "image_generation_call"}])
+
+
+def _raw_request():
+    raw = MagicMock()
+    raw.headers = {}
+    return raw
+
+
+@pytest.fixture
+def api(compaction_key):
+    with (
+        patch("modelship.openai.api.serve.get_replica_context") as mock_ctx,
+        patch.dict(_ModelshipAPI._handle_response.__globals__, {"configure_logging": lambda: None}),
+    ):
+        mock_ctx.return_value.app_name = "test-gateway"
+        inst = _ModelshipAPI("test-gateway")
+        inst._watch_task = MagicMock()
+        inst._state_store = _MemoryStore()
+        return inst
+
+
+def _chat_response_gen(text="a compact summary"):
+    async def gen():
+        yield ChatCompletionResponse(
+            model="m",
+            choices=[ChatCompletionResponseChoice(index=0, message=ChatMessage(role="assistant", content=text))],
+            usage=UsageInfo(prompt_tokens=7, completion_tokens=3, total_tokens=10),
+        )
+
+    return gen()
+
+
+def _wire(api, gen):
+    handle = MagicMock()
+    handle.generate.options.return_value.remote.return_value = gen
+    api.models = {"m": {"m-a1b2c": handle}}
+    api._round_robin = {"m": 0}
+    return handle
+
+
+class TestCompactResponseRoute:
+    @pytest.mark.asyncio
+    async def test_dispatches_to_generate_and_returns_compact_resource(self, api):
+        handle = _wire(api, _chat_response_gen(text="the gist"))
+        request = CompactRequest(model="m", input="hi", prompt_cache_key="k")
+
+        result = await api.compact_response(request, _raw_request())
+
+        assert handle.generate.options.return_value.remote.call_args is not None
+        body = json.loads(bytes(result.body))
+        assert body["object"] == "response.compaction"
+        assert len(body["output"]) == 1
+        item = body["output"][0]
+        assert item["type"] == "compaction"
+        decoded = compaction_crypto.decrypt_items(item["encrypted_content"])
+        assert decoded == [{"type": "message", "role": "assistant", "content": "the gist"}]
+        assert body["usage"]["input_tokens"] == 7
+
+    @pytest.mark.asyncio
+    async def test_empty_conversation_is_400(self, api):
+        _wire(api, _chat_response_gen())
+        request = CompactRequest(model="m", input=None)
+
+        with pytest.raises(HTTPException) as exc_info:
+            await api.compact_response(request, _raw_request())
+        assert exc_info.value.status_code == HTTPStatus.BAD_REQUEST.value
+
+    @pytest.mark.asyncio
+    async def test_previous_response_id_history_is_resolved_before_dispatch(self, api):
+        handle = _wire(api, _chat_response_gen())
+        identity = "unscoped"
+        await api._state_store.set_async(
+            f"responses/{identity}/resp_1",
+            {
+                "response": {"id": "resp_1", "object": "response", "status": "completed", "output": []},
+                "input_items": [{"type": "message", "role": "user", "content": "earlier turn"}],
+            },
+        )
+        request = CompactRequest(model="m", input="continue", previous_response_id="resp_1")
+
+        await api.compact_response(request, _raw_request())
+
+        sent_chat_request = handle.generate.options.return_value.remote.call_args.args[0]
+        contents = [m["content"] for m in sent_chat_request.messages]
+        assert any("earlier turn" in c for c in contents if isinstance(c, str))
+        assert any(c == "continue" for c in contents if isinstance(c, str))
+
+    @pytest.mark.asyncio
+    async def test_unknown_previous_response_id_is_404(self, api):
+        _wire(api, _chat_response_gen())
+        request = CompactRequest(model="m", input="hi", previous_response_id="resp_nope")
+
+        with pytest.raises(HTTPException) as exc_info:
+            await api.compact_response(request, _raw_request())
+        assert exc_info.value.status_code == HTTPStatus.NOT_FOUND.value
+
+    @pytest.mark.asyncio
+    async def test_summarization_raytaskerror_maps_to_400_not_500(self, api):
+        from ray.exceptions import RayTaskError
+
+        cause = ValueError("context overflow during summarization")
+        err = RayTaskError(function_name="fn", traceback_str="tb", cause=cause)
+
+        async def gen():
+            if False:
+                yield  # pragma: no cover
+            raise err
+
+        handle = MagicMock()
+        handle.generate.options.return_value.remote.return_value = gen()
+        api.models = {"m": {"m-a1b2c": handle}}
+        api._round_robin = {"m": 0}
+
+        request = CompactRequest(model="m", input="hi")
+        result = await api.compact_response(request, _raw_request())
+
+        assert result.status_code == 400
+        body = json.loads(bytes(result.body))
+        assert body["error"]["type"] == "invalid_request_error"
+
+    @pytest.mark.asyncio
+    async def test_does_not_persist_a_snapshot(self, api):
+        _wire(api, _chat_response_gen())
+        api._state_store.set_async = AsyncMock(side_effect=AssertionError("compaction must not write to the store"))
+        request = CompactRequest(model="m", input="hi")
+
+        await api.compact_response(request, _raw_request())

--- a/tests/test_responses_compaction.py
+++ b/tests/test_responses_compaction.py
@@ -168,6 +168,16 @@ class TestBuildSummarizationRequest:
         assert "summar" in chat.messages[0]["content"].lower()
         assert chat.messages[1] == {"role": "user", "content": "hi"}
 
+    def test_caller_instructions_are_inserted_as_additional_system_message(self):
+        chat = build_summarization_request("m", [{"role": "user", "content": "hi"}], "focus on pricing details")
+        assert chat.messages[0]["role"] == "system"
+        assert chat.messages[1] == {"role": "system", "content": "focus on pricing details"}
+        assert chat.messages[2] == {"role": "user", "content": "hi"}
+
+    def test_no_instructions_does_not_insert_extra_message(self):
+        chat = build_summarization_request("m", [{"role": "user", "content": "hi"}], None)
+        assert len(chat.messages) == 2
+
     def test_bad_item_shape_raises(self):
         from modelship.openai.protocol.responses import UnsupportedResponsesFeatureError
 
@@ -217,7 +227,10 @@ class TestCompactResponseRoute:
     @pytest.mark.asyncio
     async def test_dispatches_to_generate_and_returns_compact_resource(self, api):
         handle = _wire(api, _chat_response_gen(text="the gist"))
-        request = CompactRequest(model="m", input="hi", prompt_cache_key="k")
+        # prompt_cache_key isn't a CompactRequest field (nothing in modelship hooks a
+        # cache key in) — OpenAIBaseModel's extra="allow" means an OpenAI-SDK client
+        # that still sends it is silently tolerated rather than rejected.
+        request = CompactRequest.model_validate({"model": "m", "input": "hi", "prompt_cache_key": "k"})
 
         result = await api.compact_response(request, _raw_request())
 
@@ -230,6 +243,16 @@ class TestCompactResponseRoute:
         decoded = compaction_crypto.decrypt_items(item["encrypted_content"])
         assert decoded == [{"type": "message", "role": "assistant", "content": "the gist"}]
         assert body["usage"]["input_tokens"] == 7
+
+    @pytest.mark.asyncio
+    async def test_instructions_reach_the_dispatched_summarization_request(self, api):
+        handle = _wire(api, _chat_response_gen())
+        request = CompactRequest(model="m", input="hi", instructions="focus on pricing details")
+
+        await api.compact_response(request, _raw_request())
+
+        sent_chat_request = handle.generate.options.return_value.remote.call_args.args[0]
+        assert {"role": "system", "content": "focus on pricing details"} in sent_chat_request.messages
 
     @pytest.mark.asyncio
     async def test_empty_conversation_is_400(self, api):

--- a/tests/test_responses_compaction.py
+++ b/tests/test_responses_compaction.py
@@ -63,6 +63,17 @@ class TestCompactionCrypto:
         with pytest.raises(InvalidToken):
             compaction_crypto.decrypt_items(tampered)
 
+    def test_non_ascii_blob_raises_invalid_token(self, compaction_key):
+        # blob.encode("ascii") would otherwise raise UnicodeEncodeError, a plain
+        # ValueError that callers wouldn't catch alongside a tampered/wrong-key blob.
+        with pytest.raises(InvalidToken):
+            compaction_crypto.decrypt_items("not-ascii-🔥")
+
+    def test_invalid_configured_key_fails_fast_with_clear_error(self, monkeypatch):
+        monkeypatch.setenv("MSHIP_COMPACTION_KEY", "not-a-valid-fernet-key")
+        with pytest.raises(ValueError, match="MSHIP_COMPACTION_KEY is not a valid Fernet key"):
+            compaction_crypto.encrypt_items([{"a": 1}])
+
     def test_ephemeral_key_used_and_warns_when_unset(self, monkeypatch, caplog):
         monkeypatch.delenv("MSHIP_COMPACTION_KEY", raising=False)
         # Attach caplog's handler directly to this logger: some other test module's

--- a/uv.lock
+++ b/uv.lock
@@ -1693,6 +1693,7 @@ source = { editable = "." }
 dependencies = [
     { name = "argparse" },
     { name = "asyncio" },
+    { name = "cryptography" },
     { name = "fastapi" },
     { name = "gguf" },
     { name = "httpx" },
@@ -1767,6 +1768,7 @@ requires-dist = [
     { name = "argparse", specifier = ">=1.4.0" },
     { name = "asyncio", specifier = ">=4.0.0" },
     { name = "bitsandbytes", marker = "extra == 'cuda'", specifier = ">=0.49.0" },
+    { name = "cryptography", specifier = ">=43.0.0" },
     { name = "diffusers", marker = "extra == 'cuda'", specifier = ">=0.31.0" },
     { name = "fakeredis", marker = "extra == 'dev'", specifier = ">=2.36.2" },
     { name = "fastapi", specifier = ">=0.116.1" },


### PR DESCRIPTION
Implements the OpenAI/OpenResponses compaction endpoint: real model-driven summarization of the resolved conversation, returned as a Fernet-encrypted opaque blob (MSHIP_COMPACTION_KEY, with an ephemeral-per-process fallback) that decodes back into context on a later /v1/responses call. Shares history resolution with /v1/responses via a new field-based resolve_history_items, and factors the RayTaskError->4xx mapping out of _handle_response so both routes get the same error handling.

Verified end-to-end against the OpenResponses compliance suite (compact-response, compact-missing-model) on both the vllm and llama_server loaders.

