### PR TITLE
fix: raise onnxruntime-gpu floor to 1.28.0 for CUDA 13 compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 <div align="center">
   <picture>
-    <source media="(prefers-color-scheme: dark)" srcset="docs/assets/logo-dark.svg">
-    <source media="(prefers-color-scheme: light)" srcset="docs/assets/logo-light.svg">
-    <img alt="Modelship" src="docs/assets/logo-light.svg" width="160">
+    <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/modelship-ai/modelship/main/docs/assets/logo-dark.svg">
+    <source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/modelship-ai/modelship/main/docs/assets/logo-light.svg">
+    <img alt="Modelship" src="https://raw.githubusercontent.com/modelship-ai/modelship/main/docs/assets/logo-light.svg" width="160">
   </picture>
 </div>
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,7 @@ metal = [
     "numba>=0.61.0",
     "scipy>=1.16.1",
     "soundfile>=0.13.0",
-    "onnxruntime>=1.20.1",
+    "onnxruntime>=1.28.0",
     "stable-diffusion-cpp-python>=0.4.7",
 ]
 cuda = [
@@ -58,7 +58,7 @@ cuda = [
     "bitsandbytes>=0.49.0",
     "diffusers>=0.31.0",
     "stable-diffusion-cpp-python>=0.4.7",
-    "onnxruntime-gpu>=1.20.1",
+    "onnxruntime-gpu>=1.28.0",
     "nvidia-ml-py",
     "librosa>=0.11.0",
     "numba>=0.61.0",
@@ -70,7 +70,7 @@ cpu = [
     "torchvision>=0.25.0",
     "transformers>=5.5.3",
     "stable-diffusion-cpp-python>=0.4.7",
-    "onnxruntime>=1.20.1",
+    "onnxruntime>=1.28.0",
     "vllm==0.26.0",
     "vllm[audio]==0.26.0",
     "librosa>=0.11.0",

--- a/tests/test_cuda_abi_drift.py
+++ b/tests/test_cuda_abi_drift.py
@@ -1,0 +1,56 @@
+"""Every extension module's libcudart/libcublas/libcublasLt must link against the
+same CUDA major as torch. Those three track the toolkit major in lockstep; libcurand/
+libcusparse/libcusolver/libcufft don't, so they're excluded to avoid false positives.
+"""
+
+import re
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+torch = pytest.importorskip("torch")
+
+_NEEDED_RE = re.compile(r"\(NEEDED\)\s+Shared library: \[(?P<name>[^\]]+)\]")
+_TRACKED_SONAME_RE = re.compile(r"^lib(?:cudart|cublas|cublasLt)\.so\.(?P<major>\d+)$")
+
+# bitsandbytes bundles one prebuilt .so per CUDA major and selects the matching one
+# at import time, so older-major libs are expected to sit unused on disk.
+_EXCLUDED_DIST_DIRS = {"bitsandbytes"}
+
+
+def _torch_cuda_major() -> str | None:
+    cuda_version = torch.version.cuda
+    if not cuda_version:
+        return None
+    return cuda_version.split(".")[0]
+
+
+@pytest.mark.skipif(shutil.which("readelf") is None, reason="readelf not on PATH")
+def test_cuda_linked_extensions_match_torch_cuda_major():
+    torch_major = _torch_cuda_major()
+    if torch_major is None:
+        pytest.skip("torch build has no CUDA (cpu extra) — nothing to compare against")
+
+    site_packages = Path(torch.__file__).resolve().parent.parent
+    mismatches = []
+    for so_file in site_packages.rglob("*.so"):
+        if so_file.relative_to(site_packages).parts[0] in _EXCLUDED_DIST_DIRS:
+            continue
+        result = subprocess.run(
+            ["readelf", "-d", str(so_file)],
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=5,
+        )
+        for match in _NEEDED_RE.finditer(result.stdout):
+            soname_match = _TRACKED_SONAME_RE.match(match.group("name"))
+            if soname_match and soname_match.group("major") != torch_major:
+                mismatches.append(f"{so_file.relative_to(site_packages)} needs {match.group('name')}")
+
+    assert not mismatches, (
+        f"found extension modules linked against a different CUDA major than torch's "
+        f"cu{torch_major} build:\n" + "\n".join(mismatches)
+    )

--- a/uv.lock
+++ b/uv.lock
@@ -1358,7 +1358,8 @@ dependencies = [
     { name = "colorlog" },
     { name = "espeakng-loader" },
     { name = "numpy" },
-    { name = "onnxruntime" },
+    { name = "onnxruntime", version = "1.24.4", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-5-mship-cuda'" },
+    { name = "onnxruntime", version = "1.28.0", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-5-mship-cpu' or extra != 'extra-5-mship-cuda' or (extra == 'extra-5-mship-cuda' and extra == 'extra-5-mship-metal')" },
     { name = "phonemizer-fork" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/36/7c/4d74f7243f546716003bd0cfaae8f562f5d75672142f23fa731f69069efd/kokoro_onnx-0.4.9.tar.gz", hash = "sha256:08682138939f61548a7186ef5cdae79180a5dff6fa23781910eddb1583dcf30b", size = 81209, upload-time = "2025-05-10T22:49:04.758Z" }
@@ -1787,7 +1788,7 @@ dependencies = [
 cpu = [
     { name = "librosa" },
     { name = "numba" },
-    { name = "onnxruntime" },
+    { name = "onnxruntime", version = "1.28.0", source = { registry = "https://pypi.org/simple" } },
     { name = "scipy" },
     { name = "soundfile" },
     { name = "stable-diffusion-cpp-python" },
@@ -1831,7 +1832,7 @@ kokoroonnx = [
 metal = [
     { name = "librosa" },
     { name = "numba" },
-    { name = "onnxruntime" },
+    { name = "onnxruntime", version = "1.28.0", source = { registry = "https://pypi.org/simple" } },
     { name = "scipy" },
     { name = "soundfile" },
     { name = "stable-diffusion-cpp-python" },
@@ -1872,9 +1873,9 @@ requires-dist = [
     { name = "numba", marker = "extra == 'metal'", specifier = ">=0.61.0" },
     { name = "numpy", specifier = ">=2.2.6" },
     { name = "nvidia-ml-py", marker = "extra == 'cuda'" },
-    { name = "onnxruntime", marker = "extra == 'cpu'", specifier = ">=1.20.1" },
-    { name = "onnxruntime", marker = "extra == 'metal'", specifier = ">=1.20.1" },
-    { name = "onnxruntime-gpu", marker = "extra == 'cuda'", specifier = ">=1.20.1" },
+    { name = "onnxruntime", marker = "extra == 'cpu'", specifier = ">=1.28.0" },
+    { name = "onnxruntime", marker = "extra == 'metal'", specifier = ">=1.28.0" },
+    { name = "onnxruntime-gpu", marker = "extra == 'cuda'", specifier = ">=1.28.0" },
     { name = "opentelemetry-exporter-otlp", marker = "extra == 'otel'", specifier = ">=1.20.0" },
     { name = "opentelemetry-sdk", marker = "extra == 'otel'", specifier = ">=1.20.0" },
     { name = "orpheus", marker = "extra == 'orpheus'", editable = "plugins/orpheus" },
@@ -2353,12 +2354,18 @@ wheels = [
 name = "onnxruntime"
 version = "1.24.4"
 source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "sys_platform == 'darwin'",
+    "sys_platform == 'win32'",
+    "sys_platform == 'emscripten'",
+    "sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+]
 dependencies = [
-    { name = "flatbuffers" },
-    { name = "numpy" },
-    { name = "packaging" },
-    { name = "protobuf" },
-    { name = "sympy" },
+    { name = "flatbuffers", marker = "extra == 'extra-5-mship-cuda'" },
+    { name = "numpy", marker = "extra == 'extra-5-mship-cuda'" },
+    { name = "packaging", marker = "extra == 'extra-5-mship-cuda'" },
+    { name = "protobuf", marker = "extra == 'extra-5-mship-cuda'" },
+    { name = "sympy", marker = "extra == 'extra-5-mship-cuda'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d7/38/31db1b232b4ba960065a90c1506ad7a56995cd8482033184e97fadca17cc/onnxruntime-1.24.4-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:cad1c2b3f455c55678ab2a8caa51fb420c25e6e3cf10f4c23653cdabedc8de78", size = 17341875, upload-time = "2026-03-17T22:05:51.669Z" },
@@ -2369,19 +2376,72 @@ wheels = [
 ]
 
 [[package]]
+name = "onnxruntime"
+version = "1.28.0"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "(platform_machine == 's390x' and sys_platform == 'darwin' and extra == 'extra-5-mship-cpu' and extra != 'extra-5-mship-cuda' and extra == 'extra-5-mship-metal') or (platform_machine == 'x86_64' and sys_platform == 'darwin' and extra == 'extra-5-mship-cpu' and extra != 'extra-5-mship-cuda' and extra == 'extra-5-mship-metal')",
+    "platform_machine == 'aarch64' and sys_platform == 'darwin' and extra == 'extra-5-mship-cpu' and extra != 'extra-5-mship-cuda' and extra == 'extra-5-mship-metal'",
+    "(platform_machine == 's390x' and sys_platform == 'win32' and extra == 'extra-5-mship-cpu' and extra != 'extra-5-mship-cuda' and extra == 'extra-5-mship-metal') or (platform_machine == 'x86_64' and sys_platform == 'win32' and extra == 'extra-5-mship-cpu' and extra != 'extra-5-mship-cuda' and extra == 'extra-5-mship-metal')",
+    "(platform_machine == 's390x' and sys_platform == 'emscripten' and extra == 'extra-5-mship-cpu' and extra != 'extra-5-mship-cuda' and extra == 'extra-5-mship-metal') or (platform_machine == 'x86_64' and sys_platform == 'emscripten' and extra == 'extra-5-mship-cpu' and extra != 'extra-5-mship-cuda' and extra == 'extra-5-mship-metal')",
+    "(platform_machine == 's390x' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32' and extra == 'extra-5-mship-cpu' and extra != 'extra-5-mship-cuda' and extra == 'extra-5-mship-metal') or (platform_machine == 'x86_64' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32' and extra == 'extra-5-mship-cpu' and extra != 'extra-5-mship-cuda' and extra == 'extra-5-mship-metal')",
+    "platform_machine == 'aarch64' and sys_platform == 'win32' and extra == 'extra-5-mship-cpu' and extra != 'extra-5-mship-cuda' and extra == 'extra-5-mship-metal'",
+    "platform_machine == 'aarch64' and sys_platform == 'emscripten' and extra == 'extra-5-mship-cpu' and extra != 'extra-5-mship-cuda' and extra == 'extra-5-mship-metal'",
+    "platform_machine == 'aarch64' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32' and extra == 'extra-5-mship-cpu' and extra != 'extra-5-mship-cuda' and extra == 'extra-5-mship-metal'",
+    "(platform_machine == 'ppc64le' and sys_platform == 'win32' and extra == 'extra-5-mship-cpu' and extra != 'extra-5-mship-cuda' and extra == 'extra-5-mship-metal') or (platform_machine == 'riscv64' and sys_platform == 'win32' and extra == 'extra-5-mship-cpu' and extra != 'extra-5-mship-cuda' and extra == 'extra-5-mship-metal')",
+    "(platform_machine == 'ppc64le' and sys_platform == 'emscripten' and extra == 'extra-5-mship-cpu' and extra != 'extra-5-mship-cuda' and extra == 'extra-5-mship-metal') or (platform_machine == 'riscv64' and sys_platform == 'emscripten' and extra == 'extra-5-mship-cpu' and extra != 'extra-5-mship-cuda' and extra == 'extra-5-mship-metal')",
+    "(platform_machine != 'aarch64' and platform_machine != 's390x' and platform_machine != 'x86_64' and sys_platform == 'darwin' and extra == 'extra-5-mship-cpu' and extra != 'extra-5-mship-cuda' and extra == 'extra-5-mship-metal') or (platform_machine == 'ppc64le' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32' and extra == 'extra-5-mship-cpu' and extra != 'extra-5-mship-cuda' and extra == 'extra-5-mship-metal') or (platform_machine == 'riscv64' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32' and extra == 'extra-5-mship-cpu' and extra != 'extra-5-mship-cuda' and extra == 'extra-5-mship-metal')",
+    "platform_machine != 'aarch64' and platform_machine != 'ppc64le' and platform_machine != 'riscv64' and platform_machine != 's390x' and platform_machine != 'x86_64' and sys_platform == 'win32' and extra == 'extra-5-mship-cpu' and extra != 'extra-5-mship-cuda' and extra == 'extra-5-mship-metal'",
+    "platform_machine != 'aarch64' and platform_machine != 'ppc64le' and platform_machine != 'riscv64' and platform_machine != 's390x' and platform_machine != 'x86_64' and sys_platform == 'emscripten' and extra == 'extra-5-mship-cpu' and extra != 'extra-5-mship-cuda' and extra == 'extra-5-mship-metal'",
+    "platform_machine != 'aarch64' and platform_machine != 'ppc64le' and platform_machine != 'riscv64' and platform_machine != 's390x' and platform_machine != 'x86_64' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32' and extra == 'extra-5-mship-cpu' and extra != 'extra-5-mship-cuda' and extra == 'extra-5-mship-metal'",
+    "(platform_machine == 's390x' and sys_platform == 'darwin' and extra == 'extra-5-mship-cpu' and extra != 'extra-5-mship-cuda' and extra != 'extra-5-mship-metal') or (platform_machine == 'x86_64' and sys_platform == 'darwin' and extra == 'extra-5-mship-cpu' and extra != 'extra-5-mship-cuda' and extra != 'extra-5-mship-metal')",
+    "platform_machine == 'aarch64' and sys_platform == 'darwin' and extra == 'extra-5-mship-cpu' and extra != 'extra-5-mship-cuda' and extra != 'extra-5-mship-metal'",
+    "(platform_machine == 's390x' and sys_platform == 'win32' and extra == 'extra-5-mship-cpu' and extra != 'extra-5-mship-cuda' and extra != 'extra-5-mship-metal') or (platform_machine == 'x86_64' and sys_platform == 'win32' and extra == 'extra-5-mship-cpu' and extra != 'extra-5-mship-cuda' and extra != 'extra-5-mship-metal')",
+    "(platform_machine == 's390x' and sys_platform == 'emscripten' and extra == 'extra-5-mship-cpu' and extra != 'extra-5-mship-cuda' and extra != 'extra-5-mship-metal') or (platform_machine == 'x86_64' and sys_platform == 'emscripten' and extra == 'extra-5-mship-cpu' and extra != 'extra-5-mship-cuda' and extra != 'extra-5-mship-metal')",
+    "(platform_machine == 's390x' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32' and extra == 'extra-5-mship-cpu' and extra != 'extra-5-mship-cuda' and extra != 'extra-5-mship-metal') or (platform_machine == 'x86_64' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32' and extra == 'extra-5-mship-cpu' and extra != 'extra-5-mship-cuda' and extra != 'extra-5-mship-metal')",
+    "platform_machine == 'aarch64' and sys_platform == 'win32' and extra == 'extra-5-mship-cpu' and extra != 'extra-5-mship-cuda' and extra != 'extra-5-mship-metal'",
+    "platform_machine == 'aarch64' and sys_platform == 'emscripten' and extra == 'extra-5-mship-cpu' and extra != 'extra-5-mship-cuda' and extra != 'extra-5-mship-metal'",
+    "platform_machine == 'aarch64' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32' and extra == 'extra-5-mship-cpu' and extra != 'extra-5-mship-cuda' and extra != 'extra-5-mship-metal'",
+    "(platform_machine == 'ppc64le' and sys_platform == 'win32' and extra == 'extra-5-mship-cpu' and extra != 'extra-5-mship-cuda' and extra != 'extra-5-mship-metal') or (platform_machine == 'riscv64' and sys_platform == 'win32' and extra == 'extra-5-mship-cpu' and extra != 'extra-5-mship-cuda' and extra != 'extra-5-mship-metal')",
+    "(platform_machine == 'ppc64le' and sys_platform == 'emscripten' and extra == 'extra-5-mship-cpu' and extra != 'extra-5-mship-cuda' and extra != 'extra-5-mship-metal') or (platform_machine == 'riscv64' and sys_platform == 'emscripten' and extra == 'extra-5-mship-cpu' and extra != 'extra-5-mship-cuda' and extra != 'extra-5-mship-metal')",
+    "(platform_machine != 'aarch64' and platform_machine != 's390x' and platform_machine != 'x86_64' and sys_platform == 'darwin' and extra == 'extra-5-mship-cpu' and extra != 'extra-5-mship-cuda' and extra != 'extra-5-mship-metal') or (platform_machine == 'ppc64le' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32' and extra == 'extra-5-mship-cpu' and extra != 'extra-5-mship-cuda' and extra != 'extra-5-mship-metal') or (platform_machine == 'riscv64' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32' and extra == 'extra-5-mship-cpu' and extra != 'extra-5-mship-cuda' and extra != 'extra-5-mship-metal')",
+    "platform_machine != 'aarch64' and platform_machine != 'ppc64le' and platform_machine != 'riscv64' and platform_machine != 's390x' and platform_machine != 'x86_64' and sys_platform == 'win32' and extra == 'extra-5-mship-cpu' and extra != 'extra-5-mship-cuda' and extra != 'extra-5-mship-metal'",
+    "platform_machine != 'aarch64' and platform_machine != 'ppc64le' and platform_machine != 'riscv64' and platform_machine != 's390x' and platform_machine != 'x86_64' and sys_platform == 'emscripten' and extra == 'extra-5-mship-cpu' and extra != 'extra-5-mship-cuda' and extra != 'extra-5-mship-metal'",
+    "platform_machine != 'aarch64' and platform_machine != 'ppc64le' and platform_machine != 'riscv64' and platform_machine != 's390x' and platform_machine != 'x86_64' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32' and extra == 'extra-5-mship-cpu' and extra != 'extra-5-mship-cuda' and extra != 'extra-5-mship-metal'",
+    "sys_platform == 'win32' and extra != 'extra-5-mship-cpu' and extra != 'extra-5-mship-cuda' and extra == 'extra-5-mship-metal'",
+    "sys_platform == 'emscripten' and extra != 'extra-5-mship-cpu' and extra != 'extra-5-mship-cuda' and extra == 'extra-5-mship-metal'",
+    "sys_platform != 'emscripten' and sys_platform != 'win32' and extra != 'extra-5-mship-cpu' and extra != 'extra-5-mship-cuda' and extra == 'extra-5-mship-metal'",
+    "sys_platform == 'win32' and extra != 'extra-5-mship-cpu' and extra != 'extra-5-mship-cuda' and extra != 'extra-5-mship-metal'",
+    "sys_platform == 'emscripten' and extra != 'extra-5-mship-cpu' and extra != 'extra-5-mship-cuda' and extra != 'extra-5-mship-metal'",
+    "sys_platform != 'emscripten' and sys_platform != 'win32' and extra != 'extra-5-mship-cpu' and extra != 'extra-5-mship-cuda' and extra != 'extra-5-mship-metal'",
+]
+dependencies = [
+    { name = "flatbuffers", marker = "extra == 'extra-5-mship-cpu' or extra != 'extra-5-mship-cuda' or (extra == 'extra-5-mship-cuda' and extra == 'extra-5-mship-metal')" },
+    { name = "numpy", marker = "extra == 'extra-5-mship-cpu' or extra != 'extra-5-mship-cuda' or (extra == 'extra-5-mship-cuda' and extra == 'extra-5-mship-metal')" },
+    { name = "packaging", marker = "extra == 'extra-5-mship-cpu' or extra != 'extra-5-mship-cuda' or (extra == 'extra-5-mship-cuda' and extra == 'extra-5-mship-metal')" },
+    { name = "protobuf", marker = "extra == 'extra-5-mship-cpu' or extra != 'extra-5-mship-cuda' or (extra == 'extra-5-mship-cuda' and extra == 'extra-5-mship-metal')" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/98/f8/dcbe7700dca82fa540035abd3c868fe5ad0f86af00b9a3db7c2e27d15c7d/onnxruntime-1.28.0-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:26ff0fdd06efb6c155bae95387a09db1a2be89c7a03e4d0bffd5a171cc2826da", size = 19141362, upload-time = "2026-07-25T01:22:36.965Z" },
+    { url = "https://files.pythonhosted.org/packages/28/5b/1d77e62097fdbe07e2dc827f389b1c4c0c275f6fab0369a8f46d2461af27/onnxruntime-1.28.0-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4e81a23df16e7acb9d51b06d30cc098e49315ef9180f97bc2221d167b4b04d9c", size = 17050628, upload-time = "2026-07-25T01:21:40.481Z" },
+    { url = "https://files.pythonhosted.org/packages/95/df/5486ab03e9be288d5268867054c8b04bebcf95bfd12e801c05cc67703dab/onnxruntime-1.28.0-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0a83bdb70d143cede762b677789bf2a7acca54b3fb82565601d5c30695aa933c", size = 19214257, upload-time = "2026-07-25T01:22:01.695Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/3b/986ca67c274932ba9ac5332fb10de56f643dfd433c74e33f8ae8f847cf24/onnxruntime-1.28.0-cp312-cp312-win_amd64.whl", hash = "sha256:c35064f9b3c43c81c5d5d282091401d0f1ff22796d93ccade4ea2ece5e137ab8", size = 13755036, upload-time = "2026-07-25T01:22:26.89Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/46/059dba81d46c6ba88e0c2d1c64321ac8098847d678423300a183d42ecbd6/onnxruntime-1.28.0-cp312-cp312-win_arm64.whl", hash = "sha256:e02feeb0165c5f13b4cc954738078d59b90128516ac12b671ee24a530242bf02", size = 13454462, upload-time = "2026-07-25T01:22:17.38Z" },
+]
+
+[[package]]
 name = "onnxruntime-gpu"
-version = "1.24.4"
+version = "1.28.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "flatbuffers" },
     { name = "numpy" },
     { name = "packaging" },
     { name = "protobuf" },
-    { name = "sympy" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d0/2c/5b3fd4748cf7ed291eae541a37e426efc20ea04cb6e6a05768304ab0aa41/onnxruntime_gpu-1.24.4-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:eb0e38f0c1ef3b76ae0081c8e51eed20dd8925aa916f0fc6f9b8b17d05610e99", size = 252765531, upload-time = "2026-03-17T22:03:57.528Z" },
-    { url = "https://files.pythonhosted.org/packages/f2/86/70cecfdab1e963cc7f8c11e72040dfcd5cff85b1de2de74deba9611e0059/onnxruntime_gpu-1.24.4-cp312-cp312-win_amd64.whl", hash = "sha256:da5c1e327d8e119a831be2790e69f93cf6daab9145ed0aca7577f412a620f709", size = 207197978, upload-time = "2026-03-17T21:58:38.43Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/18/e4e906d564af3dd84c2816118ce8e0c087d351ef69a819727b940fb01b6b/onnxruntime_gpu-1.28.0-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:3b3a63cecd239d72432cd44569d047de8f4d69e471cd5f60f7ac7fc8769be5ec", size = 249767362, upload-time = "2026-07-29T16:31:09.077Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/9e/92554acd080db68f549fd0e653fcf51a9dea7cb31e70c497714a9f2310fc/onnxruntime_gpu-1.28.0-cp312-cp312-win_amd64.whl", hash = "sha256:3befb47dabd2843bb606a50abd6f14b1eb1324eb235d5e5f3b01dd8b8034af1f", size = 241459431, upload-time = "2026-07-25T01:25:05.77Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
The pinned onnxruntime-gpu>=1.20.1 resolved to 1.24.4, whose CUDA provider links against libcublas/libcudart.so.12 while the venv's torch cu130 stack only ships .so.13 sonames — the provider silently failed to load and ONNX Runtime fell back to CPUExecutionProvider with no error. 1.27.0 is upstream's first cu13 build; pin >=1.28.0 for the cleaner nvidia-cuda-runtime~=13.0 metadata, and bump the plain onnxruntime floor in cpu/metal to match.

Also add a regression test that walks installed extension modules' DT_NEEDED entries and asserts libcudart/libcublas/libcublasLt majors match torch's, so this class of drift fails CI instead of degrading silently again.


