### PR TITLE
feat: promote whispercpp to a first-class in-process loader

### DIFF
--- a/config/examples/whispercpp.yaml
+++ b/config/examples/whispercpp.yaml
@@ -1,0 +1,33 @@
+# whispercpp loader examples — in-process whisper.cpp speech-to-text via
+# pywhispercpp. See docs/model-configuration.md for the full reference.
+
+models:
+  # Bare pywhispercpp built-in name; downloaded/cached by pywhispercpp itself.
+  - name: "whisper-cpp-tiny"
+    model: "tiny.en"
+    usecase: "transcription"
+    loader: "whispercpp"
+    num_cpus: 1
+
+  # HF repo:filename, resolved the same way as every other loader.
+  - name: "whisper-cpp-base"
+    model: "ggerganov/whisper.cpp:ggml-base.en.bin"
+    usecase: "transcription"
+    loader: "whispercpp"
+    num_cpus: 2
+    whispercpp_config:
+      n_threads: 2
+
+  # Local-path ggml model; bind-mount the file into the container.
+  - name: "whisper-cpp-local"
+    model: "/.cache/huggingface/ggml-base.en.bin"
+    usecase: "transcription"
+    loader: "whispercpp"
+    num_cpus: 2
+
+  # Metal offload on Apple Silicon; ignored (with a warning) everywhere else.
+  - name: "whisper-cpp-metal"
+    model: "base.en"
+    usecase: "transcription"
+    loader: "whispercpp"
+    num_gpus: 1

