### PR TITLE
fix: refresh stale and broken model references in example configs

### DIFF
--- a/config/examples/README.md
+++ b/config/examples/README.md
@@ -7,7 +7,9 @@ Ready-to-run `models.yaml` configs for common scenarios. Mount one into the cont
 | [llama-server.yaml](llama-server.yaml) | Quantized GGUF chat (concurrent), vision, sharded GGUF, embeddings via a llama-server subprocess | CPU or NVIDIA GPU |
 | [vllm-cpu.yaml](vllm-cpu.yaml) | Quantized (AWQ/GPTQ) chat via vLLM's CPU backend | CPU |
 | [vllm.yaml](vllm.yaml) | High-throughput chat with tool calling, embeddings, Whisper | NVIDIA GPU |
+| [vllm-vision.yaml](vllm-vision.yaml) | Vision-language chat (image_url content parts) | NVIDIA GPU |
 | [diffusers.yaml](diffusers.yaml) | SDXL Turbo image generation | NVIDIA GPU |
+| [stable-diffusion-cpp.yaml](stable-diffusion-cpp.yaml) | GGUF-quantized image generation (SD 2.1, Flux-schnell) | CPU |
 | [kokoro-tts.yaml](kokoro-tts.yaml) | Kokoro ONNX TTS with GPU + CPU fallback replicas | Mixed |
 | [full-stack.yaml](full-stack.yaml) | LLM + TTS + STT + embeddings on one GPU | NVIDIA GPU |
 | [mini-pc.yaml](mini-pc.yaml) | Low-resource stack: llama-server chat + Kokoro ONNX TTS + whisper.cpp STT | CPU (e.g. Intel N100) |

--- a/config/examples/full-stack.yaml
+++ b/config/examples/full-stack.yaml
@@ -3,14 +3,10 @@
 
 models:
   - name: "llm"
-    model: "Qwen/Qwen2.5-7B-Instruct-AWQ"
+    model: "Qwen/Qwen3-8B-AWQ"
     usecase: "generate"
     loader: "vllm"
     num_gpus: 0.55
-    vllm_engine_kwargs:
-      max_model_len: 16000
-      enable_auto_tool_choice: true
-      tool_call_parser: "hermes"
 
   - name: "kokoro"
     model: "hexgrad/Kokoro-82M"
@@ -22,7 +18,7 @@ models:
       onnx_provider: "CUDAExecutionProvider"
 
   - name: "whisper"
-    model: "openai/whisper-small"
+    model: "openai/whisper-large-v3-turbo"
     usecase: "transcription"
     loader: "vllm"
     num_gpus: 0.15

--- a/config/examples/llama-server.yaml
+++ b/config/examples/llama-server.yaml
@@ -1,48 +1,37 @@
 # llama_server loader examples — GGUF inference via a llama-server subprocess
-# proxied over its native OpenAI-compatible HTTP API. --parallel slots let
-# concurrent requests overlap instead of serializing behind a single lock.
-# Requires MSHIP_LLAMA_SERVER_BIN to point at a llama-server executable (see
-# docs/development.md); the Docker images ship a pinned build already.
+# proxied over its native OpenAI-compatible HTTP API. Requires
+# MSHIP_LLAMA_SERVER_BIN to point at a llama-server executable; the Docker
+# images ship a pinned build already.
 
 models:
-  # Chat: GGUF pulled from a HuggingFace repo, 4 concurrent request slots.
   - name: "qwen"
-    model: "lmstudio-community/Qwen2.5-7B-Instruct-GGUF:*Q4_K_M.gguf"
+    model: "lmstudio-community/Qwen3-8B-GGUF:*Q4_K_M.gguf"
     usecase: "generate"
     loader: "llama_server"
     num_cpus: 3
     llama_server_config:
       parallel: 4
 
