### PR TITLE
fix: cut library log noise, prefix and de-duplicate startup log lines

### DIFF
--- a/modelship/driver.py
+++ b/modelship/driver.py
@@ -215,7 +215,7 @@ def main(argv: list[str] | None = None) -> None:
         input_raw = load_raw_models(args.config)
         desired_raw = merge(effective_raw, input_raw, gateway_name, mode)
     yml_conf = to_config(desired_raw)
-    logger.info("Deploying effective config (%s mode, %d model(s)): %s", mode, len(desired_raw), yml_conf)
+    logger.debug("Deploying effective config (%s mode, %d model(s)): %s", mode, len(desired_raw), yml_conf)
 
     plugin_wheels = resolve_all_plugin_wheels(yml_conf)
 

--- a/modelship/infer/replica_coordinator.py
+++ b/modelship/infer/replica_coordinator.py
@@ -21,7 +21,7 @@ import contextlib
 import ray
 
 from modelship.infer.deploy_coordinator import COORDINATOR_NAMESPACE
-from modelship.logging import get_logger
+from modelship.logging import configure_logging, get_logger
 from modelship.metrics import COORDINATOR_GENERATION
 from modelship.state import MemoryStateStore, get_state_store
 
@@ -42,6 +42,10 @@ class ReplicaCoordinator:
     """Durable per-gateway routing registry with long-poll change notification."""
 
     def __init__(self):
+        # MSHIP_LOG_* rides along via the actor's runtime_env (see serve_utils) — this
+        # actor never otherwise runs configure_logging(), so without this its own
+        # logger falls back to Python's bare, unprefixed lastResort handler.
+        configure_logging()
         # Durable ownership registry: gateway_name -> {deployment_name -> model_name}.
         # The driver writes it on (un)deploy; gateway replicas reconcile their
         # routing tables from it (see get_routing / wait_for_change), so the driver

