### PR TITLE
chore: add CLA, CODEOWNERS, and governance docs for contributors

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Default owner for everything in the repo, unless a later match overrides it.
+* @alez007

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -15,3 +15,4 @@ Steps to verify the change works as expected.
 - [ ] `ruff check .` passes
 - [ ] `ruff format --check .` passes
 - [ ] `pyright` passes
+- [ ] I have signed the [CLA](https://github.com/alez007/modelship/blob/main/CLA.md) (the CLA Assistant bot will prompt you if not)

--- a/CLA.md
+++ b/CLA.md
@@ -1,0 +1,47 @@
+# Modelship Contributor License Agreement
+
+*This is a template pending review by a lawyer before it is put into force. It is modeled on the structure of the Apache Software Foundation's Individual and Corporate CLAs, adapted for a single-maintainer project.*
+
+Thank you for your interest in contributing to Modelship ("the Project"), maintained by Alex Margarit ("the Maintainer"). This Contributor License Agreement ("Agreement") clarifies the terms under which intellectual property is contributed to the Project.
+
+This is a **license grant**, not a copyright assignment. You keep ownership of your contributions. What you grant the Maintainer is the right to use, relicense, and sublicense them — including, if ever necessary, under different terms than Apache 2.0 for the Project as a whole. **The Maintainer commits that Modelship will always remain available under Apache 2.0** in addition to whatever other terms may exist in the future; the CLA exists to keep that option open, not to signal an intent to close the project.
+
+You only need to sign once. It covers all past and future contributions you submit to the Project.
+
+---
+
+## A. Individual Contributor License Agreement (ICLA)
+
+By signing this Agreement, **you** ("Contributor") agree to the following terms for any Contribution, as defined below, that you submit to the Project.
+
+**1. Definitions.** "Contribution" means any original work of authorship, including any modification or addition to existing work, that is intentionally submitted by you to the Project for inclusion in, or documentation of, the Project.
+
+**2. Grant of Copyright License.** Subject to the terms of this Agreement, you grant to the Maintainer and to recipients of software distributed by the Project a perpetual, worldwide, non-exclusive, royalty-free, irrevocable copyright license to reproduce, prepare derivative works of, publicly display, publicly perform, sublicense, and distribute your Contributions and such derivative works, **under Apache 2.0 or any other license terms the Maintainer chooses to apply to the Project**, now or in the future.
+
+**3. Grant of Patent License.** You grant to the Maintainer and to recipients of software distributed by the Project a perpetual, worldwide, non-exclusive, royalty-free, irrevocable (except as stated in this section) patent license to make, have made, use, offer to sell, sell, import, and otherwise transfer your Contribution, where such license applies only to those patent claims licensable by you that are necessarily infringed by your Contribution alone or by combination with the Project. If any entity institutes patent litigation alleging that your Contribution, or the Project incorporating your Contribution, constitutes direct or contributory patent infringement, any patent licenses granted under this Agreement to that entity terminate as of the date such litigation is filed.
+
+**4. Originality.** You represent that each Contribution is your original creation, or that you have sufficient rights to submit it under this Agreement (for example, if it derives from third-party work that you have permission to relicense).
+
+**5. No Obligation.** You understand that submitting a Contribution is voluntary, and that the Maintainer is under no obligation to accept or use it.
+
+**6. As-Is.** Unless required by applicable law or agreed to in writing, you provide your Contributions on an "AS IS" basis, without warranties or conditions of any kind, either express or implied.
+
+---
+
+## B. Corporate Contributor License Agreement (CCLA)
+
+If you are contributing on behalf of your employer or another entity, an authorized representative should sign this section instead of (or in addition to) the ICLA above. The terms of Sections 1–3 and 6 of the ICLA apply equally here, with "you" read as the signing entity ("Corporation"), with the following additions:
+
+**1. Authorization.** The person signing on the Corporation's behalf represents that they are authorized to bind the Corporation to this Agreement.
+
+**2. Designated Contributors.** The Corporation may designate specific employees authorized to submit Contributions on its behalf, by listing their GitHub usernames alongside the signed Agreement. The Corporation is responsible for keeping this list current.
+
+**3. Employee Rights Unaffected.** This Agreement does not diminish any rights an employee may separately have to their own Contributions; it only governs Contributions submitted on the Corporation's behalf.
+
+---
+
+## Signing
+
+Signing happens electronically through the [CLA Assistant](https://cla-assistant.io) bot, which comments on your first pull request with a link to sign. Signatures are recorded per-GitHub-account and checked automatically on every subsequent PR — you won't be asked again.
+
+Questions about this Agreement can be raised via [GitHub Issues](https://github.com/alez007/modelship/issues) or, for anything you'd rather not discuss publicly, through [SECURITY.md](SECURITY.md)'s private reporting channel.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,6 +2,12 @@
 
 Thanks for your interest in contributing to Modelship! This document covers the basics for getting started.
 
+## License
+
+Modelship is licensed under [Apache 2.0](LICENSE), and **will always remain available under Apache 2.0** — that promise isn't contingent on the CLA below.
+
+Per Apache 2.0 §5, any contribution you intentionally submit for inclusion is licensed to the project under Apache 2.0 by default. Before your first PR can be merged, you'll also need to sign the [Contributor License Agreement](CLA.md) (individual or corporate) via the CLA Assistant bot, which will comment on your PR with a link. You keep copyright in your own contributions — the CLA grants the project the right to distribute and, if ever needed, relicense them, it does not assign them away.
+
 ## Development Setup
 
 The recommended way to develop is via the VS Code Dev Container. See [docs/development.md](docs/development.md) for full instructions.

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -1,0 +1,19 @@
+# Governance
+
+Modelship is run under a BDFL (Benevolent Dictator For Life) model. This page states plainly how decisions get made, so contributors know what to expect before investing time in a PR or proposal.
+
+## Decision authority
+
+Alex Margarit ([@alez007](https://github.com/alez007)) has final say on everything: PR acceptance, architecture and scope, roadmap direction, and release timing. There is no voting process or RFC process — disagreements are resolved by the maintainer's judgment, not by consensus.
+
+[CODEOWNERS](.github/CODEOWNERS) and branch protection on `main` enforce that nothing merges without maintainer review. This document is the human-readable reason why: a maintainer-approved PR reflects one person's decision, not a committee's.
+
+## Maintainers
+
+Currently just the one: Alex Margarit. Additional maintainers may be added at the BDFL's discretion, if and when it makes sense for the project.
+
+## Scope guidance for contributors
+
+Bug fixes, docs, and incremental improvements that fit the existing architecture are generally welcome without prior discussion — open a PR. Anything that changes public API surface, adds a new dependency, or shifts project direction is worth raising as an issue first, since it's more likely to need back-and-forth before it's mergeable.
+
+See [CONTRIBUTING.md](CONTRIBUTING.md) for the practical mechanics (setup, code style, CLA).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -6,7 +6,7 @@ Only the latest release receives security fixes.
 
 | Version | Supported |
 |---|---|
-| 0.1.x (latest) | Yes |
+| 0.7.x (latest) | Yes |
 | Older releases | No |
 
 ## Reporting a Vulnerability


### PR DESCRIPTION
Prepares the repo for outside contributors while the cost of doing so is still low: an inbound-license section in CONTRIBUTING.md, a draft CLA (individual + corporate, pending legal review), CODEOWNERS, a CLA checkbox on the PR template, a BDFL GOVERNANCE.md, and a fix for SECURITY.md's stale 0.1.x supported-version table.