-  # Chat: GGUF from a local path (bind-mount the directory into the container).
-  # Tool calling and reasoning parsing are llama-server's own, auto-detected
-  # from the chat template — no modelship-level parser config. See
-  # docs/model-configuration.md for the tool_choice gaps vs. the OpenAI spec.
-  - name: "llama3-local"
-    model: "/.cache/huggingface/llama-3-8b-instruct.Q4_K_M.gguf"
+  # Local-path GGUF; bind-mount the file into the container.
+  - name: "qwen-local"
+    model: "/.cache/huggingface/qwen3-8b-instruct.Q4_K_M.gguf"
     usecase: "generate"
     loader: "llama_server"
     num_cpus: 4
     llama_server_config:
-      n_ctx: 4096
-      n_batch: 512
       parallel: 2
 
-  # Vision: mmproj enables image input; requests with image content are
-  # rejected at the gateway when it's unset.
-  - name: "llava"
-    model: "second-state/Llava-v1.5-7B-GGUF:llava-v1.5-7b-Q4_K_M.gguf"
+  # mmproj enables image input; requests with image content are rejected at
+  # the gateway when it's unset.
+  - name: "qwen-vl"
+    model: "lmstudio-community/Qwen3-VL-8B-Instruct-GGUF:*Q4_K_M.gguf"
     usecase: "generate"
     loader: "llama_server"
     num_cpus: 3
     llama_server_config:
-      mmproj: "second-state/Llava-v1.5-7B-GGUF:llava-v1.5-7b-mmproj-model-f16.gguf"
+      mmproj: "lmstudio-community/Qwen3-VL-8B-Instruct-GGUF:mmproj-Qwen3-VL-8B-Instruct-F16.gguf"
 
-  # Sharded GGUF: models too large for HuggingFace's 50GB single-file limit
-  # ship as numbered shards (here Llama-3.3-70B-Instruct-Q8_0-00001-of-00002.gguf,
-  # -00002-of-00002.gguf). The `*-of-*.gguf` selector matches the whole shard
-  # set; modelship downloads every shard and hands llama-server the first
-  # one's path, which auto-loads the rest. See docs/model-configuration.md.
+  # `*-of-*.gguf` matches a whole sharded set; modelship downloads every shard.
   - name: "llama-70b-q8"
     model: "bartowski/Llama-3.3-70B-Instruct-GGUF:*Q8_0*-of-*.gguf"
     usecase: "generate"
@@ -51,7 +40,6 @@ models:
     llama_server_config:
       parallel: 2
 
-  # Embeddings
   - name: "nomic-embed"
     model: "nomic-ai/nomic-embed-text-v1.5-GGUF:nomic-embed-text-v1.5.Q4_K_M.gguf"
     usecase: "embed"

--- a/config/examples/mini-pc.yaml
+++ b/config/examples/mini-pc.yaml
@@ -3,16 +3,12 @@
 # Note: kokoroonnx needs espeak-ng on the host (apt-get install -y espeak-ng).
 
 models:
-  # Chat — 3B Q4 quant, ~2 GB, tool calling works for simple commands.
   - name: "qwen"
-    model: "lmstudio-community/Qwen2.5-3B-Instruct-GGUF:*Q4_K_M.gguf"
+    model: "lmstudio-community/Qwen3-4B-GGUF:*Q4_K_M.gguf"
     usecase: "generate"
     loader: "llama_server"
     num_cpus: 2
-    llama_server_config:
-      n_ctx: 4096
 
-  # TTS — Kokoro on CPU via ONNX.
   - name: "kokoro"
     model: "hexgrad/Kokoro-82M"
     usecase: "tts"
@@ -23,7 +19,7 @@ models:
     plugin_config:
       onnx_provider: "CPUExecutionProvider"
 
-  # STT — whisper.cpp base.en (~150 MB). Swap to `base` for multilingual.
+  # Swap to `base` for multilingual.
   - name: "whisper"
     model: "base.en"
     usecase: "transcription"

--- a/config/examples/stable-diffusion-cpp.yaml
+++ b/config/examples/stable-diffusion-cpp.yaml
@@ -1,13 +1,10 @@
-# stable-diffusion.cpp loader — CPU-only image generation.
-# Runs GGUF-quantized diffusion models (SD1.5 / SDXL / SD-Turbo, all-in-one Flux)
-# with no GPU. Ideal for NAS / mini-PC hosts. Serves /v1/images/generations,
+# stable-diffusion.cpp loader — CPU-only image generation via GGUF-quantized
+# diffusion models. Ideal for NAS / mini-PC hosts. Serves /v1/images/generations,
 # /v1/images/edits and /v1/images/variations.
 
 models:
