### PR TITLE
fix: crash the replica actor when a loader's backend dies unexpectedly

### DIFF
--- a/modelship/infer/llama_server/llama_server_infer.py
+++ b/modelship/infer/llama_server/llama_server_infer.py
@@ -113,8 +113,12 @@ class LlamaServerInfer(BaseInfer[dict[str, Any]]):
         self._log_lock = threading.Lock()
         self._recent_log_lines: deque[str] = deque(maxlen=_RECENT_LOG_LINES)
         self._log_threads: list[threading.Thread] = []
+        # True during our own shutdown()/retry teardown, so _watch_process can
+        # tell an intentional kill from a real crash.
+        self._shutting_down = False
 
     def shutdown(self) -> None:
+        self._shutting_down = True
         if self._proc is not None:
             if self._proc.poll() is None:
                 logger.info("Shutting down llama-server for %s", self.model_config.name)
@@ -204,12 +208,26 @@ class LlamaServerInfer(BaseInfer[dict[str, Any]]):
             raise
 
         assert self._port is not None
+        assert self._proc is not None
+        # A prior retry's shutdown() (see the _EarlyCrashError branch above) may
+        # have left this set — this is the process we're actually keeping, so
+        # arm the watcher fresh rather than inheriting a stale "don't crash" flag.
+        self._shutting_down = False
+        threading.Thread(target=self._watch_process, args=(self._proc,), daemon=True).start()
         self._client = httpx.AsyncClient(
             base_url=f"http://127.0.0.1:{self._port}",
             headers={"Authorization": f"Bearer {self._api_key}"},
             timeout=httpx.Timeout(timeout=None, connect=10.0),
         )
         self._set_max_context_length(self.config.n_ctx)
+
+    def _watch_process(self, proc: subprocess.Popen) -> None:
+        """Crash the actor if the subprocess exits outside of our own shutdown()."""
+        rc = proc.wait()
+        if self._shutting_down:
+            return
+        logger.error("llama-server for '%s' exited unexpectedly (rc=%s) — exiting actor", self.model_config.name, rc)
+        os._exit(1)
 
     async def _launch(self, binary: str, model_path: str) -> None:
         loop = asyncio.get_running_loop()

--- a/modelship/infer/vllm/vllm_infer.py
+++ b/modelship/infer/vllm/vllm_infer.py
@@ -368,12 +368,14 @@ class VllmInfer(BaseInfer[_VllmPrepared]):
         else:
             logger.warning("vllm engine for '%s' has no output_handler to watch for crashes", self.model_config.name)
 
-    def _on_engine_output_handler_done(self, task: asyncio.Task) -> None:
+    def _on_engine_output_handler_done(self, future: asyncio.Future) -> None:
         """shutdown() cancels output_handler intentionally, so a non-cancelled
         completion here means the engine core died on its own."""
-        if task.cancelled():
+        if future.cancelled():
             return
-        logger.error("vllm engine core for '%s' died — exiting actor", self.model_config.name)
+        logger.error(
+            "vllm engine core for '%s' died — exiting actor", self.model_config.name, exc_info=future.exception()
+        )
         os._exit(1)
 
     async def warmup(self) -> None:

--- a/modelship/infer/vllm/vllm_infer.py
+++ b/modelship/infer/vllm/vllm_infer.py
@@ -1,4 +1,6 @@
+import asyncio
 import io
+import os
 from collections.abc import AsyncGenerator, Sequence
 from dataclasses import dataclass
 from http import HTTPStatus
@@ -360,6 +362,19 @@ class VllmInfer(BaseInfer[_VllmPrepared]):
         self.serving_embedding = await self.init_serving_embedding()
         self.serving_transcription = await self.init_serving_transcription()
         self.serving_translation = await self.init_serving_translation()