--- a/modelship/logging.py
+++ b/modelship/logging.py
@@ -91,7 +91,8 @@ _LIB_ENV_VARS = {
 # logging-module names.
 _LOWERCASE_LEVEL_LIBS = frozenset({"transformers", "diffusers", "huggingface_hub"})
 
-_LEVELS = [TRACE, logging.DEBUG, logging.INFO, logging.WARNING, logging.ERROR, logging.CRITICAL]
+# Above CRITICAL — effectively off, until the app drops to DEBUG/TRACE.
+_LIB_SILENT_LEVEL = logging.CRITICAL + 10
 
 
 def _resolve_app_level(level_name: str) -> int:
@@ -100,9 +101,10 @@ def _resolve_app_level(level_name: str) -> int:
 
 
 def compute_lib_level(app_level: int) -> tuple[int, str]:
-    """Library log level is one step above the app level (with CRITICAL as ceiling)."""
-    lib_level = next((lv for lv in _LEVELS if lv > app_level), logging.CRITICAL)
-    return lib_level, logging.getLevelName(lib_level)
+    """Libraries mirror the app level at DEBUG or below; fully silent otherwise."""
+    if app_level <= logging.DEBUG:
+        return logging.DEBUG, "DEBUG"
+    return _LIB_SILENT_LEVEL, "CRITICAL"  # name must be one library env vars recognize
 
 
 def get_lib_log_config() -> tuple[int, str]:
@@ -129,6 +131,10 @@ def propagate_lib_log_env(level_name: str | None = None) -> None:
     # We own vLLM's level via setLevel + VLLM_LOGGING_LEVEL, so its dictConfig is pure
     # downside. setdefault so an explicit user value wins.
     os.environ.setdefault("VLLM_CONFIGURE_LOGGING", "0")
+
+    # tqdm disables per-file byte progress bars by default when not a real TTY
+    # (true for every modelship process). This forces them on.
+    os.environ.setdefault("TQDM_POSITION", "-1")
 
 
 def _parse_syslog_target(target: str) -> SysLogHandler:
@@ -184,11 +190,20 @@ def configure_logging() -> None:
     if otel_endpoint:
         _setup_otel(root_logger, otel_endpoint, app_level)
 
-    # Set library log levels via both the Python logger (immediate effect) and
-    # the library's native env var (so the level sticks when the library
-    # re-configures its own loggers later, e.g. vLLM's init_logger).
+    # Give libraries modelship's formatter, each via its own handler instance —
+    # not modelship's own handler object, which e.g. ray.init(logging_level=...)
+    # reaches into and mutates in place, corrupting modelship's own formatting too
+    # since Handler objects are shared by reference, not copied.
     for name in _LIB_LOGGERS:
-        logging.getLogger(name).setLevel(lib_level)
+        lib_logger = logging.getLogger(name)
+        lib_logger.handlers.clear()
+        lib_logger.propagate = False
+        lib_logger.setLevel(lib_level)
+        lib_handler = _parse_syslog_target(log_target) if log_target.startswith("syslog") else logging.StreamHandler()
+        lib_handler.setLevel(lib_level)
+        lib_handler.setFormatter(handler.formatter)
+        lib_handler.addFilter(RequestContextFilter())
+        lib_logger.addHandler(lib_handler)
     propagate_lib_log_env(level_name)
 
 

--- a/modelship/logging.py
+++ b/modelship/logging.py
@@ -101,7 +101,7 @@ def _resolve_app_level(level_name: str) -> int:
 
 
 def compute_lib_level(app_level: int) -> tuple[int, str]:
-    """Libraries mirror the app level at DEBUG or below; fully silent otherwise."""
+    """Silent above DEBUG; at DEBUG or TRACE, floor at DEBUG — no library defines lower."""
     if app_level <= logging.DEBUG:
         return logging.DEBUG, "DEBUG"
     return _LIB_SILENT_LEVEL, "CRITICAL"  # name must be one library env vars recognize

--- a/modelship/openai/api.py
+++ b/modelship/openai/api.py
@@ -91,6 +91,9 @@ class PayloadSizeLimitMiddleware(BaseHTTPMiddleware):
 
 
 def build_app():
+    # Runs at import time in both the driver process (binding the deployment) and
+    # each replica process — before ModelshipAPI.__init__'s configure_logging() call
+    # — so it must stay logging-free; ModelshipAPI.__init__ logs the outcome below instead.
     app = FastAPI()
     app.add_middleware(
         CORSMiddleware,
@@ -102,14 +105,10 @@ def build_app():
 
     max_body_bytes = int(os.environ.get("MSHIP_MAX_REQUEST_BODY_BYTES", _DEFAULT_MAX_BODY_BYTES))
     app.add_middleware(PayloadSizeLimitMiddleware, max_bytes=max_body_bytes)
-    logger.info("Payload size limit: %d bytes", max_body_bytes)
 
     api_keys = get_api_keys()
     if api_keys:
         app.add_middleware(ApiKeyMiddleware, api_keys=api_keys)
-        logger.info("API key authentication enabled (%d key(s))", len(api_keys))
-    else:
-        logger.warning("API key authentication disabled (MSHIP_API_KEYS not set)")
 
     @app.exception_handler(RequestValidationError)
     async def log_validation_error(request: Request, exc: RequestValidationError):
@@ -183,6 +182,13 @@ class ModelshipAPI:
         # Set up modelship-formatted application loggers at the driver's level;
         # MSHIP_LOG_* are forwarded to this replica via runtime_env (see serve_utils).
         configure_logging()
+        max_body_bytes = int(os.environ.get("MSHIP_MAX_REQUEST_BODY_BYTES", _DEFAULT_MAX_BODY_BYTES))
+        logger.info("Payload size limit: %d bytes", max_body_bytes)
+        api_keys = get_api_keys()
+        if api_keys:
+            logger.info("API key authentication enabled (%d key(s))", len(api_keys))
+        else:
+            logger.warning("API key authentication disabled (MSHIP_API_KEYS not set)")
         # model_name -> (app_name -> handle). The inner dict is keyed by app_name
         # so a specific deployment can be dropped by name in remove_deployments.
         self.models: dict[str, dict[str, DeploymentHandle]] = {}

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -38,6 +38,8 @@ def _reset_logging():
     root.setLevel(logging.WARNING)
     root.propagate = True
     saved_lib_levels = {name: logging.getLogger(name).level for name in _LIB_LOGGERS}
+    saved_lib_handlers = {name: list(logging.getLogger(name).handlers) for name in _LIB_LOGGERS}
+    saved_lib_propagate = {name: logging.getLogger(name).propagate for name in _LIB_LOGGERS}
     saved_env = {k: os.environ.get(k) for k in _LIB_ENV_VARS}
     # Clear so each test exercises a clean setdefault path. Importing mship_deploy.py
     # in another test runs propagate_lib_log_env() and pollutes os.environ for
@@ -54,7 +56,10 @@ def _reset_logging():
     yl._configured = False
     root.handlers.clear()
     for name, lvl in saved_lib_levels.items():
-        logging.getLogger(name).setLevel(lvl)
+        lib_logger = logging.getLogger(name)
+        lib_logger.setLevel(lvl)
+        lib_logger.handlers = saved_lib_handlers[name]
+        lib_logger.propagate = saved_lib_propagate[name]
     for k, v in saved_env.items():
         if v is None:
             os.environ.pop(k, None)
@@ -92,20 +97,41 @@ class TestConfigureLogging:
         root = logging.getLogger("modelship")
         assert root.level == logging.DEBUG
 
-    def test_lib_loggers_default_to_warning(self):
+    def test_lib_loggers_silent_by_default(self):
+        from modelship.logging import _LIB_SILENT_LEVEL
+
         configure_logging()
         for name in _LIB_LOGGERS:
-            assert logging.getLogger(name).level == logging.WARNING
+            assert logging.getLogger(name).level == _LIB_SILENT_LEVEL
         for env_var, lib_name in _LIB_ENV_VARS.items():
-            expected = "warning" if lib_name in _LOWERCASE_LEVEL_LIBS else "WARNING"
+            expected = "critical" if lib_name in _LOWERCASE_LEVEL_LIBS else "CRITICAL"
             assert os.environ.get(env_var) == expected
 
     @patch.dict(os.environ, {"MSHIP_LOG_LEVEL": "DEBUG"})
-    def test_lib_loggers_info_at_debug(self):
+    def test_lib_loggers_mirror_debug(self):
         configure_logging()
         assert logging.getLogger("modelship").level == logging.DEBUG
         for name in _LIB_LOGGERS:
-            assert logging.getLogger(name).level == logging.INFO
+            assert logging.getLogger(name).level == logging.DEBUG
+
+    def test_lib_loggers_get_modelship_handler(self):
+        # Also covers the double-print risk: a pre-existing handler (e.g. Ray's
+        # own, attached at import time) must be cleared, not just appended to.
+        stray = logging.StreamHandler()
+        logging.getLogger("ray").addHandler(stray)
+
+        configure_logging()
+        root_formatter = logging.getLogger("modelship").handlers[0].formatter
+        for name in _LIB_LOGGERS:
+            lib_logger = logging.getLogger(name)
+            assert len(lib_logger.handlers) == 1
+            # Formatter is shared, but the handler instance must NOT be — code
+            # like ray.init(logging_level=...) mutates whatever handler it finds
+            # on "ray" in place, which would corrupt modelship's own formatting
+            # too if the object were shared rather than just the formatter.
+            assert lib_logger.handlers[0] is not logging.getLogger("modelship").handlers[0]
+            assert lib_logger.handlers[0].formatter is root_formatter
+            assert lib_logger.propagate is False
 
     @patch.dict(os.environ, {"MSHIP_LOG_LEVEL": "TRACE"})
     def test_trace_mode_sets_trace_app_debug_libs(self):


### PR DESCRIPTION
Library loggers (ray, vllm, huggingface_hub, etc.) now stay fully silent until DEBUG, then mirror modelship's own level and get their own handler instance carrying modelship's formatter, instead of leaking bare/unprefixed lines at INFO. TQDM_POSITION=-1 restores real download progress granularity that non-TTY output otherwise collapses to per-file counts.

Also: move the effective-config dump to DEBUG, fix the API-key/payload-limit and ReplicaCoordinator startup lines missing modelship's prefix (they logged before configure_logging() had run in that process), and stop the API-key lines from double-logging once from the driver's own import of api.py and once from the actual serving replica.