-  # SDXL-Turbo: fast, few-step single-file GGUF pulled from a HuggingFace repo
-  # (the glob after `:` picks the quant).
-  - name: "sdxl-turbo"
-    model: "second-state/stable-diffusion-xl-turbo-GGUF:*Q4_0.gguf"
+  - name: "sd21-turbo"
+    model: "gpustack/stable-diffusion-v2-1-turbo-GGUF:*Q4_1.gguf"
     usecase: "image"
     loader: "stable_diffusion_cpp"
     num_cpus: 4
@@ -15,8 +12,7 @@ models:
       sample_steps: 4
       cfg_scale: 1.0
 
-  # All-in-one Flux-schnell from a local path (bind-mount the file into the
-  # container). High quality, 4 steps. Enable vae_tiling to cap peak RAM.
+  # Flux-schnell from a local path; bind-mount the file into the container.
   - name: "flux-schnell"
     model: "/.cache/models/flux1-schnell-q4_k.gguf"
     usecase: "image"
@@ -25,4 +21,3 @@ models:
     stable_diffusion_cpp_config:
       sample_steps: 4
       cfg_scale: 1.0
-      vae_tiling: true

--- a/config/examples/vllm-cpu.yaml
+++ b/config/examples/vllm-cpu.yaml
@@ -1,28 +1,11 @@
-# vLLM loader on CPU — no GPU required.
-#
-# Requires a non-GGUF checkpoint: safetensors, or an AWQ/GPTQ/compressed-tensors
-# quant (CPU backend supports AWQ/GPTQ on x86, plus INT8 W8A8).
-#
-# gpu_memory_utilization means something different here than on GPU: vLLM's
-# CPU backend repurposes it as the fraction of HOST RAM to reserve for the KV
-# cache, not VRAM. modelship defaults it to 0.4 for num_gpus: 0 deploys (the
-# GPU-oriented 0.9 default would ask to reserve 90% of node RAM and fail at
-# worker init on a real machine) — set it explicitly here to whatever your
-# box can spare. For finer control, vLLM also reads VLLM_CPU_KVCACHE_SPACE
-# (a fixed GiB budget instead of a RAM fraction) and VLLM_CPU_OMP_THREADS_BIND
-# from the process environment directly; see docs/model-configuration.md.
-#
-# See docs/model-configuration.md for the full vllm_engine_kwargs reference.
+# vLLM loader on CPU — no GPU required. Requires a non-GGUF checkpoint:
+# safetensors, or an AWQ/GPTQ/compressed-tensors quant. gpu_memory_utilization
+# and max_model_len are left unset so preflight sizes both from free host RAM.
 
 models:
   - name: "qwen-cpu"
-    model: "Qwen/Qwen2.5-7B-Instruct-AWQ"
+    model: "Qwen/Qwen3-8B-AWQ"
     usecase: "generate"
     loader: "vllm"
     num_gpus: 0
     num_cpus: 4
-    vllm_engine_kwargs:
-      max_model_len: 8192
-      enable_auto_tool_choice: true
-      tool_call_parser: "hermes"
-      gpu_memory_utilization: 0.4

--- a/config/examples/vllm-vision.yaml
+++ b/config/examples/vllm-vision.yaml
@@ -1,24 +1,18 @@
 # vLLM vision (VLM) example — requires an NVIDIA GPU with enough VRAM for the
-# vision encoder plus KV cache. Tested with Qwen2.5-VL-7B-Instruct on a single
-# 24GB GPU. Send chat messages with `image_url` content parts the same way you
-# would against the official OpenAI API.
+# vision encoder plus KV cache. Send chat messages with `image_url` content
+# parts the same way you would against the official OpenAI API.
 
 models:
   - name: "qwen-vl"