+
+        if self.engine.output_handler is not None:
+            self.engine.output_handler.add_done_callback(self._on_engine_output_handler_done)
+        else:
+            logger.warning("vllm engine for '%s' has no output_handler to watch for crashes", self.model_config.name)
+
+    def _on_engine_output_handler_done(self, task: asyncio.Task) -> None:
+        """shutdown() cancels output_handler intentionally, so a non-cancelled
+        completion here means the engine core died on its own."""
+        if task.cancelled():
+            return
+        logger.error("vllm engine core for '%s' died — exiting actor", self.model_config.name)
+        os._exit(1)
 
     async def warmup(self) -> None:
         logger.info("Warming up vllm model: %s", self.model_config.name)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -93,7 +93,7 @@ MODEL_CONFIGS: dict[str, dict] = {
         # target_ongoing_requests=1 makes a handful of concurrent requests
         # exceed one replica's setpoint and drive scale-out; the short delays
         # keep the test's poll windows tractable.
-        "model": "lmstudio-community/Qwen2.5-0.5B-Instruct-GGUF:*Q4_K_M.gguf",
+        "model": "lmstudio-community/Qwen3-0.6B-GGUF:*Q4_K_M.gguf",
         "usecase": "generate",
         "loader": "llama_server",
         "num_cpus": 1,

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1318,11 +1318,10 @@ def _find_and_kill_vllm_engine_core(deadline_s: float = 30) -> int:
     while time.time() < end:
         for proc in psutil.process_iter():
             try:
-                name = proc.name()
                 cmdline = " ".join(proc.cmdline())
             except (psutil.NoSuchProcess, psutil.AccessDenied, psutil.ZombieProcess):
                 continue
-            if "EngineCore" in name or "EngineCore" in cmdline:
+            if "VLLM::EngineCore" in cmdline:
                 pid = proc.pid
                 proc.kill()
                 return pid

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1309,6 +1309,57 @@ class TestAutoscaling:
         assert settled == 1, f"expected scale-in to min_replicas=1 after load, saw {settled}"
 
 
+def _find_and_kill_vllm_engine_core(deadline_s: float = 30) -> int:
+    """SIGKILL the vLLM engine-core subprocess (titled `VLLM::EngineCore` via
+    setproctitle) and return its PID."""
+    import psutil
+
+    end = time.time() + deadline_s
+    while time.time() < end:
+        for proc in psutil.process_iter():
+            try:
+                name = proc.name()
+                cmdline = " ".join(proc.cmdline())
+            except (psutil.NoSuchProcess, psutil.AccessDenied, psutil.ZombieProcess):
+                continue
+            if "EngineCore" in name or "EngineCore" in cmdline:
+                pid = proc.pid
+                proc.kill()
+                return pid
+        time.sleep(1)
+    pytest.fail("Could not find a vLLM EngineCore subprocess to kill within the deadline")
+
+
+@pytest.mark.integration
+@pytest.mark.vllm
+class TestVllmCrashRecovery:
+    """Kills the vLLM engine-core subprocess directly and verifies the replica recovers."""
+
+    MODEL = "chat-capable"
+
+    @pytest.fixture(autouse=True, scope="class")
+    def _deploy(self, model_deployer):
+        model_deployer.deploy(self.MODEL)
+
+    def test_recovers_after_engine_core_crash(self, client):
+        # Sanity: the deployment is actually serving before we kill anything.
+        client.chat.completions.create(model=self.MODEL, messages=_PING_PROMPT, max_tokens=4)
+
+        _find_and_kill_vllm_engine_core()
+
+        def _request_succeeds() -> bool:
+            try:
+                client.chat.completions.create(model=self.MODEL, messages=_PING_PROMPT, max_tokens=4, timeout=15)
+                return True
+            except Exception:
+                return False
+
+        recovered = _poll(_request_succeeds, deadline_s=90)
+        assert recovered, (
+            "expected the deployment to recover (replica respawn) after its engine core crashed; requests kept failing"
+        )
+
+
 def _model_in_all_samples(client: OpenAI, model: str, samples: int = 20) -> bool:
     """True iff `model` appears in /v1/models on EVERY sampled request. With the
     gateway load-balanced across replicas, a stale replica would omit it on some


### PR DESCRIPTION
llama_server and vllm both spawn a subprocess (llama-server, vLLM's engine core) that could die after startup with nothing noticing — the Ray Serve replica stayed marked healthy and blackholed all future traffic forever.

LlamaServerInfer now watches its subprocess in a background thread and VllmInfer hooks AsyncLLM.output_handler's completion; either backend dying outside of our own shutdown() now exits the actor process immediately, so Ray Serve's router (which already reacts to a dead actor per-request) evicts the replica and the controller reconciles a replacement — no health-check polling needed.

tests/test_integration.py::TestAutoscaling is restored to its original Qwen3-0.6B-GGUF trigger and a new TestVllmCrashRecovery reproduces the same gap for vllm by killing the engine-core subprocess directly; both now pass.

Fixes #156