--- a/docs/model-configuration.md
+++ b/docs/model-configuration.md
@@ -95,7 +95,7 @@ If `MSHIP_TRUSTED_IDENTITY_HEADER` is unset (the default), modelship falls back 
 | `name` | string | Model identifier used in API requests |
 | `model` | string | HuggingFace repo ID, local path, or `repo:filename` (see [Model source](#model-source)). Required for built-in loaders; optional for `loader: custom` |
 | `usecase` | string | `generate`, `embed`, `transcription`, `translation`, `tts`, or `image` |
-| `loader` | string | `vllm`, `diffusers`, `llama_server`, `stable_diffusion_cpp`, or `custom` |
+| `loader` | string | `vllm`, `diffusers`, `llama_server`, `stable_diffusion_cpp`, `whispercpp`, or `custom` |
 | `plugin` | string | Plugin module name (required when `loader: custom`); automatically loaded from wheels when referenced |
 | `num_gpus` | float \| int | GPU allocation. Fractional `< 1` shares one GPU (also sets vLLM `gpu_memory_utilization`); integer `≥ 1` requests that many whole GPUs (for `vllm`, this auto-sets `tensor_parallel_size = num_gpus` unless tp/pp is already specified). |
 | `num_cpus` | float | CPU units to allocate (default `0.1`) |
@@ -440,6 +440,31 @@ models:
       cfg_scale: 1.0
 ```
 
+## whispercpp Loader
+
+The `whispercpp` loader runs [whisper.cpp](https://github.com/ggml-org/whisper.cpp) speech-to-text in-process via [`pywhispercpp`](https://github.com/absadiki/pywhispercpp) bindings — no subprocess, unlike `llama_server`. It's CPU-only on Linux; on Apple Silicon (`num_gpus: 1`) it also gets Metal offload via the same wheel. `num_gpus` must be `0` or a whole integer — fractional is rejected, same as `llama_server`.
+
+| Field | Type | Default | Description |
+|---|---|---|---|
+| `n_threads` | int | pywhispercpp's own default (`min(4, cores)`) | Compute thread count |
+| `flash_attn` | bool | `false` | ggml flash attention |
+| `models_dir` | string | `<cache_root>/whispercpp` | Only used when `model:` is a bare pywhispercpp built-in name (see below) — where it downloads/caches that model |
+
+`model:` accepts three forms:
+- A pywhispercpp built-in name (e.g. `base.en`, `large-v3-turbo` — see [pywhispercpp's model list](https://github.com/absadiki/pywhispercpp/blob/main/pywhispercpp/constants.py)). pywhispercpp resolves and downloads these itself; modelship does not pre-validate or pin a source.
+- A local path or HF `repo:filename` pointing at a `ggml-*.bin` file, resolved the same way as every other loader (see [Model source](#model-source)). GGUF and safetensors are both rejected with a pointer at the right form (whisper.cpp needs the legacy ggml format; a `.gguf` isn't it).
+
+```yaml
+models:
+  - name: "whisper-cpp-base"
+    model: "base.en"
+    usecase: "transcription"
+    loader: "whispercpp"
+    num_cpus: 2
+```
+
+See `config/examples/whispercpp.yaml` for every `model:` form and a Metal example.
+
 ## Custom Loader (Plugins)
 
 The `custom` loader delegates to a plugin module. The `plugin` field is required and must match an installed plugin package. Plugin-specific options are passed via `plugin_config`.
@@ -447,7 +472,7 @@ The `custom` loader delegates to a plugin module. The `plugin` field is required
 See each plugin's README for configuration details:
 - [Kokoro ONNX TTS](https://github.com/modelship-ai/modelship/blob/main/plugins/kokoroonnx/README.md)
 - [Orpheus TTS](https://github.com/modelship-ai/modelship/blob/main/plugins/orpheus/README.md)
-- [whisper.cpp STT](https://github.com/modelship-ai/modelship/blob/main/plugins/whispercpp/README.md)
+- whisper.cpp STT: superseded by [`loader: whispercpp`](#whispercpp-loader) above; the plugin still exists but the loader is the supported path going forward.
 
 For writing your own plugin, see [Plugin Development](plugins.md).
 

--- a/modelship/deploy/actor_options.py
+++ b/modelship/deploy/actor_options.py
@@ -59,6 +59,9 @@ def build_cache_env_vars() -> dict[str, str]:
         "TRITON_CACHE_DIR": os.environ.get("TRITON_CACHE_DIR", f"{base_cache}/triton"),
         # vLLM's usage-stats thread writes usage_stats.json/do_not_track here
         "VLLM_CONFIG_ROOT": os.environ.get("VLLM_CONFIG_ROOT", f"{base_cache}/vllm-config"),
+        # Default download dir for the whispercpp loader's pywhispercpp-managed
+        # built-in model names (a bare `model:` like `base.en`).
+        "MSHIP_WHISPERCPP_CACHE_DIR": os.environ.get("MSHIP_WHISPERCPP_CACHE_DIR", f"{base_cache}/whispercpp"),
     }
     for var in ("HF_TOKEN", "HF_HUB_OFFLINE"):
         if os.environ.get(var) is not None:
@@ -140,16 +143,16 @@ def build_deployment_options(config: ModelshipModelConfig, plugin_wheel: Path | 
 
     capability_resources = deployment_capability_resources(config)
 
-    if config.loader == ModelLoader.stable_diffusion_cpp and platform.system() != "Darwin":
-        # Off Darwin the loader's ggml backend genuinely is CPU-only. On Darwin,
-        # ggml's runtime device registry picks up Metal automatically — forcing
-        # 0 here wouldn't stop the actor from using the GPU, it would just make
-        # Ray believe it isn't, letting it co-schedule another GPU actor onto it.
+    if config.loader in (ModelLoader.stable_diffusion_cpp, ModelLoader.whispercpp) and platform.system() != "Darwin":
+        # Off Darwin both loaders' ggml backends are CPU-only; on Darwin ggml
+        # picks up Metal on its own, so forcing 0 there would just mislead Ray
+        # into co-scheduling another GPU actor onto the same device.
         if config.num_gpus > 0:
             logger.warning(
-                "num_gpus=%s is ignored for model '%s': stable_diffusion_cpp loader only supports GPU on Metal.",
+                "num_gpus=%s is ignored for model '%s': %s loader only supports GPU on Metal (Apple Silicon).",
                 config.num_gpus,
                 config.name,
+                config.loader.value,
             )
         opts: dict = {
             "ray_actor_options": {

--- a/modelship/deploy/capabilities.py
+++ b/modelship/deploy/capabilities.py
@@ -26,6 +26,7 @@ LOADER_MODULES = {
     "vllm": "vllm",
     "diffusers": "diffusers",
     "stable_diffusion_cpp": "stable_diffusion_cpp",
+    "whispercpp": "pywhispercpp",
 }
 
 _LLAMA_SERVER_LOADER = "llama_server"

--- a/modelship/deploy/config.py
+++ b/modelship/deploy/config.py
@@ -69,6 +69,16 @@ def resolve_all_plugin_wheels(yml_conf: ModelshipConfig) -> dict[str, Path]:
     return wheels
 
 
+def _is_whispercpp_builtin_model_name(model: str) -> bool:
+    """A pywhispercpp built-in model name (e.g. `base.en`) resolves/downloads
+    itself; unavailable (False) on a `pywhispercpp`-less `thin` driver."""
+    try:
+        from pywhispercpp.constants import AVAILABLE_MODELS
+    except ImportError:
+        return False
+    return model in AVAILABLE_MODELS
+
+
 def resolve_all_model_sources(yml_conf: ModelshipConfig) -> None:
     """Pre-flight: check every built-in-loader model's source, without
     downloading any weight bytes.
@@ -87,6 +97,10 @@ def resolve_all_model_sources(yml_conf: ModelshipConfig) -> None:
     """
     for cfg in yml_conf.models:
         if cfg.loader == ModelLoader.custom:
+            continue
+        if cfg.loader == ModelLoader.whispercpp and cfg.model and _is_whispercpp_builtin_model_name(cfg.model):
+            # pywhispercpp resolves/downloads its own built-in models; nothing to pin here.
+            logger.info("Skipping source check for '%s': pywhispercpp built-in model %r", cfg.name, cfg.model)
             continue
         assert cfg.model is not None  # validator guarantees this for built-in loaders
         trust_remote_code = bool(cfg.vllm_engine_kwargs and cfg.vllm_engine_kwargs.trust_remote_code)
@@ -107,4 +121,17 @@ def resolve_all_model_sources(yml_conf: ModelshipConfig) -> None:
                 f"Model '{cfg.name}' resolves to a GGUF file, which the vllm loader does not support "
                 f"(vLLM 0.24 dropped in-tree GGUF). Use `loader: llama_server` for GGUF models, or point "
                 f"the vllm loader at a non-GGUF checkpoint (safetensors, or an AWQ/GPTQ/FP8 quant)."
+            )
+
+        # whisper.cpp needs its own legacy ggml/bin format, never GGUF or safetensors.
+        if cfg.loader == ModelLoader.whispercpp and cfg._pinned_source.resolves_to_gguf:
+            raise ValueError(
+                f"Model '{cfg.name}' resolves to a GGUF file, which the whispercpp loader does not support "
+                f"(whisper.cpp needs its own legacy ggml/bin format, e.g. a `ggml-base.en.bin` file)."
+            )
+        if cfg.loader == ModelLoader.whispercpp and cfg._pinned_source.resolves_to_safetensors:
+            raise ValueError(
+                f"Model '{cfg.name}' resolves to a safetensors checkpoint, which the whispercpp loader does not "
+                f"support (whisper.cpp needs the legacy ggml/bin format). Use `loader: vllm` for a HF-format "
+                f"Whisper checkpoint instead (e.g. openai/whisper-large-v3-turbo)."
             )

--- a/modelship/deploy/config.py
+++ b/modelship/deploy/config.py
@@ -69,14 +69,10 @@ def resolve_all_plugin_wheels(yml_conf: ModelshipConfig) -> dict[str, Path]:
     return wheels
 
 
-def _is_whispercpp_builtin_model_name(model: str) -> bool:
-    """A pywhispercpp built-in model name (e.g. `base.en`) resolves/downloads
-    itself; unavailable (False) on a `pywhispercpp`-less `thin` driver."""
-    try:
-        from pywhispercpp.constants import AVAILABLE_MODELS
-    except ImportError:
-        return False
-    return model in AVAILABLE_MODELS
+def _is_whispercpp_builtin_ref(model: str) -> bool:
+    """A bare pywhispercpp built-in name (e.g. `base.en`) — no repo or path
+    separator. Validated in the actor; the driver may lack pywhispercpp."""
+    return "/" not in model and not os.path.exists(model)
 
 
 def resolve_all_model_sources(yml_conf: ModelshipConfig) -> None:
@@ -98,7 +94,7 @@ def resolve_all_model_sources(yml_conf: ModelshipConfig) -> None:
     for cfg in yml_conf.models:
         if cfg.loader == ModelLoader.custom:
             continue
-        if cfg.loader == ModelLoader.whispercpp and cfg.model and _is_whispercpp_builtin_model_name(cfg.model):
+        if cfg.loader == ModelLoader.whispercpp and cfg.model and _is_whispercpp_builtin_ref(cfg.model):
             # pywhispercpp resolves/downloads its own built-in models; nothing to pin here.
             logger.info("Skipping source check for '%s': pywhispercpp built-in model %r", cfg.name, cfg.model)
             continue
@@ -121,17 +117,4 @@ def resolve_all_model_sources(yml_conf: ModelshipConfig) -> None:
                 f"Model '{cfg.name}' resolves to a GGUF file, which the vllm loader does not support "
                 f"(vLLM 0.24 dropped in-tree GGUF). Use `loader: llama_server` for GGUF models, or point "
                 f"the vllm loader at a non-GGUF checkpoint (safetensors, or an AWQ/GPTQ/FP8 quant)."
-            )
-
-        # whisper.cpp needs its own legacy ggml/bin format, never GGUF or safetensors.
-        if cfg.loader == ModelLoader.whispercpp and cfg._pinned_source.resolves_to_gguf:
-            raise ValueError(
-                f"Model '{cfg.name}' resolves to a GGUF file, which the whispercpp loader does not support "
-                f"(whisper.cpp needs its own legacy ggml/bin format, e.g. a `ggml-base.en.bin` file)."
-            )
-        if cfg.loader == ModelLoader.whispercpp and cfg._pinned_source.resolves_to_safetensors:
-            raise ValueError(
-                f"Model '{cfg.name}' resolves to a safetensors checkpoint, which the whispercpp loader does not "
-                f"support (whisper.cpp needs the legacy ggml/bin format). Use `loader: vllm` for a HF-format "
-                f"Whisper checkpoint instead (e.g. openai/whisper-large-v3-turbo)."
             )

--- a/modelship/infer/infer_config.py
+++ b/modelship/infer/infer_config.py
@@ -53,6 +53,7 @@ class ModelLoader(StrEnum):
     diffusers = "diffusers"
     llama_server = "llama_server"
     stable_diffusion_cpp = "stable_diffusion_cpp"
+    whispercpp = "whispercpp"
     custom = "custom"
 
 
@@ -144,6 +145,17 @@ class LlamaServerConfig(BaseModel):
     cache_ram_mib: int | None = Field(default=None, ge=-1)
     # Escape hatch for launch flags not otherwise surfaced, appended verbatim.
     extra_args: list[str] = Field(default_factory=list)
+
+
+class WhispercppConfig(BaseModel):
+    """Tunables for the ``whispercpp`` loader, which runs whisper.cpp in-process
+    via `pywhispercpp` bindings (no subprocess)."""
+
+    # None keeps pywhispercpp's own default (min(4, hardware_concurrency())).
+    n_threads: int | None = None
+    flash_attn: bool = False
+    # Only used for a bare pywhispercpp model name. None -> `<cache_root>/whispercpp`.
+    models_dir: str | None = None
 
 
 class StableDiffusionCppConfig(BaseModel):
@@ -241,6 +253,7 @@ class ModelshipModelConfig(BaseModel):
     diffusers_config: DiffusersConfig | None = None
     llama_server_config: LlamaServerConfig | None = None
     stable_diffusion_cpp_config: StableDiffusionCppConfig | None = None
+    whispercpp_config: WhispercppConfig | None = None
     plugin_config: dict[str, Any] | None = None  # plugin devs parse this themselves
     # Extra variables forwarded verbatim into the chat-template Jinja render on
     # every text loader (e.g. `enable_thinking: false` for Qwen3). Only does
@@ -279,14 +292,14 @@ class ModelshipModelConfig(BaseModel):
         return self
 
     @model_validator(mode="after")
-    def validate_llama_server_num_gpus(self):
-        # llama.cpp has no VRAM-fraction knob, so a fractional GPU share can't be
-        # honored — require whole GPUs (or 0 for CPU).
-        if self.loader == ModelLoader.llama_server and self.num_gpus != int(self.num_gpus):
+    def validate_whole_gpu_only_loaders_num_gpus(self):
+        # Neither backend has a VRAM-fraction knob — require whole GPUs (or 0).
+        whole_gpu_loaders = (ModelLoader.llama_server, ModelLoader.whispercpp)
+        if self.loader in whole_gpu_loaders and self.num_gpus != int(self.num_gpus):
             raise ValueError(
                 f"num_gpus={self.num_gpus!r} is not allowed for the {self.loader.value} loader: "
                 f"use an integer number of whole GPUs, or 0 for CPU. Fractional GPU "
-                f"sharing isn't supported (llama.cpp has no GPU-memory fraction control)."
+                f"sharing isn't supported (no GPU-memory fraction control for this loader)."
             )
         return self
 

--- a/modelship/infer/model_deployment.py
+++ b/modelship/infer/model_deployment.py
@@ -39,7 +39,7 @@ from modelship.openai.protocol import (
 
 logger = get_logger("infer.deployment")
 
-# llama_server and stable_diffusion_cpp both have Metal backends; vllm/diffusers don't.
+# llama_server, stable_diffusion_cpp, and whispercpp all have Metal backends; vllm/diffusers don't.
 _DARWIN_UNSUPPORTED_LOADERS = {ModelLoader.vllm, ModelLoader.diffusers}
 
 
@@ -193,6 +193,10 @@ class ModelDeployment:
                 from modelship.infer.stable_diffusion_cpp.stable_diffusion_cpp_infer import StableDiffusionCppInfer
 
                 self.infer = StableDiffusionCppInfer(config)
+            elif config.loader == ModelLoader.whispercpp:
+                from modelship.infer.whispercpp.whispercpp_infer import WhispercppInfer
+
+                self.infer = WhispercppInfer(config)
             else:
                 from modelship.infer.custom.custom_infer import CustomInfer
 

--- a/modelship/infer/model_resolver.py
+++ b/modelship/infer/model_resolver.py
@@ -117,12 +117,6 @@ class PinnedSource(NamedTuple):
         downloading it."""
         return self._resolves_to_extension(".gguf")
 
-    @property
-    def resolves_to_safetensors(self) -> bool:
-        """Whether this source resolves to a `.safetensors` file, without
-        downloading it."""
-        return self._resolves_to_extension(".safetensors")
-
     def _resolves_to_extension(self, suffix: str) -> bool:
         if self.resolved_path is not None:
             return self.resolved_path.lower().endswith(suffix)

--- a/modelship/infer/model_resolver.py
+++ b/modelship/infer/model_resolver.py
@@ -115,10 +115,19 @@ class PinnedSource(NamedTuple):
     def resolves_to_gguf(self) -> bool:
         """Whether this source resolves to a single `.gguf` file, without
         downloading it."""
+        return self._resolves_to_extension(".gguf")
+
+    @property
+    def resolves_to_safetensors(self) -> bool:
+        """Whether this source resolves to a `.safetensors` file, without
+        downloading it."""
+        return self._resolves_to_extension(".safetensors")
+
+    def _resolves_to_extension(self, suffix: str) -> bool:
         if self.resolved_path is not None:
-            return self.resolved_path.lower().endswith(".gguf")
+            return self.resolved_path.lower().endswith(suffix)
         filename = self.download_filename or self.first_shard
-        return bool(filename and filename.lower().endswith(".gguf"))
+        return bool(filename and filename.lower().endswith(suffix))
 
 
 def check_model_source(model_ref: str, trust_remote_code: bool = False) -> PinnedSource:

--- a/modelship/infer/whispercpp/whispercpp_infer.py
+++ b/modelship/infer/whispercpp/whispercpp_infer.py
@@ -27,7 +27,8 @@ from modelship.utils.audio import decode_audio
 logger = get_logger("infer.whispercpp")
 
 _WHISPER_SAMPLE_RATE = 16000
-_GGML_MAGIC = b"ggml"
+# whisper.cpp writes the ggml magic as a little-endian uint32, so on disk it reads "lmgg".
+_GGML_MAGIC = b"lmgg"
 _GGUF_MAGIC = b"GGUF"
 
 # TranslationResponseVerbose.language is documented as always "english" (the output language).
@@ -41,6 +42,7 @@ class WhispercppInfer(BaseInfer):
         super().__init__(model_config)
         self.config = model_config.whispercpp_config or WhispercppConfig()
         self.model: Any = None
+        self._multilingual = True
 
     def shutdown(self) -> None:
         self.model = None
@@ -53,6 +55,7 @@ class WhispercppInfer(BaseInfer):
         self.model = await loop.run_in_executor(None, self._load)
 
     def _load(self) -> Any:
+        import _pywhispercpp as _pw
         from pywhispercpp.constants import AVAILABLE_MODELS
         from pywhispercpp.model import Model
 
@@ -83,7 +86,9 @@ class WhispercppInfer(BaseInfer):
                 kwargs["models_dir"] = models_dir
 
         logger.info("loading whisper.cpp model %r (gpu=%s) for '%s'", model_ref, use_gpu, self.model_config.name)
-        return Model(model_ref, **kwargs)
+        model: Any = Model(model_ref, **kwargs)
+        self._multilingual = bool(_pw.whisper_is_multilingual(model._ctx))
+        return model
 
     async def warmup(self) -> None:
         pass
@@ -98,6 +103,10 @@ class WhispercppInfer(BaseInfer):
         return kwargs
 
     async def _detect_language(self, samples: Any) -> str:
+        # Detection on an English-only model returns an out-of-range id, which
+        # pywhispercpp maps to a wrong language.
+        if not self._multilingual:
+            return "en"
         (lang, _prob), _all = await asyncio.to_thread(self.model.auto_detect_language, samples)
         return lang
 

--- a/modelship/infer/whispercpp/whispercpp_infer.py
+++ b/modelship/infer/whispercpp/whispercpp_infer.py
@@ -90,9 +90,9 @@ class WhispercppInfer(BaseInfer):
 
     def _decode_kwargs(self, request: TranscriptionRequest | TranslationRequest, *, translate: bool) -> dict[str, Any]:
         kwargs: dict[str, Any] = {"translate": translate, "temperature": request.temperature}
-        language = None if translate else getattr(request, "language", None)
-        if language:
-            kwargs["language"] = language
+        # Source hint for both tasks; no target-language knob exists, so to_language is unread.
+        if request.language:
+            kwargs["language"] = request.language
         if request.prompt:
             kwargs["initial_prompt"] = request.prompt
         return kwargs

--- a/modelship/infer/whispercpp/whispercpp_infer.py
+++ b/modelship/infer/whispercpp/whispercpp_infer.py
@@ -1,0 +1,292 @@
+import asyncio
+import json
+import os
+import threading
+from collections.abc import AsyncGenerator
+from typing import Any, cast
+
+from modelship.infer.base_infer import BaseInfer, ClientDisconnectedError
+from modelship.infer.infer_config import ModelshipModelConfig, RawRequestProxy, WhispercppConfig
+from modelship.logging import TRACE, get_logger
+from modelship.openai.protocol import (
+    ErrorResponse,
+    TranscriptionRequest,
+    TranscriptionResponse,
+    TranscriptionResponseVerbose,
+    TranscriptionSegment,
+    TranscriptionUsageAudio,
+    TranslationRequest,
+    TranslationResponse,
+    TranslationResponseVerbose,
+    create_error_response,
+)
+from modelship.openai.utils.chat import encode_error_sse
+from modelship.utils import base_request_id
+from modelship.utils.audio import decode_audio
+
+logger = get_logger("infer.whispercpp")
+
+_WHISPER_SAMPLE_RATE = 16000
+_GGML_MAGIC = b"ggml"
+_GGUF_MAGIC = b"GGUF"
+
+# TranslationResponseVerbose.language is documented as always "english" (the output language).
+_TRANSLATION_OUTPUT_LANGUAGE = "english"
+
+
+class WhispercppInfer(BaseInfer):
+    """In-process whisper.cpp speech-to-text loader via `pywhispercpp` (no subprocess)."""
+
+    def __init__(self, model_config: ModelshipModelConfig):
+        super().__init__(model_config)
+        self.config = model_config.whispercpp_config or WhispercppConfig()
+        self.model: Any = None
+
+    def shutdown(self) -> None:
+        self.model = None
+
+    def __del__(self):
+        self.shutdown()
+
+    async def start(self) -> None:
+        loop = asyncio.get_running_loop()
+        self.model = await loop.run_in_executor(None, self._load)
+
+    def _load(self) -> Any:
+        from pywhispercpp.constants import AVAILABLE_MODELS
+        from pywhispercpp.model import Model
+
+        use_gpu = self.model_config.num_gpus > 0
+        context_params: dict[str, Any] = {"use_gpu": use_gpu}
+        if self.config.flash_attn:
+            context_params["flash_attn"] = True
+
+        kwargs: dict[str, Any] = {"context_params": context_params}
+        if self.config.n_threads is not None:
+            kwargs["n_threads"] = self.config.n_threads
+
+        resolved_path = self.model_config._resolved_path
+        if resolved_path is not None:
+            _validate_ggml_model_file(resolved_path, self.model_config.name)
+            model_ref = resolved_path
+        else:
+            model_ref = self.model_config.model
+            if model_ref not in AVAILABLE_MODELS:
+                raise ValueError(
+                    f"whispercpp deployment '{self.model_config.name}': model {model_ref!r} did not resolve to a "
+                    f"local/HF source and is not one of pywhispercpp's built-in model names. Built-in names: "
+                    f"{', '.join(AVAILABLE_MODELS)}"
+                )
+            models_dir = self.config.models_dir or os.environ.get("MSHIP_WHISPERCPP_CACHE_DIR")
+            if models_dir:
+                os.makedirs(models_dir, exist_ok=True)
+                kwargs["models_dir"] = models_dir
+
+        logger.info("loading whisper.cpp model %r (gpu=%s) for '%s'", model_ref, use_gpu, self.model_config.name)
+        return Model(model_ref, **kwargs)
+
+    async def warmup(self) -> None:
+        pass
+
+    def _decode_kwargs(self, request: TranscriptionRequest | TranslationRequest, *, translate: bool) -> dict[str, Any]:
+        kwargs: dict[str, Any] = {"translate": translate, "temperature": request.temperature}
+        language = None if translate else getattr(request, "language", None)
+        if language:
+            kwargs["language"] = language
+        if request.prompt:
+            kwargs["initial_prompt"] = request.prompt
+        return kwargs
+
+    async def _detect_language(self, samples: Any) -> str:
+        (lang, _prob), _all = await asyncio.to_thread(self.model.auto_detect_language, samples)
+        return lang
+
+    # -- transcription -----------------------------------------------------
+
+    async def create_transcription(
+        self, audio_data: bytes, request: TranscriptionRequest, raw_request: RawRequestProxy
+    ) -> ErrorResponse | TranscriptionResponse | TranscriptionResponseVerbose | AsyncGenerator[str, None]:
+        request_id = f"asr-{base_request_id(raw_request)}"
+        logger.info("transcription request %s: stream=%s", request_id, request.stream)
+        if request.stream:
+            return self.run_cancellable_stream(
+                self._stream(audio_data, request, translate=False, request_id=request_id), raw_request
+            )
+        try:
+            result = await self.run_cancellable(
+                self._transcribe_once(audio_data, request, translate=False, request_id=request_id), raw_request
+            )
+        except ClientDisconnectedError:
+            logger.info("transcription request %s aborted: client disconnected", request_id)
+            return create_error_response("Client disconnected")
+        return cast("ErrorResponse | TranscriptionResponse | TranscriptionResponseVerbose", result)
+
+    async def create_translation(
+        self, audio_data: bytes, request: TranslationRequest, raw_request: RawRequestProxy
+    ) -> ErrorResponse | TranslationResponse | TranslationResponseVerbose | AsyncGenerator[str, None]:
+        request_id = f"translate-{base_request_id(raw_request)}"
+        logger.info("translation request %s: stream=%s", request_id, request.stream)
+        if request.stream:
+            return self.run_cancellable_stream(
+                self._stream(audio_data, request, translate=True, request_id=request_id), raw_request
+            )
+        try:
+            result = await self.run_cancellable(
+                self._transcribe_once(audio_data, request, translate=True, request_id=request_id), raw_request
+            )
+        except ClientDisconnectedError:
+            logger.info("translation request %s aborted: client disconnected", request_id)
+            return create_error_response("Client disconnected")
+        return cast("ErrorResponse | TranslationResponse | TranslationResponseVerbose", result)
+
+    async def _transcribe_once(
+        self,
+        audio_data: bytes,
+        request: TranscriptionRequest | TranslationRequest,
+        *,
+        translate: bool,
+        request_id: str,
+    ) -> (
+        ErrorResponse
+        | TranscriptionResponse
+        | TranscriptionResponseVerbose
+        | TranslationResponse
+        | TranslationResponseVerbose
+    ):
+        try:
+            samples, duration_seconds = decode_audio(audio_data, _WHISPER_SAMPLE_RATE)
+        except Exception as e:
+            logger.warning("%s: failed to decode audio: %s", request_id, e)
+            return create_error_response(f"failed to decode audio: {e}")
+
+        decode_kwargs = self._decode_kwargs(request, translate=translate)
+        segments = await asyncio.to_thread(self.model.transcribe, samples, **decode_kwargs)
+        text = "".join(s.text for s in segments).strip()
+        logger.log(TRACE, "%s response: text=%r", request_id, text)
+
+        verbose = request.response_format == "verbose_json"
+        if not verbose:
+            if translate:
+                return TranslationResponse(text=text)
+            return TranscriptionResponse(text=text, usage=TranscriptionUsageAudio(seconds=int(duration_seconds)))
+
+        if translate:
+            detected_language = _TRANSLATION_OUTPUT_LANGUAGE
+        else:
+            language = decode_kwargs.get("language")
+            detected_language = language if language else await self._detect_language(samples)
+
+        response_segments = [
+            TranscriptionSegment(id=i, start=s.t0 / 100.0, end=s.t1 / 100.0, text=s.text.strip())
+            for i, s in enumerate(segments)
+        ]
+        usage = TranscriptionUsageAudio(seconds=int(duration_seconds))
+        if translate:
+            return TranslationResponseVerbose(
+                language=detected_language,
+                duration=duration_seconds,
+                text=text,
+                segments=response_segments,
+                usage=usage,
+            )
+        return TranscriptionResponseVerbose(
+            language=detected_language,
+            duration=duration_seconds,
+            text=text,
+            segments=response_segments,
+            usage=usage,
+        )
+
+    async def _stream(
+        self,
+        audio_data: bytes,
+        request: TranscriptionRequest | TranslationRequest,
+        *,
+        translate: bool,
+        request_id: str,
+    ) -> AsyncGenerator[str, None]:
+        """One `transcript.text.delta` per decoded segment (no token-level API).
+        `abort_event` mirrors whisper.cpp's `abort_callback`; set in `finally` so
+        an early `aclose()` (client disconnect) stops it between segments."""
+        try:
+            samples, _duration_seconds = decode_audio(audio_data, _WHISPER_SAMPLE_RATE)
+        except Exception as e:
+            logger.warning("%s: failed to decode audio: %s", request_id, e)
+            yield encode_error_sse(create_error_response(f"failed to decode audio: {e}"))
+            return
+
+        decode_kwargs = self._decode_kwargs(request, translate=translate)
+        loop = asyncio.get_running_loop()
+        queue: asyncio.Queue[Any] = asyncio.Queue()
+        abort_event = threading.Event()
+        _done = object()
+
+        def on_segment(segment: Any) -> None:
+            loop.call_soon_threadsafe(queue.put_nowait, segment)
+
+        def run() -> None:
+            try:
+                self.model.transcribe(
+                    samples,
+                    new_segment_callback=on_segment,
+                    abort_callback=abort_event.is_set,
+                    **decode_kwargs,
+                )
+            except BaseException as exc:  # forwarded to the consumer below, not swallowed
+                loop.call_soon_threadsafe(queue.put_nowait, exc)
+            finally:
+                loop.call_soon_threadsafe(queue.put_nowait, _done)
+
+        worker = asyncio.create_task(asyncio.to_thread(run))
+        text_parts: list[str] = []
+        try:
+            while True:
+                item = await queue.get()
+                if item is _done:
+                    break
+                if isinstance(item, BaseException):
+                    raise item
+                segment_text = item.text.strip()
+                if segment_text:
+                    text_parts.append(segment_text)
+                    yield _encode_transcript_event({"type": "transcript.text.delta", "delta": segment_text})
+            yield _encode_transcript_event({"type": "transcript.text.done", "text": " ".join(text_parts)})
+        except Exception as exc:
+            logger.warning("%s failed mid-stream: %s", request_id, exc)
+            yield encode_error_sse(
+                create_error_response(f"whisper.cpp transcription failed: {exc}", err_type="api_error", status_code=502)
+            )
+        finally:
+            abort_event.set()
+            await worker
+
+
+def _encode_transcript_event(payload: dict[str, Any]) -> str:
+    return f"data: {json.dumps(payload)}\n\n"
+
+
+def _validate_ggml_model_file(path: str, model_name: str) -> None:
+    """Rejects GGUF/safetensors and checks the ggml magic bytes — a selector
+    match at driver preflight can't always tell the format from the filename alone."""
+    if not os.path.isfile(path):
+        raise ValueError(
+            f"whispercpp deployment '{model_name}' is missing a resolved model file at {path!r}. "
+            f"Check driver logs for resolution errors."
+        )
+    with open(path, "rb") as f:
+        magic = f.read(4)
+    if path.lower().endswith(".gguf") or magic == _GGUF_MAGIC:
+        raise ValueError(
+            f"whispercpp deployment '{model_name}': {path!r} is a GGUF file. whisper.cpp needs its own legacy "
+            f"ggml/bin format (files named like `ggml-base.en.bin`), not GGUF."
+        )
+    if path.lower().endswith(".safetensors"):
+        raise ValueError(
+            f"whispercpp deployment '{model_name}': {path!r} is a safetensors checkpoint. whisper.cpp needs the "
+            f"legacy ggml/bin format; use `loader: vllm` for a HF-format Whisper checkpoint instead."
+        )
+    if magic != _GGML_MAGIC:
+        raise ValueError(
+            f"whispercpp deployment '{model_name}': {path!r} does not look like a whisper.cpp ggml model file "
+            f"(expected the 4-byte magic {_GGML_MAGIC!r}, got {magic!r})."
+        )

--- a/modelship/openai/api.py
+++ b/modelship/openai/api.py
@@ -54,8 +54,10 @@ from modelship.openai.protocol import (
     SpeechRequest,
     TranscriptionRequest,
     TranscriptionResponse,
+    TranscriptionResponseVerbose,
     TranslationRequest,
     TranslationResponse,
+    TranslationResponseVerbose,
     create_error_response,
     error_ws_frame,
     frame_sse,
@@ -468,7 +470,9 @@ class ModelshipAPI:
                 | ResponseObject
                 | EmbeddingResponse
                 | TranscriptionResponse
+                | TranscriptionResponseVerbose
                 | TranslationResponse
+                | TranslationResponseVerbose
                 | ImageGenerationResponse,
             ):
                 REQUEST_TOTAL.inc(tags={"model": model, "endpoint": endpoint, "status": "ok"})

--- a/plugins/whispercpp/whispercpp/whispercpp.py
+++ b/plugins/whispercpp/whispercpp/whispercpp.py
@@ -49,6 +49,9 @@ _WHISPER_SAMPLE_RATE = 16000
 class ModelPlugin(BasePlugin):
     def __init__(self, model_config: ModelshipModelConfig):
         self.model_config = model_config
+        if not model_config.model:
+            raise ValueError(f"whispercpp plugin requires `model:` (deployment '{model_config.name}')")
+        model_name = model_config.model
         plugin_config = model_config.plugin_config or {}
 
         models_dir = plugin_config.get("models_dir", f"{plugins_dir()}/whispercpp")
@@ -58,8 +61,8 @@ class ModelPlugin(BasePlugin):
         if (n_threads := plugin_config.get("n_threads")) is not None:
             kwargs["n_threads"] = n_threads
 
-        logger.info("loading whisper.cpp model: %s (dir=%s)", model_config.model, models_dir)
-        self.model = Model(model_config.model, **kwargs)
+        logger.info("loading whisper.cpp model: %s (dir=%s)", model_name, models_dir)
+        self.model = Model(model_name, **kwargs)
 
     async def start(self):
         pass

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,7 @@ metal = [
     "soundfile>=0.13.0",
     "onnxruntime>=1.28.0",
     "stable-diffusion-cpp-python>=0.4.7",
+    "pywhispercpp>=1.5.0",
 ]
 cuda = [
     "torch>=2.10.0",
@@ -64,6 +65,7 @@ cuda = [
     "numba>=0.61.0",
     "scipy>=1.16.1",
     "soundfile>=0.13.0",
+    "pywhispercpp>=1.5.0",
 ]
 cpu = [
     "torch>=2.10.0",
@@ -77,6 +79,7 @@ cpu = [
     "numba>=0.61.0",
     "scipy>=1.16.1",
     "soundfile>=0.13.0",
+    "pywhispercpp>=1.5.0",
 ]
 kokoroonnx = ["kokoroonnx"]
 orpheus = ["orpheus"]
@@ -195,6 +198,7 @@ markers = [
     "vllm: integration tests that exercise the vllm loader",
     "diffusers: integration tests that exercise the diffusers loader",
     "stable_diffusion_cpp: integration tests that exercise the stable_diffusion_cpp loader",
+    "whispercpp: integration tests that exercise the whispercpp loader",
     "autoscaling: integration test that exercises Ray Serve autoscaling (scale out/in under load)",
     "gateway_ha: integration test that exercises multi-replica gateway routing consistency",
     "blue_green: integration test that exercises the blue_green replace-strategy cutover",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -182,6 +182,14 @@ MODEL_CONFIGS: dict[str, dict] = {
         "loader": "whispercpp",
         "num_cpus": 1,
     },
+    "stt-cpp-multilingual": {
+        "name": "stt-cpp-multilingual",
+        # Multilingual counterpart of stt-cpp-model: exercises auto-detection and translate.
+        "model": "tiny",
+        "usecase": "transcription",
+        "loader": "whispercpp",
+        "num_cpus": 1,
+    },
     "tts-model": {
         "name": "tts-model",
         "model": "hexgrad/Kokoro-82M",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -175,6 +175,13 @@ MODEL_CONFIGS: dict[str, dict] = {
             "trust_remote_code": True,
         },
     },
+    "stt-cpp-model": {
+        "name": "stt-cpp-model",
+        "model": "tiny.en",
+        "usecase": "transcription",
+        "loader": "whispercpp",
+        "num_cpus": 1,
+    },
     "tts-model": {
         "name": "tts-model",
         "model": "hexgrad/Kokoro-82M",

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1020,6 +1020,22 @@ class TestAudio:
 
 
 @pytest.mark.integration
+@pytest.mark.whispercpp
+def test_audio_transcription_whispercpp(client, model_deployer, tmp_path):
+    model_deployer.deploy("tts-model", "stt-cpp-model")
+    audio_data = client.audio.speech.create(
+        model="tts-model", voice="af_bella", input="This is a test transcription."
+    ).content
+
+    audio_file = tmp_path / "test_audio.mp3"
+    audio_file.write_bytes(audio_data)
+
+    with open(audio_file, "rb") as f:
+        transcription = client.audio.transcriptions.create(model="stt-cpp-model", file=f)
+    assert "test" in transcription.text.lower()
+
+
+@pytest.mark.integration
 @pytest.mark.diffusers
 class TestImage:
     """End-to-end image generation, editing and variations through the

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1020,22 +1020,6 @@ class TestAudio:
 
 
 @pytest.mark.integration
-@pytest.mark.whispercpp
-def test_audio_transcription_whispercpp(client, model_deployer, tmp_path):
-    model_deployer.deploy("tts-model", "stt-cpp-model")
-    audio_data = client.audio.speech.create(
-        model="tts-model", voice="af_bella", input="This is a test transcription."
-    ).content
-
-    audio_file = tmp_path / "test_audio.mp3"
-    audio_file.write_bytes(audio_data)
-
-    with open(audio_file, "rb") as f:
-        transcription = client.audio.transcriptions.create(model="stt-cpp-model", file=f)
-    assert "test" in transcription.text.lower()
-
-
-@pytest.mark.integration
 @pytest.mark.diffusers
 class TestImage:
     """End-to-end image generation, editing and variations through the

--- a/tests/test_whispercpp_infer.py
+++ b/tests/test_whispercpp_infer.py
@@ -94,11 +94,17 @@ class TestDecodeKwargs:
         assert kwargs["initial_prompt"] == "hello"
         assert kwargs["temperature"] == 0.6
 
-    def test_translate_never_forwards_language(self):
+    def test_translate_forwards_language_as_source_hint(self):
         infer = _infer(_StubModel([]))
         kwargs = infer._decode_kwargs(_translation_request(language="fr"), translate=True)
-        assert "language" not in kwargs
+        assert kwargs["language"] == "fr"
         assert kwargs["translate"] is True
+
+    def test_to_language_is_ignored(self):
+        infer = _infer(_StubModel([]))
+        kwargs = infer._decode_kwargs(_translation_request(to_language="de"), translate=True)
+        assert "to_language" not in kwargs
+        assert "language" not in kwargs
 
 
 class TestTranscribeOnce:
@@ -137,7 +143,10 @@ class TestTranscribeOnce:
     async def test_translation_verbose_language_is_always_english(self):
         infer = _infer(_StubModel([_Segment("hello")]))
         result = await infer._transcribe_once(
-            MINIMAL_WAV, _translation_request(response_format="verbose_json"), translate=True, request_id="r1"
+            MINIMAL_WAV,
+            _translation_request(response_format="verbose_json", language="fr"),
+            translate=True,
+            request_id="r1",
         )
         assert isinstance(result, TranslationResponseVerbose)
         assert result.language == "english"

--- a/tests/test_whispercpp_infer.py
+++ b/tests/test_whispercpp_infer.py
@@ -1,0 +1,204 @@
+"""Unit tests for the whispercpp loader: request-param forwarding, real
+detected-language plumbing, ggml model-file validation, and streaming — all
+against a stubbed `pywhispercpp.model.Model` (no real ggml file needed)."""
+
+from __future__ import annotations
+
+import io
+import time
+
+import pytest
+from fastapi import UploadFile
+
+from modelship.infer.base_infer import MINIMAL_WAV
+from modelship.infer.infer_config import ModelLoader, ModelshipModelConfig, ModelUsecase
+from modelship.infer.whispercpp.whispercpp_infer import WhispercppInfer, _validate_ggml_model_file
+from modelship.openai.protocol import (
+    ErrorResponse,
+    TranscriptionRequest,
+    TranscriptionResponse,
+    TranscriptionResponseVerbose,
+    TranslationRequest,
+    TranslationResponse,
+    TranslationResponseVerbose,
+)
+
+
+class _Segment:
+    def __init__(self, text: str, t0: int = 0, t1: int = 100):
+        self.text = text
+        self.t0 = t0
+        self.t1 = t1
+
+
+class _StubModel:
+    """Stand-in for a `pywhispercpp.model.Model`. Records the decode kwargs
+    each `transcribe` call received; `abort_callback` (if given) is polled
+    between segments, matching real whisper.cpp's per-segment check."""
+
+    def __init__(self, segments: list[_Segment], detected: tuple[str, float] = ("es", 0.9)):
+        self._segments = segments
+        self._detected = detected
+        self.calls: list[dict] = []
+        self.aborted_early = False
+
+    def transcribe(self, samples, new_segment_callback=None, abort_callback=None, **kwargs):
+        self.calls.append(kwargs)
+        emitted = []
+        for seg in self._segments:
+            if abort_callback is not None and abort_callback():
+                self.aborted_early = True
+                break
+            if new_segment_callback is not None:
+                new_segment_callback(seg)
+            emitted.append(seg)
+            time.sleep(0.05)  # gives the consumer a window to aclose() mid-loop
+        return emitted
+
+    def auto_detect_language(self, samples):
+        return self._detected, {self._detected[0]: self._detected[1]}
+
+
+def _config(**overrides) -> ModelshipModelConfig:
+    defaults = {
+        "name": "stt",
+        "model": "tiny.en",
+        "usecase": ModelUsecase.transcription,
+        "loader": ModelLoader.whispercpp,
+    }
+    return ModelshipModelConfig(**{**defaults, **overrides})
+
+
+def _infer(model: _StubModel) -> WhispercppInfer:
+    infer = WhispercppInfer(_config())
+    infer.model = model
+    return infer
+
+
+def _transcription_request(**overrides) -> TranscriptionRequest:
+    file = UploadFile(file=io.BytesIO(b"x"), filename="a.wav")
+    return TranscriptionRequest(**{"file": file, "model": "stt", **overrides})
+
+
+def _translation_request(**overrides) -> TranslationRequest:
+    file = UploadFile(file=io.BytesIO(b"x"), filename="a.wav")
+    return TranslationRequest(**{"file": file, "model": "stt", **overrides})
+
+
+class TestDecodeKwargs:
+    """Gap 1: prompt/temperature must reach whisper.cpp's transcribe() call."""
+
+    def test_prompt_and_temperature_forwarded(self):
+        infer = _infer(_StubModel([]))
+        kwargs = infer._decode_kwargs(_transcription_request(prompt="hello", temperature=0.6), translate=False)
+        assert kwargs["initial_prompt"] == "hello"
+        assert kwargs["temperature"] == 0.6
+
+    def test_translate_never_forwards_language(self):
+        infer = _infer(_StubModel([]))
+        kwargs = infer._decode_kwargs(_translation_request(language="fr"), translate=True)
+        assert "language" not in kwargs
+        assert kwargs["translate"] is True
+
+
+class TestTranscribeOnce:
+    @pytest.mark.asyncio
+    async def test_plain_json_has_no_language(self):
+        infer = _infer(_StubModel([_Segment("hello "), _Segment("world")]))
+        result = await infer._transcribe_once(MINIMAL_WAV, _transcription_request(), translate=False, request_id="r1")
+        assert isinstance(result, TranscriptionResponse)
+        assert result.text == "hello world"
+
+    @pytest.mark.asyncio
+    async def test_verbose_json_uses_explicit_language_without_detection(self):
+        model = _StubModel([_Segment("hola")], detected=("en", 0.99))
+        infer = _infer(model)
+        result = await infer._transcribe_once(
+            MINIMAL_WAV,
+            _transcription_request(response_format="verbose_json", language="es"),
+            translate=False,
+            request_id="r1",
+        )
+        assert isinstance(result, TranscriptionResponseVerbose)
+        assert result.language == "es"  # user-given language wins, no detection call needed
+
+    @pytest.mark.asyncio
+    async def test_verbose_json_detects_real_language_when_unset(self):
+        """Gap 2: no language given -> the real detected language, not a fabricated value."""
+        model = _StubModel([_Segment("hola")], detected=("es", 0.87))
+        infer = _infer(model)
+        result = await infer._transcribe_once(
+            MINIMAL_WAV, _transcription_request(response_format="verbose_json"), translate=False, request_id="r1"
+        )
+        assert isinstance(result, TranscriptionResponseVerbose)
+        assert result.language == "es"
+
+    @pytest.mark.asyncio
+    async def test_translation_verbose_language_is_always_english(self):
+        infer = _infer(_StubModel([_Segment("hello")]))
+        result = await infer._transcribe_once(
+            MINIMAL_WAV, _translation_request(response_format="verbose_json"), translate=True, request_id="r1"
+        )
+        assert isinstance(result, TranslationResponseVerbose)
+        assert result.language == "english"
+
+    @pytest.mark.asyncio
+    async def test_translation_plain_json(self):
+        infer = _infer(_StubModel([_Segment("hello")]))
+        result = await infer._transcribe_once(MINIMAL_WAV, _translation_request(), translate=True, request_id="r1")
+        assert isinstance(result, TranslationResponse)
+        assert result.text == "hello"
+
+    @pytest.mark.asyncio
+    async def test_bad_audio_returns_error_response(self):
+        infer = _infer(_StubModel([]))
+        result = await infer._transcribe_once(b"not audio", _transcription_request(), translate=False, request_id="r1")
+        assert isinstance(result, ErrorResponse)
+
+
+class TestStreaming:
+    @pytest.mark.asyncio
+    async def test_yields_delta_per_segment_then_done(self):
+        infer = _infer(_StubModel([_Segment("hello"), _Segment("world")]))
+        chunks = [
+            c async for c in infer._stream(MINIMAL_WAV, _transcription_request(), translate=False, request_id="r1")
+        ]
+        assert '"type": "transcript.text.delta"' in chunks[0]
+        assert '"delta": "hello"' in chunks[0]
+        assert chunks[-1].strip().endswith("}")
+        assert '"type": "transcript.text.done"' in chunks[-1]
+        assert '"text": "hello world"' in chunks[-1]
+
+    @pytest.mark.asyncio
+    async def test_early_aclose_sets_abort_before_worker_finishes(self):
+        model = _StubModel([_Segment("a"), _Segment("b"), _Segment("c")])
+        infer = _infer(model)
+        gen = infer._stream(MINIMAL_WAV, _transcription_request(), translate=False, request_id="r1")
+        await gen.__anext__()  # first delta
+        await gen.aclose()
+        assert model.aborted_early
+
+
+class TestValidateGgmlModelFile:
+    def test_accepts_ggml_magic(self, tmp_path):
+        path = tmp_path / "ggml-base.en.bin"
+        path.write_bytes(b"ggml" + b"\x00" * 16)
+        _validate_ggml_model_file(str(path), "m")  # no raise
+
+    def test_rejects_gguf(self, tmp_path):
+        path = tmp_path / "model.gguf"
+        path.write_bytes(b"GGUF" + b"\x00" * 16)
+        with pytest.raises(ValueError, match="GGUF"):
+            _validate_ggml_model_file(str(path), "m")
+
+    def test_rejects_safetensors(self, tmp_path):
+        path = tmp_path / "model.safetensors"
+        path.write_bytes(b"\x00" * 16)
+        with pytest.raises(ValueError, match="safetensors"):
+            _validate_ggml_model_file(str(path), "m")
+
+    def test_rejects_unknown_format(self, tmp_path):
+        path = tmp_path / "weights.bin"
+        path.write_bytes(b"\x00" * 16)
+        with pytest.raises(ValueError, match="ggml"):
+            _validate_ggml_model_file(str(path), "m")

--- a/tests/test_whispercpp_infer.py
+++ b/tests/test_whispercpp_infer.py
@@ -140,6 +140,18 @@ class TestTranscribeOnce:
         assert result.language == "es"
 
     @pytest.mark.asyncio
+    async def test_english_only_model_skips_detection(self):
+        # A real ggml-tiny.en detects as 'sq' here.
+        model = _StubModel([_Segment("hello")], detected=("sq", 0.4))
+        infer = _infer(model)
+        infer._multilingual = False
+        result = await infer._transcribe_once(
+            MINIMAL_WAV, _transcription_request(response_format="verbose_json"), translate=False, request_id="r1"
+        )
+        assert isinstance(result, TranscriptionResponseVerbose)
+        assert result.language == "en"
+
+    @pytest.mark.asyncio
     async def test_translation_verbose_language_is_always_english(self):
         infer = _infer(_StubModel([_Segment("hello")]))
         result = await infer._transcribe_once(
@@ -191,7 +203,8 @@ class TestStreaming:
 class TestValidateGgmlModelFile:
     def test_accepts_ggml_magic(self, tmp_path):
         path = tmp_path / "ggml-base.en.bin"
-        path.write_bytes(b"ggml" + b"\x00" * 16)
+        # Byte order matches a real whisper.cpp model file, not the "ggml" spelling.
+        path.write_bytes((0x67676D6C).to_bytes(4, "little") + b"\x00" * 16)
         _validate_ggml_model_file(str(path), "m")  # no raise
 
     def test_rejects_gguf(self, tmp_path):

--- a/tests/test_whispercpp_integration.py
+++ b/tests/test_whispercpp_integration.py
@@ -1,0 +1,154 @@
+"""End-to-end coverage for the whispercpp loader against a real pywhispercpp
+binding. `test_whispercpp_infer.py` covers the same logic against a stub."""
+
+import json
+
+import httpx
+import pytest
+
+OPENAI_API_BASE = "http://localhost:8000/v1"
+
+# `tiny.en` has no language tokens; only `tiny` can auto-detect or translate.
+ENGLISH_ONLY_MODEL = "stt-cpp-model"
+MULTILINGUAL_MODEL = "stt-cpp-multilingual"
+
+
+def _post_audio(endpoint: str, model: str, audio: bytes, **fields) -> httpx.Response:
+    data = {"model": model, **{k: str(v) for k, v in fields.items()}}
+    return httpx.post(
+        f"{OPENAI_API_BASE}/audio/{endpoint}",
+        data=data,
+        files={"file": ("audio.mp3", audio, "audio/mpeg")},
+        timeout=180,
+    )
+
+
+def _sse_events(body: str) -> list[dict]:
+    return [
+        json.loads(line[len("data: ") :])
+        for line in body.splitlines()
+        if line.startswith("data: ") and line[len("data: ") :].strip() not in ("", "[DONE]")
+    ]
+
+
+@pytest.mark.integration
+@pytest.mark.whispercpp
+class TestWhispercpp:
+    @pytest.fixture(autouse=True, scope="class")
+    def _deploy(self, model_deployer):
+        model_deployer.deploy("tts-model", ENGLISH_ONLY_MODEL, MULTILINGUAL_MODEL)
+
+    @pytest.fixture(scope="class")
+    def speech(self, client) -> bytes:
+        return client.audio.speech.create(
+            model="tts-model", voice="af_bella", input="This is a test transcription."
+        ).content
+
+    # -- transcription -----------------------------------------------------
+
+    def test_transcription_json(self, client, speech, tmp_path):
+        audio = tmp_path / "a.mp3"
+        audio.write_bytes(speech)
+        with open(audio, "rb") as f:
+            result = client.audio.transcriptions.create(model=ENGLISH_ONLY_MODEL, file=f)
+        assert "test" in result.text.lower()
+
+    def test_transcription_verbose_json(self, speech):
+        response = _post_audio("transcriptions", ENGLISH_ONLY_MODEL, speech, response_format="verbose_json")
+        assert response.status_code == 200
+        body = response.json()
+        assert body["task"] == "transcribe"
+        assert "test" in body["text"].lower()
+        assert body["duration"] > 0
+        assert body["segments"], "verbose_json must carry segments"
+        first = body["segments"][0]
+        assert first["end"] >= first["start"]
+        assert body["usage"]["seconds"] >= 0
+
+    def test_explicit_language_is_accepted(self, speech):
+        response = _post_audio(
+            "transcriptions", MULTILINGUAL_MODEL, speech, response_format="verbose_json", language="en"
+        )
+        assert response.status_code == 200
+        assert response.json()["language"] == "en"
+
+    def test_prompt_and_temperature_are_accepted(self, speech):
+        # A stubbed Model accepts any kwarg; whisper.cpp rejects ones it doesn't define.
+        response = _post_audio(
+            "transcriptions",
+            ENGLISH_ONLY_MODEL,
+            speech,
+            prompt="This is a transcription test.",
+            temperature=0.2,
+        )
+        assert response.status_code == 200
+        assert response.json()["text"].strip()
+
+    def test_english_only_model_reports_en(self, speech):
+        # Regression: detection on a .en model returned a wrong language (observed: 'sq').
+        response = _post_audio("transcriptions", ENGLISH_ONLY_MODEL, speech, response_format="verbose_json")
+        assert response.status_code == 200
+        assert response.json()["language"] == "en"
+
+    def test_multilingual_model_detects_language(self, speech):
+        response = _post_audio("transcriptions", MULTILINGUAL_MODEL, speech, response_format="verbose_json")
+        assert response.status_code == 200
+        assert response.json()["language"] == "en"
+
+    def test_transcription_streaming(self, speech):
+        response = _post_audio("transcriptions", ENGLISH_ONLY_MODEL, speech, stream=True)
+        assert response.status_code == 200
+        assert response.headers["content-type"].startswith("text/event-stream")
+
+        events = _sse_events(response.text)
+        deltas = [e for e in events if e["type"] == "transcript.text.delta"]
+        done = [e for e in events if e["type"] == "transcript.text.done"]
+        assert deltas
+        assert len(done) == 1
+        assert done[0] is events[-1]
+        assert "test" in done[0]["text"].lower()
+        assert done[0]["text"] == " ".join(d["delta"] for d in deltas)
+
+    # -- translation -------------------------------------------------------
+
+    def test_translation_json(self, speech):
+        response = _post_audio("translations", MULTILINGUAL_MODEL, speech)
+        assert response.status_code == 200
+        assert response.json()["text"].strip()
+
+    def test_translation_verbose_json(self, speech):
+        response = _post_audio("translations", MULTILINGUAL_MODEL, speech, response_format="verbose_json")
+        assert response.status_code == 200
+        body = response.json()
+        assert body["task"] == "translate"
+        assert body["language"] == "english"
+        assert body["duration"] > 0
+        assert body["segments"]
+
+    def test_source_language_does_not_change_output_language(self, speech):
+        response = _post_audio(
+            "translations", MULTILINGUAL_MODEL, speech, response_format="verbose_json", language="en"
+        )
+        assert response.status_code == 200
+        assert response.json()["language"] == "english"
+
+    def test_to_language_is_ignored(self, speech):
+        response = _post_audio(
+            "translations", MULTILINGUAL_MODEL, speech, response_format="verbose_json", to_language="de"
+        )
+        assert response.status_code == 200
+        assert response.json()["language"] == "english"
+
+    def test_translation_streaming(self, speech):
+        response = _post_audio("translations", MULTILINGUAL_MODEL, speech, stream=True)
+        assert response.status_code == 200
+        events = _sse_events(response.text)
+        assert [e for e in events if e["type"] == "transcript.text.delta"]
+        assert events[-1]["type"] == "transcript.text.done"
+
+    # -- errors ------------------------------------------------------------
+
+    def test_undecodable_audio_returns_400(self):
+        response = _post_audio("transcriptions", ENGLISH_ONLY_MODEL, b"this is not audio")
+        assert response.status_code == 400
+        assert "decode" in response.json()["error"]["message"].lower()

--- a/tests/test_whispercpp_model_source.py
+++ b/tests/test_whispercpp_model_source.py
@@ -1,0 +1,76 @@
+"""Driver preflight must route bare built-in model names past source resolution
+without importing pywhispercpp (a thin coordinator has no pywhispercpp); the name
+itself is validated in the actor, against pywhispercpp's own AVAILABLE_MODELS."""
+
+import sys
+from unittest.mock import patch
+
+import pytest
+
+from modelship.deploy.config import resolve_all_model_sources
+from modelship.infer.infer_config import (
+    ModelLoader,
+    ModelshipConfig,
+    ModelshipModelConfig,
+    ModelUsecase,
+)
+from modelship.infer.model_resolver import PinnedSource
+from modelship.infer.whispercpp.whispercpp_infer import WhispercppInfer
+
+_GGML_PIN = PinnedSource(
+    resolved_path=None,
+    repo="ggerganov/whisper.cpp",
+    revision="deadbeef",
+    download_filename="ggml-base.en.bin",
+    download_patterns=None,
+    first_shard=None,
+)
+
+
+def _cfg(model: str) -> ModelshipModelConfig:
+    return ModelshipModelConfig(
+        name="stt",
+        model=model,
+        usecase=ModelUsecase.transcription,
+        loader=ModelLoader.whispercpp,
+        num_gpus=0,
+    )
+
+
+@pytest.fixture
+def no_pywhispercpp(monkeypatch):
+    # None in sys.modules makes `import pywhispercpp...` raise, as on the thin image.
+    monkeypatch.setitem(sys.modules, "pywhispercpp", None)
+    monkeypatch.setitem(sys.modules, "pywhispercpp.constants", None)
+
+
+@pytest.mark.parametrize("model", ["base.en", "large-v3-turbo-q5_0", "bse.en"])
+def test_bare_name_skips_source_check_without_pywhispercpp(no_pywhispercpp, model):
+    # A typo'd name is skipped too — the actor owns that rejection.
+    cfg = _cfg(model)
+    resolve_all_model_sources(ModelshipConfig(models=[cfg]))
+    assert cfg._pinned_source is None
+
+
+def test_repo_ref_still_resolves_as_a_source():
+    cfg = _cfg("ggerganov/whisper.cpp:ggml-base.en.bin")
+    with patch("modelship.deploy.config.check_model_source", return_value=_GGML_PIN) as check:
+        resolve_all_model_sources(ModelshipConfig(models=[cfg]))
+    check.assert_called_once()
+    assert cfg._pinned_source == _GGML_PIN
+
+
+def test_local_path_still_resolves_as_a_source(tmp_path):
+    path = tmp_path / "ggml-base.en.bin"
+    path.write_bytes(b"\x00" * 4)
+    cfg = _cfg(str(path))
+    with patch("modelship.deploy.config.check_model_source", return_value=_GGML_PIN) as check:
+        resolve_all_model_sources(ModelshipConfig(models=[cfg]))
+    check.assert_called_once()
+
+
+def test_actor_rejects_unknown_builtin_name():
+    pytest.importorskip("pywhispercpp.constants")
+    infer = WhispercppInfer(_cfg("bse.en"))
+    with pytest.raises(ValueError, match="built-in model names"):
+        infer._load()

--- a/uv.lock
+++ b/uv.lock
@@ -1358,8 +1358,7 @@ dependencies = [
     { name = "colorlog" },
     { name = "espeakng-loader" },
     { name = "numpy" },
-    { name = "onnxruntime", version = "1.24.4", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-5-mship-cuda'" },
-    { name = "onnxruntime", version = "1.28.0", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-5-mship-cpu' or extra != 'extra-5-mship-cuda' or (extra == 'extra-5-mship-cuda' and extra == 'extra-5-mship-metal')" },
+    { name = "onnxruntime" },
     { name = "phonemizer-fork" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/36/7c/4d74f7243f546716003bd0cfaae8f562f5d75672142f23fa731f69069efd/kokoro_onnx-0.4.9.tar.gz", hash = "sha256:08682138939f61548a7186ef5cdae79180a5dff6fa23781910eddb1583dcf30b", size = 81209, upload-time = "2025-05-10T22:49:04.758Z" }
@@ -1788,7 +1787,8 @@ dependencies = [
 cpu = [
     { name = "librosa" },
     { name = "numba" },
-    { name = "onnxruntime", version = "1.28.0", source = { registry = "https://pypi.org/simple" } },
+    { name = "onnxruntime" },
+    { name = "pywhispercpp" },
     { name = "scipy" },
     { name = "soundfile" },
     { name = "stable-diffusion-cpp-python" },
@@ -1807,6 +1807,7 @@ cuda = [
     { name = "numba" },
     { name = "nvidia-ml-py" },
     { name = "onnxruntime-gpu" },
+    { name = "pywhispercpp" },
     { name = "scipy" },
     { name = "soundfile" },
     { name = "stable-diffusion-cpp-python" },
@@ -1832,7 +1833,8 @@ kokoroonnx = [
 metal = [
     { name = "librosa" },
     { name = "numba" },
-    { name = "onnxruntime", version = "1.28.0", source = { registry = "https://pypi.org/simple" } },
+    { name = "onnxruntime" },
+    { name = "pywhispercpp" },
     { name = "scipy" },
     { name = "soundfile" },
     { name = "stable-diffusion-cpp-python" },
@@ -1889,6 +1891,9 @@ requires-dist = [
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0.0" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.25.0" },
     { name = "python-multipart", specifier = ">=0.0.20" },
+    { name = "pywhispercpp", marker = "extra == 'cpu'", specifier = ">=1.5.0" },
+    { name = "pywhispercpp", marker = "extra == 'cuda'", specifier = ">=1.5.0" },
+    { name = "pywhispercpp", marker = "extra == 'metal'", specifier = ">=1.5.0" },
     { name = "ray", extras = ["data", "default", "serve-grpc"], specifier = ">=2.54.0,<2.55.0" },
     { name = "redis", specifier = ">=8.0.0" },
     { name = "requests", specifier = ">=2.32.5" },
@@ -2352,74 +2357,13 @@ wheels = [
 
 [[package]]
 name = "onnxruntime"
-version = "1.24.4"
-source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "sys_platform == 'darwin'",
-    "sys_platform == 'win32'",
-    "sys_platform == 'emscripten'",
-    "sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32'",
-]
-dependencies = [
-    { name = "flatbuffers", marker = "extra == 'extra-5-mship-cuda'" },
-    { name = "numpy", marker = "extra == 'extra-5-mship-cuda'" },
-    { name = "packaging", marker = "extra == 'extra-5-mship-cuda'" },
-    { name = "protobuf", marker = "extra == 'extra-5-mship-cuda'" },
-    { name = "sympy", marker = "extra == 'extra-5-mship-cuda'" },
-]
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/d7/38/31db1b232b4ba960065a90c1506ad7a56995cd8482033184e97fadca17cc/onnxruntime-1.24.4-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:cad1c2b3f455c55678ab2a8caa51fb420c25e6e3cf10f4c23653cdabedc8de78", size = 17341875, upload-time = "2026-03-17T22:05:51.669Z" },
-    { url = "https://files.pythonhosted.org/packages/aa/60/c4d1c8043eb42f8a9aa9e931c8c293d289c48ff463267130eca97d13357f/onnxruntime-1.24.4-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1a5c5a544b22f90859c88617ecb30e161ee3349fcc73878854f43d77f00558b5", size = 15172485, upload-time = "2026-03-17T22:03:32.182Z" },
-    { url = "https://files.pythonhosted.org/packages/6d/ab/5b68110e0460d73fad814d5bd11c7b1ddcce5c37b10177eb264d6a36e331/onnxruntime-1.24.4-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0d640eb9f3782689b55cfa715094474cd5662f2f137be6a6f847a594b6e9705c", size = 17244912, upload-time = "2026-03-17T22:04:37.251Z" },
-    { url = "https://files.pythonhosted.org/packages/8b/f4/6b89e297b93704345f0f3f8c62229bee323ef25682a3f9b4f89a39324950/onnxruntime-1.24.4-cp312-cp312-win_amd64.whl", hash = "sha256:535b29475ca42b593c45fbb2152fbf1cdf3f287315bf650e6a724a0a1d065cdb", size = 12596856, upload-time = "2026-03-17T22:05:41.224Z" },
-    { url = "https://files.pythonhosted.org/packages/43/06/8b8ec6e9e6a474fcd5d772453f627ad4549dfe3ab8c0bf70af5afcde551b/onnxruntime-1.24.4-cp312-cp312-win_arm64.whl", hash = "sha256:e6214096e14b7b52e3bee1903dc12dc7ca09cb65e26664668a4620cc5e6f9a90", size = 12270275, upload-time = "2026-03-17T22:05:31.132Z" },
-]
-
-[[package]]
-name = "onnxruntime"
 version = "1.28.0"
 source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "(platform_machine == 's390x' and sys_platform == 'darwin' and extra == 'extra-5-mship-cpu' and extra != 'extra-5-mship-cuda' and extra == 'extra-5-mship-metal') or (platform_machine == 'x86_64' and sys_platform == 'darwin' and extra == 'extra-5-mship-cpu' and extra != 'extra-5-mship-cuda' and extra == 'extra-5-mship-metal')",
-    "platform_machine == 'aarch64' and sys_platform == 'darwin' and extra == 'extra-5-mship-cpu' and extra != 'extra-5-mship-cuda' and extra == 'extra-5-mship-metal'",
-    "(platform_machine == 's390x' and sys_platform == 'win32' and extra == 'extra-5-mship-cpu' and extra != 'extra-5-mship-cuda' and extra == 'extra-5-mship-metal') or (platform_machine == 'x86_64' and sys_platform == 'win32' and extra == 'extra-5-mship-cpu' and extra != 'extra-5-mship-cuda' and extra == 'extra-5-mship-metal')",
-    "(platform_machine == 's390x' and sys_platform == 'emscripten' and extra == 'extra-5-mship-cpu' and extra != 'extra-5-mship-cuda' and extra == 'extra-5-mship-metal') or (platform_machine == 'x86_64' and sys_platform == 'emscripten' and extra == 'extra-5-mship-cpu' and extra != 'extra-5-mship-cuda' and extra == 'extra-5-mship-metal')",
-    "(platform_machine == 's390x' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32' and extra == 'extra-5-mship-cpu' and extra != 'extra-5-mship-cuda' and extra == 'extra-5-mship-metal') or (platform_machine == 'x86_64' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32' and extra == 'extra-5-mship-cpu' and extra != 'extra-5-mship-cuda' and extra == 'extra-5-mship-metal')",
-    "platform_machine == 'aarch64' and sys_platform == 'win32' and extra == 'extra-5-mship-cpu' and extra != 'extra-5-mship-cuda' and extra == 'extra-5-mship-metal'",
-    "platform_machine == 'aarch64' and sys_platform == 'emscripten' and extra == 'extra-5-mship-cpu' and extra != 'extra-5-mship-cuda' and extra == 'extra-5-mship-metal'",
-    "platform_machine == 'aarch64' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32' and extra == 'extra-5-mship-cpu' and extra != 'extra-5-mship-cuda' and extra == 'extra-5-mship-metal'",
-    "(platform_machine == 'ppc64le' and sys_platform == 'win32' and extra == 'extra-5-mship-cpu' and extra != 'extra-5-mship-cuda' and extra == 'extra-5-mship-metal') or (platform_machine == 'riscv64' and sys_platform == 'win32' and extra == 'extra-5-mship-cpu' and extra != 'extra-5-mship-cuda' and extra == 'extra-5-mship-metal')",
-    "(platform_machine == 'ppc64le' and sys_platform == 'emscripten' and extra == 'extra-5-mship-cpu' and extra != 'extra-5-mship-cuda' and extra == 'extra-5-mship-metal') or (platform_machine == 'riscv64' and sys_platform == 'emscripten' and extra == 'extra-5-mship-cpu' and extra != 'extra-5-mship-cuda' and extra == 'extra-5-mship-metal')",
-    "(platform_machine != 'aarch64' and platform_machine != 's390x' and platform_machine != 'x86_64' and sys_platform == 'darwin' and extra == 'extra-5-mship-cpu' and extra != 'extra-5-mship-cuda' and extra == 'extra-5-mship-metal') or (platform_machine == 'ppc64le' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32' and extra == 'extra-5-mship-cpu' and extra != 'extra-5-mship-cuda' and extra == 'extra-5-mship-metal') or (platform_machine == 'riscv64' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32' and extra == 'extra-5-mship-cpu' and extra != 'extra-5-mship-cuda' and extra == 'extra-5-mship-metal')",
-    "platform_machine != 'aarch64' and platform_machine != 'ppc64le' and platform_machine != 'riscv64' and platform_machine != 's390x' and platform_machine != 'x86_64' and sys_platform == 'win32' and extra == 'extra-5-mship-cpu' and extra != 'extra-5-mship-cuda' and extra == 'extra-5-mship-metal'",
-    "platform_machine != 'aarch64' and platform_machine != 'ppc64le' and platform_machine != 'riscv64' and platform_machine != 's390x' and platform_machine != 'x86_64' and sys_platform == 'emscripten' and extra == 'extra-5-mship-cpu' and extra != 'extra-5-mship-cuda' and extra == 'extra-5-mship-metal'",
-    "platform_machine != 'aarch64' and platform_machine != 'ppc64le' and platform_machine != 'riscv64' and platform_machine != 's390x' and platform_machine != 'x86_64' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32' and extra == 'extra-5-mship-cpu' and extra != 'extra-5-mship-cuda' and extra == 'extra-5-mship-metal'",
-    "(platform_machine == 's390x' and sys_platform == 'darwin' and extra == 'extra-5-mship-cpu' and extra != 'extra-5-mship-cuda' and extra != 'extra-5-mship-metal') or (platform_machine == 'x86_64' and sys_platform == 'darwin' and extra == 'extra-5-mship-cpu' and extra != 'extra-5-mship-cuda' and extra != 'extra-5-mship-metal')",
-    "platform_machine == 'aarch64' and sys_platform == 'darwin' and extra == 'extra-5-mship-cpu' and extra != 'extra-5-mship-cuda' and extra != 'extra-5-mship-metal'",
-    "(platform_machine == 's390x' and sys_platform == 'win32' and extra == 'extra-5-mship-cpu' and extra != 'extra-5-mship-cuda' and extra != 'extra-5-mship-metal') or (platform_machine == 'x86_64' and sys_platform == 'win32' and extra == 'extra-5-mship-cpu' and extra != 'extra-5-mship-cuda' and extra != 'extra-5-mship-metal')",
-    "(platform_machine == 's390x' and sys_platform == 'emscripten' and extra == 'extra-5-mship-cpu' and extra != 'extra-5-mship-cuda' and extra != 'extra-5-mship-metal') or (platform_machine == 'x86_64' and sys_platform == 'emscripten' and extra == 'extra-5-mship-cpu' and extra != 'extra-5-mship-cuda' and extra != 'extra-5-mship-metal')",
-    "(platform_machine == 's390x' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32' and extra == 'extra-5-mship-cpu' and extra != 'extra-5-mship-cuda' and extra != 'extra-5-mship-metal') or (platform_machine == 'x86_64' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32' and extra == 'extra-5-mship-cpu' and extra != 'extra-5-mship-cuda' and extra != 'extra-5-mship-metal')",
-    "platform_machine == 'aarch64' and sys_platform == 'win32' and extra == 'extra-5-mship-cpu' and extra != 'extra-5-mship-cuda' and extra != 'extra-5-mship-metal'",
-    "platform_machine == 'aarch64' and sys_platform == 'emscripten' and extra == 'extra-5-mship-cpu' and extra != 'extra-5-mship-cuda' and extra != 'extra-5-mship-metal'",
-    "platform_machine == 'aarch64' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32' and extra == 'extra-5-mship-cpu' and extra != 'extra-5-mship-cuda' and extra != 'extra-5-mship-metal'",
-    "(platform_machine == 'ppc64le' and sys_platform == 'win32' and extra == 'extra-5-mship-cpu' and extra != 'extra-5-mship-cuda' and extra != 'extra-5-mship-metal') or (platform_machine == 'riscv64' and sys_platform == 'win32' and extra == 'extra-5-mship-cpu' and extra != 'extra-5-mship-cuda' and extra != 'extra-5-mship-metal')",
-    "(platform_machine == 'ppc64le' and sys_platform == 'emscripten' and extra == 'extra-5-mship-cpu' and extra != 'extra-5-mship-cuda' and extra != 'extra-5-mship-metal') or (platform_machine == 'riscv64' and sys_platform == 'emscripten' and extra == 'extra-5-mship-cpu' and extra != 'extra-5-mship-cuda' and extra != 'extra-5-mship-metal')",
-    "(platform_machine != 'aarch64' and platform_machine != 's390x' and platform_machine != 'x86_64' and sys_platform == 'darwin' and extra == 'extra-5-mship-cpu' and extra != 'extra-5-mship-cuda' and extra != 'extra-5-mship-metal') or (platform_machine == 'ppc64le' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32' and extra == 'extra-5-mship-cpu' and extra != 'extra-5-mship-cuda' and extra != 'extra-5-mship-metal') or (platform_machine == 'riscv64' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32' and extra == 'extra-5-mship-cpu' and extra != 'extra-5-mship-cuda' and extra != 'extra-5-mship-metal')",
-    "platform_machine != 'aarch64' and platform_machine != 'ppc64le' and platform_machine != 'riscv64' and platform_machine != 's390x' and platform_machine != 'x86_64' and sys_platform == 'win32' and extra == 'extra-5-mship-cpu' and extra != 'extra-5-mship-cuda' and extra != 'extra-5-mship-metal'",
-    "platform_machine != 'aarch64' and platform_machine != 'ppc64le' and platform_machine != 'riscv64' and platform_machine != 's390x' and platform_machine != 'x86_64' and sys_platform == 'emscripten' and extra == 'extra-5-mship-cpu' and extra != 'extra-5-mship-cuda' and extra != 'extra-5-mship-metal'",
-    "platform_machine != 'aarch64' and platform_machine != 'ppc64le' and platform_machine != 'riscv64' and platform_machine != 's390x' and platform_machine != 'x86_64' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32' and extra == 'extra-5-mship-cpu' and extra != 'extra-5-mship-cuda' and extra != 'extra-5-mship-metal'",
-    "sys_platform == 'win32' and extra != 'extra-5-mship-cpu' and extra != 'extra-5-mship-cuda' and extra == 'extra-5-mship-metal'",
-    "sys_platform == 'emscripten' and extra != 'extra-5-mship-cpu' and extra != 'extra-5-mship-cuda' and extra == 'extra-5-mship-metal'",
-    "sys_platform != 'emscripten' and sys_platform != 'win32' and extra != 'extra-5-mship-cpu' and extra != 'extra-5-mship-cuda' and extra == 'extra-5-mship-metal'",
-    "sys_platform == 'win32' and extra != 'extra-5-mship-cpu' and extra != 'extra-5-mship-cuda' and extra != 'extra-5-mship-metal'",
-    "sys_platform == 'emscripten' and extra != 'extra-5-mship-cpu' and extra != 'extra-5-mship-cuda' and extra != 'extra-5-mship-metal'",
-    "sys_platform != 'emscripten' and sys_platform != 'win32' and extra != 'extra-5-mship-cpu' and extra != 'extra-5-mship-cuda' and extra != 'extra-5-mship-metal'",
-]
 dependencies = [
-    { name = "flatbuffers", marker = "extra == 'extra-5-mship-cpu' or extra != 'extra-5-mship-cuda' or (extra == 'extra-5-mship-cuda' and extra == 'extra-5-mship-metal')" },
-    { name = "numpy", marker = "extra == 'extra-5-mship-cpu' or extra != 'extra-5-mship-cuda' or (extra == 'extra-5-mship-cuda' and extra == 'extra-5-mship-metal')" },
-    { name = "packaging", marker = "extra == 'extra-5-mship-cpu' or extra != 'extra-5-mship-cuda' or (extra == 'extra-5-mship-cuda' and extra == 'extra-5-mship-metal')" },
-    { name = "protobuf", marker = "extra == 'extra-5-mship-cpu' or extra != 'extra-5-mship-cuda' or (extra == 'extra-5-mship-cuda' and extra == 'extra-5-mship-metal')" },
+    { name = "flatbuffers" },
+    { name = "numpy" },
+    { name = "packaging" },
+    { name = "protobuf" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/98/f8/dcbe7700dca82fa540035abd3c868fe5ad0f86af00b9a3db7c2e27d15c7d/onnxruntime-1.28.0-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:26ff0fdd06efb6c155bae95387a09db1a2be89c7a03e4d0bffd5a171cc2826da", size = 19141362, upload-time = "2026-07-25T01:22:36.965Z" },
@@ -3298,7 +3242,7 @@ wheels = [
 
 [[package]]
 name = "pywhispercpp"
-version = "1.4.1"
+version = "1.5.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "numpy" },
@@ -3306,15 +3250,15 @@ dependencies = [
     { name = "requests" },
     { name = "tqdm" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/f6/7d/fe4b2b190d6cdcf0d5e4ca2b946d73bc449a586606a24d25ff50ffec5a5c/pywhispercpp-1.4.1.tar.gz", hash = "sha256:520ce9275bb6fc81e0daa2e08144a80ee006b117a18058a77860c5b1c9c122f4", size = 1812704, upload-time = "2025-12-30T03:02:12.54Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/1c/43/8778f0685a4d32d74efdfa78fc5f745ca9998d96f8121dbf7793db2da5d3/pywhispercpp-1.5.0.tar.gz", hash = "sha256:5aa54c73ec96617d97aa519dbbf817e44255eddd9bd52ee1243be61028dbd018", size = 2333262, upload-time = "2026-05-30T03:43:37.398Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/93/81/a4ca043b96a1cd05659af556223de31ce336f5c88f1decd9ca4def8b8f42/pywhispercpp-1.4.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:92168783736e23e9e274e4496024a7a25d670601a130a35befd627b6f717a98a", size = 2207307, upload-time = "2025-12-30T03:01:22.876Z" },
-    { url = "https://files.pythonhosted.org/packages/77/63/7f3f7af598bfaa0fd4836cbd16716a7098c521a76404d5f7bac6211ec725/pywhispercpp-1.4.1-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ed46e7469feaad4a03e25a9f75fe54da791d161489ca02c160540135f21ac481", size = 2378182, upload-time = "2025-12-30T03:01:24.115Z" },
-    { url = "https://files.pythonhosted.org/packages/b0/5f/6ad9e807bf705c053a87078aec118f1d154247418a592a2ac0a7622b0539/pywhispercpp-1.4.1-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:aef812596e4726a76c8b5a090d3e4f0ad9e2ebc70f004164ec754a60aaf56446", size = 2630413, upload-time = "2025-12-30T03:01:25.915Z" },
-    { url = "https://files.pythonhosted.org/packages/2e/06/9dac4ebee6fb436650965161082e7de674c68a959fd4ee530cbb231eb4f4/pywhispercpp-1.4.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:b0dd76b28359f7cb82b999627acd4b6a6c1f7aa8106810601d80712d873e3f90", size = 3285003, upload-time = "2025-12-30T03:01:27.676Z" },
-    { url = "https://files.pythonhosted.org/packages/a4/91/72c3b3f85239816d5414b12b190b474e9e7e37472fb0b1cfdff75d42448b/pywhispercpp-1.4.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:8f7f2cd5a0f876134d7ee85c7603e55d0df830ca2e8d910cc11d7e8c0423b739", size = 3556791, upload-time = "2025-12-30T03:01:29.417Z" },
-    { url = "https://files.pythonhosted.org/packages/c0/77/bc7c07353afcf31c81817fcced7a09457aadfe2f825d6243664189955715/pywhispercpp-1.4.1-cp312-cp312-win32.whl", hash = "sha256:dfe69c89c830aad506685c460d5115e6a52159150b86ee2b9a2618e7786767be", size = 1041447, upload-time = "2025-12-30T03:01:30.686Z" },
-    { url = "https://files.pythonhosted.org/packages/f0/b0/ffcb3e797d80b02e77a174e60f80cd94e851491647e64227ca76b4e2bcf8/pywhispercpp-1.4.1-cp312-cp312-win_amd64.whl", hash = "sha256:4beb57ec35dc0457188470ab4ef673620ce9a49a99ddecd0ae76567986dba908", size = 1222302, upload-time = "2025-12-30T03:01:32.631Z" },
+    { url = "https://files.pythonhosted.org/packages/78/22/e944ab33c3daf6c78f30d6dd943d84ececf3eb4625da2a3eedacff5590cd/pywhispercpp-1.5.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:24602b8d0329a224fe6eb1c1e455853e983a5e04a63d4cb759ae2f275e254f5f", size = 3963140, upload-time = "2026-05-30T03:42:50.93Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/a3/e1daeb58fc76b9cd5f108708ecbeb4e1175ee9d366502033066eae71c51b/pywhispercpp-1.5.0-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a839b738936a8cd72cdd55c59a83a462820532bee78e233241bf9a3503e92144", size = 3962387, upload-time = "2026-05-30T03:42:52.536Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/a7/d8b196d1fa83ec6072c32e021f1987079bbeb25009a4fe7a10967d02b249/pywhispercpp-1.5.0-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6ad4071772eb9dad59a741611e44e3819e6249c46e295ab8468609d03c6e4232", size = 4437117, upload-time = "2026-05-30T03:42:53.842Z" },
+    { url = "https://files.pythonhosted.org/packages/45/8e/28069ac89a08ebc3e56616a07a36c1628d61fa679a45ea3f507da7f5cb13/pywhispercpp-1.5.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:22f9ddf12f6fb0fe3c43465d976b554e8928fcc113c902127e94c792d85f0631", size = 4736369, upload-time = "2026-05-30T03:42:55.283Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/c8/2e63aaf0c1c6f9a3e4f05db9c2c6f8f922937f0b508f5f9e338b2ac5e58a/pywhispercpp-1.5.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:3f825942067da3b0c48fc5b552b816fcee1761e955b9fdfdc911f0ab2d6fff11", size = 5211824, upload-time = "2026-05-30T03:42:56.735Z" },
+    { url = "https://files.pythonhosted.org/packages/97/15/bf1ff8b4fbc777fa2bfc89ff8cddff103ee251807f3f440a518184da7570/pywhispercpp-1.5.0-cp312-cp312-win32.whl", hash = "sha256:03025227d0da211e382db6b6b16d910a267c663b6b2c57092b1200965ec45393", size = 1170123, upload-time = "2026-05-30T03:42:58.197Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/88/fb11006f84b0af46cedf1f66a6190bb78cafb29c0d89d5a73d5ba25ffc43/pywhispercpp-1.5.0-cp312-cp312-win_amd64.whl", hash = "sha256:f9b1cd9dd4c3eb7fb2b777529eb62618e58a6bb05be20f82b7b1afe3d0b12274", size = 1318389, upload-time = "2026-05-30T03:42:59.28Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Subplan 3 of the ONNX/speech loader consolidation: adds `loader: whispercpp` (pywhispercpp, no subprocess) alongside the existing plugin, fixing the gaps the plugin tier let slide — prompt/temperature forwarding, real detected language instead of a fabricated one, off-event-loop transcription, segment streaming with mid-call abort, and model resolution through modelship's own resolver (with a ggml/GGUF/safetensors format check) instead of pywhispercpp downloading into its own directory.

Also fixes the gateway not recognizing TranscriptionResponseVerbose / TranslationResponseVerbose as terminal JSON responses (a pre-existing bug that would've broken verbose_json for any loader, vLLM included).