-    model: "Qwen/Qwen2.5-VL-7B-Instruct"
+    model: "Qwen/Qwen3-VL-8B-Instruct"
     usecase: "generate"
     loader: "vllm"
     num_gpus: 1
     vllm_engine_kwargs:
-      # VLMs eat hundreds to thousands of tokens per image; bump the context
-      # so a single user turn with one image still has room for a response.
-      max_model_len: 16384
-      # Cap images per request: protects against accidentally OOM-ing the GPU
-      # when a client sends a 50-image batch. Adjust to your VRAM budget.
+      # Cap images per request to avoid OOM on a large batch.
       limit_mm_per_prompt:
         image: 4
-      # Qwen2.5-VL accepts min/max pixel knobs that trade off latency vs detail.
-      # Defaults are high quality; lower max_pixels to speed up inference.
+      # Trades off latency vs detail; defaults are high quality.
       mm_processor_kwargs:
         min_pixels: 50176   # 224 * 224
         max_pixels: 1003520 # 1280 * 784

--- a/config/examples/vllm.yaml
+++ b/config/examples/vllm.yaml
@@ -2,19 +2,13 @@
 # See docs/model-configuration.md for the full vllm_engine_kwargs reference.
 
 models:
-  # High-throughput chat with tool calling
+  # Tool calling and reasoning parsers auto-detect from the chat template.
   - name: "llm"
-    model: "Qwen/Qwen2.5-7B-Instruct-AWQ"
+    model: "Qwen/Qwen3-8B-AWQ"
     usecase: "generate"
     loader: "vllm"
     num_gpus: 0.7
-    vllm_engine_kwargs:
-      tensor_parallel_size: 1
-      max_model_len: 16000
-      enable_auto_tool_choice: true
-      tool_call_parser: "hermes"
 
-  # Embeddings
   - name: "nomic-embed"
     model: "nomic-ai/nomic-embed-text-v1.5"
     usecase: "embed"
@@ -23,22 +17,18 @@ models:
     vllm_engine_kwargs:
       trust_remote_code: true
 
-  # Speech-to-text (Whisper)
   - name: "whisper"
-    model: "openai/whisper-small"
+    model: "openai/whisper-large-v3-turbo"
     usecase: "transcription"
     loader: "vllm"
     num_gpus: 0.25
     vllm_engine_kwargs:
       trust_remote_code: true
 
-  # Load-driven autoscaling. Ray Serve scales replicas between min_replicas and
-  # max_replicas based on in-flight requests. Mutually exclusive with
-  # num_replicas (set one or the other, never both). min_replicas: 0 enables
-  # scale-to-zero — the model releases its GPU when idle and cold-starts on the
-  # next request.
+  # Autoscaling replaces num_replicas (set one or the other, never both).
+  # min_replicas: 0 enables scale-to-zero.
   - name: "bursty-llm"
-    model: "Qwen/Qwen2.5-7B-Instruct-AWQ"
+    model: "Qwen/Qwen3-8B-AWQ"
     usecase: "generate"
     loader: "vllm"
     num_gpus: 0.5

--- a/docs/model-configuration.md
+++ b/docs/model-configuration.md
@@ -228,7 +228,7 @@ The fool-proof minimum — preflight fills in everything else:
 ```yaml
 models:
   - name: qwen-cpu
-    model: Qwen/Qwen2.5-7B-Instruct-AWQ
+    model: Qwen/Qwen3-8B-AWQ
     usecase: generate
     loader: vllm
     num_gpus: 0
@@ -308,7 +308,7 @@ models:
 ```yaml
 models:
   - name: whisper
-    model: openai/whisper-small
+    model: openai/whisper-large-v3-turbo
     usecase: transcription
     loader: vllm
     num_gpus: 0.15
@@ -366,7 +366,7 @@ The fool-proof minimum — preflight fills in `n_ctx`, `n_gpu_layers`, and `thre
 ```yaml
 models:
   - name: "qwen-llama-server"
-    model: "lmstudio-community/Qwen2.5-7B-Instruct-GGUF:*Q4_K_M.gguf"
+    model: "lmstudio-community/Qwen3-8B-GGUF:*Q4_K_M.gguf"
     usecase: "generate"
     loader: "llama_server"
     num_gpus: 1
@@ -388,12 +388,12 @@ Set `mmproj` to a multimodal projector file (local path or `repo:filename`, reso
 
 ```yaml
 models:
-  - name: "llava-llama-server"
-    model: "second-state/Llava-v1.5-7B-GGUF:llava-v1.5-7b-Q4_K_M.gguf"
+  - name: "qwen-vl-llama-server"
+    model: "lmstudio-community/Qwen3-VL-8B-Instruct-GGUF:*Q4_K_M.gguf"
     usecase: "generate"
     loader: "llama_server"
     llama_server_config:
-      mmproj: "second-state/Llava-v1.5-7B-GGUF:llava-v1.5-7b-mmproj-model-f16.gguf"
+      mmproj: "lmstudio-community/Qwen3-VL-8B-Instruct-GGUF:mmproj-Qwen3-VL-8B-Instruct-F16.gguf"
 ```
 
 ### Embeddings (GGUF)
@@ -430,8 +430,8 @@ GGUF variants in a HuggingFace repo are picked via the `:filename` syntax on the
 
 ```yaml
 models:
-  - name: sdxl-turbo
-    model: "second-state/stable-diffusion-xl-turbo-GGUF:*Q4_0.gguf"
+  - name: sd21-turbo
+    model: "gpustack/stable-diffusion-v2-1-turbo-GGUF:*Q4_1.gguf"
     usecase: image
     loader: stable_diffusion_cpp
     num_cpus: 4

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -75,7 +75,7 @@ MODEL_CONFIGS: dict[str, dict] = {
     },
     "chat-vlm": {
         "name": "chat-vlm",
-        "model": "Qwen/Qwen2.5-VL-3B-Instruct",
+        "model": "Qwen/Qwen3-VL-2B-Instruct",
         "usecase": "generate",
         "loader": "vllm",
         "num_gpus": 1,
@@ -194,13 +194,11 @@ MODEL_CONFIGS: dict[str, dict] = {
     },
     "image-cpu-model": {
         "name": "image-cpu-model",
-        # SD2.1 packaged as a single-file sd.cpp GGUF (CLIP + UNet + VAE bundled).
-        # CPU-only; few steps + small size keep the integration run tractable.
-        "model": "jiaowobaba02/stable-diffusion-v2-1-GGUF:*q4_1.gguf",
+        "model": "gpustack/stable-diffusion-v2-1-turbo-GGUF:*Q4_1.gguf",
         "usecase": "image",
         "loader": "stable_diffusion_cpp",
         "num_cpus": 4,
-        "stable_diffusion_cpp_config": {"sample_steps": 6, "cfg_scale": 7.0},
+        "stable_diffusion_cpp_config": {"sample_steps": 4, "cfg_scale": 1.0},
     },
 }
 

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -445,7 +445,7 @@ _RED_PIXEL_DATA_URI = (
 @pytest.mark.integration
 @pytest.mark.vllm
 class TestChatVlm:
-    """End-to-end vision: a real Qwen2.5-VL-3B deployment receiving an
+    """End-to-end vision: a real Qwen3-VL-2B deployment receiving an
     ``image_url`` content part through the modelship gateway."""
 
     @pytest.fixture(autouse=True, scope="class")


### PR DESCRIPTION
Swaps Qwen2.5 examples to Qwen3, whisper-small to whisper-large-v3-turbo, and replaces a dead HuggingFace repo (second-state/stable-diffusion-xl-turbo-GGUF) with a verified, actively-maintained one. Trims example configs to lean on preflight for sizing instead of hardcoded n_ctx/max_model_len/gpu_memory_utilization, and drops explicit tool_call_parser/enable_auto_tool_choice now that vLLM tool-call detection is auto-detected from the chat template.

Aligns integration test models (chat-vlm, image-cpu-model) with the example configs so a broken example now fails CI instead of shipping silently.


