### PR TITLE
feat: add sherpa_onnx TTS loader (kokoro, CPU/CoreML, streaming)

### DIFF
--- a/config/examples/sherpa-onnx.yaml
+++ b/config/examples/sherpa-onnx.yaml
@@ -1,0 +1,27 @@
+# sherpa_onnx loader examples — in-process sherpa-onnx TTS via its Python
+# bindings. See docs/model-configuration.md for the full reference.
+
+models:
+  # Registry name; the tarball is fetched, sha256-verified, and cached under
+  # <cache_root>/sherpa_onnx/kokoro-en-v0_19/ on first use.
+  - name: "kokoro"
+    model: "kokoro-en-v0_19"
+    usecase: "tts"
+    loader: "sherpa_onnx"
+    num_cpus: 2
+
+  # Multi-language variant — same registry mechanism, more voices.
+  - name: "kokoro-multi-lang"
+    model: "kokoro-multi-lang-v1_0"
+    usecase: "tts"
+    loader: "sherpa_onnx"
+    num_cpus: 2
+
+  # Local directory instead of a download; basename must match a registry
+  # name above (`kokoro-en-v0_19`), which is how the loader knows what to
+  # expect inside it.
+  - name: "kokoro-local"
+    model: "/models/kokoro-en-v0_19"
+    usecase: "tts"
+    loader: "sherpa_onnx"
+    num_cpus: 2

--- a/docs/model-configuration.md
+++ b/docs/model-configuration.md
@@ -95,7 +95,7 @@ If `MSHIP_TRUSTED_IDENTITY_HEADER` is unset (the default), modelship falls back 
 | `name` | string | Model identifier used in API requests |
 | `model` | string | HuggingFace repo ID, local path, or `repo:filename` (see [Model source](#model-source)). Required for built-in loaders; optional for `loader: custom` |
 | `usecase` | string | `generate`, `embed`, `transcription`, `translation`, `tts`, or `image` |
-| `loader` | string | `vllm`, `diffusers`, `llama_server`, `stable_diffusion_cpp`, `whispercpp`, or `custom` |
+| `loader` | string | `vllm`, `diffusers`, `llama_server`, `stable_diffusion_cpp`, `whispercpp`, `sherpa_onnx`, or `custom` |
 | `plugin` | string | Plugin module name (required when `loader: custom`); automatically loaded from wheels when referenced |
 | `num_gpus` | float \| int | GPU allocation. Fractional `< 1` shares one GPU (also sets vLLM `gpu_memory_utilization`); integer `≥ 1` requests that many whole GPUs (for `vllm`, this auto-sets `tensor_parallel_size = num_gpus` unless tp/pp is already specified). |
 | `num_cpus` | float | CPU units to allocate (default `0.1`) |
@@ -464,6 +464,30 @@ models:
 ```
 
 See `config/examples/whispercpp.yaml` for every `model:` form and a Metal example.
+
+## sherpa_onnx Loader
+
+The `sherpa_onnx` loader runs [sherpa-onnx](https://github.com/k2-fsa/sherpa-onnx) in-process via its Python bindings. Current scope: TTS only, kokoro family only, CPU (and CoreML on macOS) only — no CUDA wheel wired up yet. `num_gpus` must be `0` or a whole integer; on Linux this means `0` in practice.
+
+`model:` is not an HF repo or path — it's a name from a curated, built-in registry (or a local directory whose basename matches one). Each name maps to a GitHub release tarball with a pinned sha256, downloaded and cached under `<cache_root>/sherpa_onnx/<name>/` on first use. There is no `sherpa_onnx_config` — `provider` (`cpu`/`coreml`) and thread count are derived from `num_gpus`/`num_cpus`, never user-supplied, since an invalid provider string silently falls back to CPU inside sherpa's own C++.
+
+Supported `model:` names:
+
+| Name | Speakers | Notes |
+|---|---|---|
+| `kokoro-en-v0_19` | 11 | English only. Includes `af_bella`. |
+| `kokoro-multi-lang-v1_0` | 53 | English, Mandarin, Japanese, and more. Includes `af_bella` and `af_heart`. |
+
+```yaml
+models:
+  - name: "kokoro"
+    model: "kokoro-en-v0_19"
+    usecase: "tts"
+    loader: "sherpa_onnx"
+    num_cpus: 2
+```
+
+See `config/examples/sherpa-onnx.yaml` for the local-directory form.
 
 ## Custom Loader (Plugins)
 

--- a/docs/model-configuration.md
+++ b/docs/model-configuration.md
@@ -467,7 +467,7 @@ See `config/examples/whispercpp.yaml` for every `model:` form and a Metal exampl
 
 ## sherpa_onnx Loader
 
-The `sherpa_onnx` loader runs [sherpa-onnx](https://github.com/k2-fsa/sherpa-onnx) in-process via its Python bindings. Current scope: TTS only, kokoro family only, CPU (and CoreML on macOS) only — no CUDA wheel wired up yet. `num_gpus` must be `0` or a whole integer; on Linux this means `0` in practice.
+The `sherpa_onnx` loader runs [sherpa-onnx](https://github.com/k2-fsa/sherpa-onnx) in-process via its Python bindings. Current scope: TTS only, kokoro family only, CPU (and CoreML on macOS) only. `num_gpus` must be `0` or a whole integer; on Linux this means `0` in practice.
 
 `model:` is not an HF repo or path — it's a name from a curated, built-in registry (or a local directory whose basename matches one). Each name maps to a GitHub release tarball with a pinned sha256, downloaded and cached under `<cache_root>/sherpa_onnx/<name>/` on first use. There is no `sherpa_onnx_config` — `provider` (`cpu`/`coreml`) and thread count are derived from `num_gpus`/`num_cpus`, never user-supplied, since an invalid provider string silently falls back to CPU inside sherpa's own C++.
 

--- a/modelship/deploy/capabilities.py
+++ b/modelship/deploy/capabilities.py
@@ -27,6 +27,7 @@ LOADER_MODULES = {
     "diffusers": "diffusers",
     "stable_diffusion_cpp": "stable_diffusion_cpp",
     "whispercpp": "pywhispercpp",
+    "sherpa_onnx": "sherpa_onnx",
 }
 
 _LLAMA_SERVER_LOADER = "llama_server"

--- a/modelship/deploy/config.py
+++ b/modelship/deploy/config.py
@@ -75,6 +75,28 @@ def _is_whispercpp_builtin_ref(model: str) -> bool:
     return "/" not in model and not os.path.exists(model)
 
 
+def _resolve_sherpa_onnx_source(cfg) -> None:
+    """Not an HF repo, so no `check_model_source`. A local-directory `model:` is
+    validated here at driver preflight; a bare registry name has nothing to pin
+    since the tarball fetch happens in the actor."""
+    from modelship.infer.sherpa_onnx.bundle import validate_bundle
+    from modelship.infer.sherpa_onnx.registry import REGISTRY
+
+    model = cfg.model
+    assert model is not None  # validator guarantees this for built-in loaders
+    if model.startswith(("/", "./", "~")):
+        path = os.path.expanduser(model)
+        name = os.path.basename(path.rstrip("/"))
+        entry = REGISTRY[name]  # config validation already guarantees this key exists
+        logger.info("Checking sherpa_onnx bundle for '%s': %s", cfg.name, path)
+        validate_bundle(path, entry)
+        logger.info("Checked '%s' (local bundle, no download)", cfg.name)
+    else:
+        logger.info(
+            "Skipping source check for '%s': sherpa_onnx registry model %r is fetched by the actor", cfg.name, model
+        )
+
+
 def resolve_all_model_sources(yml_conf: ModelshipConfig) -> None:
     """Pre-flight: check every built-in-loader model's source, without
     downloading any weight bytes.
@@ -97,6 +119,9 @@ def resolve_all_model_sources(yml_conf: ModelshipConfig) -> None:
         if cfg.loader == ModelLoader.whispercpp and cfg.model and _is_whispercpp_builtin_ref(cfg.model):
             # pywhispercpp resolves/downloads its own built-in models; nothing to pin here.
             logger.info("Skipping source check for '%s': pywhispercpp built-in model %r", cfg.name, cfg.model)
+            continue
+        if cfg.loader == ModelLoader.sherpa_onnx:
+            _resolve_sherpa_onnx_source(cfg)
             continue
         assert cfg.model is not None  # validator guarantees this for built-in loaders
         trust_remote_code = bool(cfg.vllm_engine_kwargs and cfg.vllm_engine_kwargs.trust_remote_code)

--- a/modelship/deploy/config.py
+++ b/modelship/deploy/config.py
@@ -8,6 +8,7 @@ from modelship.deploy.actor_options import resolve_plugin_wheel
 from modelship.infer.infer_config import ModelLoader, ModelshipConfig
 from modelship.infer.model_resolver import check_model_source
 from modelship.logging import get_logger
+from modelship.utils import is_pathy
 
 logger = get_logger("startup")
 
@@ -84,7 +85,7 @@ def _resolve_sherpa_onnx_source(cfg) -> None:
 
     model = cfg.model
     assert model is not None  # validator guarantees this for built-in loaders
-    if model.startswith(("/", "./", "~")):
+    if is_pathy(model):
         path = os.path.expanduser(model)
         name = os.path.basename(path.rstrip("/"))
         entry = REGISTRY[name]  # config validation already guarantees this key exists

--- a/modelship/infer/custom/openai/serving_speech.py
+++ b/modelship/infer/custom/openai/serving_speech.py
@@ -1,15 +1,9 @@
-import base64
 from collections.abc import AsyncGenerator
 
 from modelship.infer.infer_config import RawRequestProxy
 from modelship.logging import get_logger
-from modelship.openai.protocol import (
-    ErrorResponse,
-    RawSpeechResponse,
-    SpeechRequest,
-    SpeechResponse,
-    create_error_response,
-)
+from modelship.openai.protocol import ErrorResponse, RawSpeechResponse, SpeechRequest, create_error_response
+from modelship.openai.utils.audio import sse_stream_speech
 from modelship.plugins.base_plugin import BasePlugin
 from modelship.utils import base_request_id
 
@@ -44,13 +38,4 @@ class OpenAIServingSpeech:
         if isinstance(result, ErrorResponse | RawSpeechResponse):
             return result
 
-        return _sse_stream(result)
-
-
-async def _sse_stream(chunks: AsyncGenerator[tuple[bytes, int], None]) -> AsyncGenerator[str, None]:
-    async for pcm, _sample_rate in chunks:
-        audio_b64 = base64.b64encode(pcm).decode("ascii")
-        event = SpeechResponse(type="speech.audio.delta", audio=audio_b64)
-        yield f"data: {event.model_dump_json()}\n\n"
-    done = SpeechResponse(type="speech.audio.done")
-    yield f"data: {done.model_dump_json()}\n\n"
+        return sse_stream_speech(result)

--- a/modelship/infer/infer_config.py
+++ b/modelship/infer/infer_config.py
@@ -1,5 +1,6 @@
 import asyncio
 import hashlib
+import os
 import time
 from collections.abc import Callable
 from enum import StrEnum
@@ -54,6 +55,7 @@ class ModelLoader(StrEnum):
     llama_server = "llama_server"
     stable_diffusion_cpp = "stable_diffusion_cpp"
     whispercpp = "whispercpp"
+    sherpa_onnx = "sherpa_onnx"
     custom = "custom"
 
 
@@ -293,8 +295,8 @@ class ModelshipModelConfig(BaseModel):
 
     @model_validator(mode="after")
     def validate_whole_gpu_only_loaders_num_gpus(self):
-        # Neither backend has a VRAM-fraction knob — require whole GPUs (or 0).
-        whole_gpu_loaders = (ModelLoader.llama_server, ModelLoader.whispercpp)
+        # None of these backends has a VRAM-fraction knob — require whole GPUs (or 0).
+        whole_gpu_loaders = (ModelLoader.llama_server, ModelLoader.whispercpp, ModelLoader.sherpa_onnx)
         if self.loader in whole_gpu_loaders and self.num_gpus != int(self.num_gpus):
             raise ValueError(
                 f"num_gpus={self.num_gpus!r} is not allowed for the {self.loader.value} loader: "
@@ -313,6 +315,27 @@ class ModelshipModelConfig(BaseModel):
             self.usecase is not ModelUsecase.image
         ):
             raise ValueError(f"loader={self.loader.value!r} only supports usecase='image', got {self.usecase!r}")
+        return self
+
+    @model_validator(mode="after")
+    def check_sherpa_onnx_model_and_usecase(self):
+        # `model:` must be a curated registry name (or a local dir named for one),
+        # not an arbitrary HF repo/URL.
+        if self.loader != ModelLoader.sherpa_onnx:
+            return self
+        from modelship.infer.sherpa_onnx.registry import registry_names
+
+        assert self.model is not None  # enforced by check_custom_requires_plugin above
+        is_pathy = self.model.startswith(("/", "./", "~"))
+        name = os.path.basename(self.model.rstrip("/")) if is_pathy else self.model
+        names = registry_names()
+        if name not in names:
+            raise ValueError(
+                f"model '{self.name}': sherpa_onnx model {self.model!r} is not a supported registry name "
+                f"(or a local directory whose basename matches one). Supported names: {', '.join(names)}"
+            )
+        if self.usecase is not ModelUsecase.tts:
+            raise ValueError(f"loader='sherpa_onnx' only supports usecase='tts' (v1 scope), got {self.usecase!r}")
         return self
 
     @model_validator(mode="after")

--- a/modelship/infer/infer_config.py
+++ b/modelship/infer/infer_config.py
@@ -14,6 +14,7 @@ from starlette.datastructures import Headers, State
 
 from modelship.infer.model_resolver import PinnedSource
 from modelship.logging import get_logger
+from modelship.utils import is_pathy
 
 _logger = get_logger("config")
 
@@ -326,8 +327,7 @@ class ModelshipModelConfig(BaseModel):
         from modelship.infer.sherpa_onnx.registry import registry_names
 
         assert self.model is not None  # enforced by check_custom_requires_plugin above
-        is_pathy = self.model.startswith(("/", "./", "~"))
-        name = os.path.basename(self.model.rstrip("/")) if is_pathy else self.model
+        name = os.path.basename(self.model.rstrip("/")) if is_pathy(self.model) else self.model
         names = registry_names()
         if name not in names:
             raise ValueError(

--- a/modelship/infer/model_deployment.py
+++ b/modelship/infer/model_deployment.py
@@ -39,7 +39,8 @@ from modelship.openai.protocol import (
 
 logger = get_logger("infer.deployment")
 
-# llama_server, stable_diffusion_cpp, and whispercpp all have Metal backends; vllm/diffusers don't.
+# llama_server, stable_diffusion_cpp, and whispercpp all have Metal backends; sherpa_onnx has
+# CoreML; vllm/diffusers don't.
 _DARWIN_UNSUPPORTED_LOADERS = {ModelLoader.vllm, ModelLoader.diffusers}
 
 
@@ -197,6 +198,10 @@ class ModelDeployment:
                 from modelship.infer.whispercpp.whispercpp_infer import WhispercppInfer
 
                 self.infer = WhispercppInfer(config)
+            elif config.loader == ModelLoader.sherpa_onnx:
+                from modelship.infer.sherpa_onnx.sherpa_onnx_infer import SherpaOnnxInfer
+
+                self.infer = SherpaOnnxInfer(config)
             else:
                 from modelship.infer.custom.custom_infer import CustomInfer
 

--- a/modelship/infer/model_resolver.py
+++ b/modelship/infer/model_resolver.py
@@ -6,6 +6,7 @@ from typing import NamedTuple
 from huggingface_hub import hf_hub_download, model_info, snapshot_download
 
 from modelship.logging import get_logger
+from modelship.utils import is_pathy
 
 logger = get_logger("startup")
 
@@ -25,14 +26,10 @@ class ResolvedSource(NamedTuple):
     is_local: bool
 
 
-def _is_pathy(s: str) -> bool:
-    return s.startswith("/") or s.startswith("./") or s.startswith("~")
-
-
 def _expand(s: str) -> str:
     """expanduser only for pathy strings — Path.resolve() never expands `~`,
     so this must happen here or a valid `~/...` ref 404s downstream."""
-    return os.path.expanduser(s) if _is_pathy(s) else s
+    return os.path.expanduser(s) if is_pathy(s) else s
 
 
 def parse_model_ref(model: str) -> ResolvedSource:
@@ -46,14 +43,14 @@ def parse_model_ref(model: str) -> ResolvedSource:
     whether it exists, so a missing path fails clearly downstream instead of
     being misread as an HF repo id. `~` is expanded in the returned source."""
     expanded = _expand(model)
-    if _is_pathy(model) and Path(expanded).exists():
+    if is_pathy(model) and Path(expanded).exists():
         return ResolvedSource(source=expanded, selector=None, is_local=True)
 
     if ":" in model:
         source, selector = model.split(":", 1)
-        return ResolvedSource(source=_expand(source), selector=selector, is_local=_is_pathy(source))
+        return ResolvedSource(source=_expand(source), selector=selector, is_local=is_pathy(source))
 
-    return ResolvedSource(source=expanded, selector=None, is_local=_is_pathy(model))
+    return ResolvedSource(source=expanded, selector=None, is_local=is_pathy(model))
 
 
 def _select_patterns(repo_files: list[str], trust_remote_code: bool = False) -> list[str] | None:

--- a/modelship/infer/sherpa_onnx/bundle.py
+++ b/modelship/infer/sherpa_onnx/bundle.py
@@ -4,9 +4,9 @@ modelship/launcher.py for llama.cpp's binary tarball)."""
 
 import os
 
-from modelship.infer.sherpa_onnx.registry import REGISTRY, RegistryDir, RegistryFile, SherpaOnnxRegistryEntry
+from modelship.infer.sherpa_onnx.registry import REGISTRY, SherpaOnnxRegistryEntry
 from modelship.logging import get_logger
-from modelship.utils import cache_dir, fetch_and_extract_archive, verify_sha256
+from modelship.utils import cache_dir, fetch_and_extract_archive
 
 logger = get_logger("infer.sherpa_onnx.bundle")
 
@@ -38,41 +38,22 @@ def resolve_bundle_dir(model: str) -> tuple[str, SherpaOnnxRegistryEntry]:
 
 
 def validate_bundle(bundle_dir: str, entry: SherpaOnnxRegistryEntry) -> None:
-    """Raises ValueError with an actionable message on any mismatch. Used both
-    right after a tarball extraction and directly against a user-supplied
-    local directory — same check either way."""
+    """Raises ValueError with an actionable message if a declared file/dir is
+    missing. Used both right after a tarball extraction and directly against a
+    user-supplied local directory — same check either way. Existence only:
+    the tarball's own sha256 (checked before extraction) already catches a
+    corrupt/truncated download."""
     if not os.path.isdir(bundle_dir):
         raise ValueError(f"sherpa_onnx bundle directory not found: {bundle_dir!r}")
 
-    for slot, file in entry.files.items():
-        _check_file(bundle_dir, file, f"files[{slot!r}]")
-    for i, file in enumerate(entry.lexicon):
-        _check_file(bundle_dir, file, f"lexicon[{i}]")
-    for slot, d in entry.dirs.items():
-        _check_dir(bundle_dir, d, f"dirs[{slot!r}]")
+    for slot, path in entry.files.items():
+        _check_exists(bundle_dir, path, os.path.isfile, f"files[{slot!r}]")
+    for i, path in enumerate(entry.lexicon):
+        _check_exists(bundle_dir, path, os.path.isfile, f"lexicon[{i}]")
+    for slot, path in entry.dirs.items():
+        _check_exists(bundle_dir, path, os.path.isdir, f"dirs[{slot!r}]")
 
 
-def _check_file(bundle_dir: str, file: RegistryFile, context: str) -> None:
-    path = os.path.join(bundle_dir, file.path)
-    if not os.path.isfile(path):
-        raise ValueError(f"sherpa_onnx bundle {bundle_dir!r}: missing {context} file {file.path!r}")
-    actual_size = os.path.getsize(path)
-    if actual_size != file.size:
-        raise ValueError(
-            f"sherpa_onnx bundle {bundle_dir!r}: {context} file {file.path!r} is {actual_size} bytes, "
-            f"expected {file.size} (a truncated download or a `git clone` without LFS often looks like this)"
-        )
-    if file.sha256 is not None:
-        verify_sha256(path, file.sha256)
-
-
-def _check_dir(bundle_dir: str, d: RegistryDir, context: str) -> None:
-    path = os.path.join(bundle_dir, d.path)
-    if not os.path.isdir(path):
-        raise ValueError(f"sherpa_onnx bundle {bundle_dir!r}: missing {context} directory {d.path!r}")
-    actual_count = sum(len(files) for _root, _dirs, files in os.walk(path))
-    if actual_count != d.file_count:
-        raise ValueError(
-            f"sherpa_onnx bundle {bundle_dir!r}: {context} directory {d.path!r} has {actual_count} files, "
-            f"expected {d.file_count} (a half-extracted archive often looks like this)"
-        )
+def _check_exists(bundle_dir: str, rel_path: str, check, context: str) -> None:
+    if not check(os.path.join(bundle_dir, rel_path)):
+        raise ValueError(f"sherpa_onnx bundle {bundle_dir!r}: missing {context} {rel_path!r}")

--- a/modelship/infer/sherpa_onnx/bundle.py
+++ b/modelship/infer/sherpa_onnx/bundle.py
@@ -7,7 +7,7 @@ import shutil
 
 from modelship.infer.sherpa_onnx.registry import REGISTRY, SherpaOnnxRegistryEntry
 from modelship.logging import get_logger
-from modelship.utils import cache_dir, fetch_and_extract_archive, is_pathy
+from modelship.utils import cache_dir, fetch_and_extract_archive, is_pathy, random_uuid
 
 logger = get_logger("infer.sherpa_onnx.bundle")
 
@@ -33,7 +33,7 @@ def resolve_bundle_dir(model: str) -> tuple[str, SherpaOnnxRegistryEntry]:
             logger.warning("cached sherpa_onnx bundle %r failed validation, re-fetching", model)
             shutil.rmtree(bundle_dir, ignore_errors=True)
 
-    archive_path = os.path.join(cache_dir(), "sherpa_onnx", f".{model}.tar.bz2")
+    archive_path = os.path.join(cache_dir(), "sherpa_onnx", f".{model}-{random_uuid()}.tar.bz2")
     fetch_and_extract_archive(entry.tarball_url, entry.sha256, archive_path, bundle_dir)
     validate_bundle(bundle_dir, entry)
     return bundle_dir, entry

--- a/modelship/infer/sherpa_onnx/bundle.py
+++ b/modelship/infer/sherpa_onnx/bundle.py
@@ -7,7 +7,7 @@ import shutil
 
 from modelship.infer.sherpa_onnx.registry import REGISTRY, SherpaOnnxRegistryEntry
 from modelship.logging import get_logger
-from modelship.utils import cache_dir, fetch_and_extract_archive
+from modelship.utils import cache_dir, fetch_and_extract_archive, is_pathy
 
 logger = get_logger("infer.sherpa_onnx.bundle")
 
@@ -16,7 +16,7 @@ def resolve_bundle_dir(model: str) -> tuple[str, SherpaOnnxRegistryEntry]:
     """`model` is a registry name (fetched into the shared cache) or a local
     directory path (used in place, basename must match a registry name —
     config validation already guarantees this)."""
-    if model.startswith(("/", "./", "~")):
+    if is_pathy(model):
         path = os.path.expanduser(model)
         name = os.path.basename(path.rstrip("/"))
         entry = REGISTRY[name]

--- a/modelship/infer/sherpa_onnx/bundle.py
+++ b/modelship/infer/sherpa_onnx/bundle.py
@@ -1,0 +1,111 @@
+"""Fetch, verify, and extract sherpa_onnx's curated model bundles into the
+shared cache dir. Mirrors modelship/launcher.py's llama.cpp tarball
+provisioning (download -> verify_sha256 -> extract), except extraction keeps
+the tarball's directory structure instead of flattening to basenames."""
+
+import contextlib
+import os
+import shutil
+import tarfile
+
+from modelship.infer.sherpa_onnx.registry import REGISTRY, RegistryDir, RegistryFile, SherpaOnnxRegistryEntry
+from modelship.logging import get_logger
+from modelship.utils import cache_dir, download, random_uuid, verify_sha256
+
+logger = get_logger("infer.sherpa_onnx.bundle")
+
+
+def resolve_bundle_dir(model: str) -> tuple[str, SherpaOnnxRegistryEntry]:
+    """`model` is a registry name (fetched into the shared cache) or a local
+    directory path (used in place, basename must match a registry name —
+    config validation already guarantees this)."""
+    if model.startswith(("/", "./", "~")):
+        path = os.path.expanduser(model)
+        name = os.path.basename(path.rstrip("/"))
+        entry = REGISTRY[name]
+        validate_bundle(path, entry)
+        return path, entry
+
+    entry = REGISTRY[model]
+    bundle_dir = os.path.join(cache_dir(), "sherpa_onnx", model)
+    if os.path.isdir(bundle_dir):
+        try:
+            validate_bundle(bundle_dir, entry)
+            return bundle_dir, entry
+        except ValueError:
+            logger.warning("cached sherpa_onnx bundle %r failed validation, re-fetching", model)
+
+    _fetch_and_extract(model, entry, bundle_dir)
+    validate_bundle(bundle_dir, entry)
+    return bundle_dir, entry
+
+
+def _fetch_and_extract(name: str, entry: SherpaOnnxRegistryEntry, bundle_dir: str) -> None:
+    root = os.path.join(cache_dir(), "sherpa_onnx")
+    os.makedirs(root, exist_ok=True)
+    archive_path = os.path.join(root, f".{name}.tar.bz2")
+
+    download(entry.tarball_url, archive_path)
+    try:
+        verify_sha256(archive_path, entry.sha256)
+    except ValueError:
+        os.remove(archive_path)  # don't let a retry re-verify the same corrupt bytes
+        raise
+
+    tmp_dir = os.path.join(root, f".{name}-{random_uuid()}.tmp")
+    os.makedirs(tmp_dir, exist_ok=True)
+    try:
+        with tarfile.open(archive_path) as tar:
+            tar.extractall(tmp_dir, filter="data")
+        extracted_root = os.path.join(tmp_dir, name)
+        if not os.path.isdir(extracted_root):
+            raise ValueError(
+                f"sherpa_onnx bundle {name!r}: extracted tarball has no top-level {name!r} directory "
+                f"(found: {os.listdir(tmp_dir)})"
+            )
+        with contextlib.suppress(OSError):  # another replica on this node already extracted a valid bundle
+            os.replace(extracted_root, bundle_dir)
+    finally:
+        shutil.rmtree(tmp_dir, ignore_errors=True)
+    os.remove(archive_path)
+
+
+def validate_bundle(bundle_dir: str, entry: SherpaOnnxRegistryEntry) -> None:
+    """Raises ValueError with an actionable message on any mismatch. Used both
+    right after a tarball extraction and directly against a user-supplied
+    local directory — same check either way."""
+    if not os.path.isdir(bundle_dir):
+        raise ValueError(f"sherpa_onnx bundle directory not found: {bundle_dir!r}")
+
+    for slot, file in entry.files.items():
+        _check_file(bundle_dir, file, f"files[{slot!r}]")
+    for i, file in enumerate(entry.lexicon):
+        _check_file(bundle_dir, file, f"lexicon[{i}]")
+    for slot, d in entry.dirs.items():
+        _check_dir(bundle_dir, d, f"dirs[{slot!r}]")
+
+
+def _check_file(bundle_dir: str, file: RegistryFile, context: str) -> None:
+    path = os.path.join(bundle_dir, file.path)
+    if not os.path.isfile(path):
+        raise ValueError(f"sherpa_onnx bundle {bundle_dir!r}: missing {context} file {file.path!r}")
+    actual_size = os.path.getsize(path)
+    if actual_size != file.size:
+        raise ValueError(
+            f"sherpa_onnx bundle {bundle_dir!r}: {context} file {file.path!r} is {actual_size} bytes, "
+            f"expected {file.size} (a truncated download or a `git clone` without LFS often looks like this)"
+        )
+    if file.sha256 is not None:
+        verify_sha256(path, file.sha256)
+
+
+def _check_dir(bundle_dir: str, d: RegistryDir, context: str) -> None:
+    path = os.path.join(bundle_dir, d.path)
+    if not os.path.isdir(path):
+        raise ValueError(f"sherpa_onnx bundle {bundle_dir!r}: missing {context} directory {d.path!r}")
+    actual_count = sum(len(files) for _root, _dirs, files in os.walk(path))
+    if actual_count != d.file_count:
+        raise ValueError(
+            f"sherpa_onnx bundle {bundle_dir!r}: {context} directory {d.path!r} has {actual_count} files, "
+            f"expected {d.file_count} (a half-extracted archive often looks like this)"
+        )

--- a/modelship/infer/sherpa_onnx/bundle.py
+++ b/modelship/infer/sherpa_onnx/bundle.py
@@ -3,6 +3,7 @@ shared cache dir, via modelship.utils.fetch_and_extract_archive (also used by
 modelship/launcher.py for llama.cpp's binary tarball)."""
 
 import os
+import shutil
 
 from modelship.infer.sherpa_onnx.registry import REGISTRY, SherpaOnnxRegistryEntry
 from modelship.logging import get_logger
@@ -30,6 +31,7 @@ def resolve_bundle_dir(model: str) -> tuple[str, SherpaOnnxRegistryEntry]:
             return bundle_dir, entry
         except ValueError:
             logger.warning("cached sherpa_onnx bundle %r failed validation, re-fetching", model)
+            shutil.rmtree(bundle_dir, ignore_errors=True)
 
     archive_path = os.path.join(cache_dir(), "sherpa_onnx", f".{model}.tar.bz2")
     fetch_and_extract_archive(entry.tarball_url, entry.sha256, archive_path, bundle_dir)

--- a/modelship/infer/sherpa_onnx/bundle.py
+++ b/modelship/infer/sherpa_onnx/bundle.py
@@ -2,12 +2,13 @@
 shared cache dir, via modelship.utils.fetch_and_extract_archive (also used by
 modelship/launcher.py for llama.cpp's binary tarball)."""
 
+import fcntl
 import os
 import shutil
 
 from modelship.infer.sherpa_onnx.registry import REGISTRY, SherpaOnnxRegistryEntry
 from modelship.logging import get_logger
-from modelship.utils import cache_dir, fetch_and_extract_archive, is_pathy, random_uuid
+from modelship.utils import cache_dir, fetch_and_extract_archive, is_pathy
 
 logger = get_logger("infer.sherpa_onnx.bundle")
 
@@ -25,18 +26,36 @@ def resolve_bundle_dir(model: str) -> tuple[str, SherpaOnnxRegistryEntry]:
 
     entry = REGISTRY[model]
     bundle_dir = os.path.join(cache_dir(), "sherpa_onnx", model)
-    if os.path.isdir(bundle_dir):
+    if _is_valid(bundle_dir, entry):
+        return bundle_dir, entry
+
+    # flock serializes same-node replicas of one deployment onto a single
+    # download+extract instead of each fetching its own copy.
+    root = os.path.join(cache_dir(), "sherpa_onnx")
+    os.makedirs(root, exist_ok=True)
+    with open(os.path.join(root, f".{model}.lock"), "w") as lock_file:
+        fcntl.flock(lock_file, fcntl.LOCK_EX)
         try:
+            if _is_valid(bundle_dir, entry):  # a lock-holder ahead of us may have fixed it
+                return bundle_dir, entry
+            if os.path.isdir(bundle_dir):
+                logger.warning("cached sherpa_onnx bundle %r failed validation, re-fetching", model)
+                shutil.rmtree(bundle_dir, ignore_errors=True)
+
+            archive_path = os.path.join(root, f".{model}.tar.bz2")
+            fetch_and_extract_archive(entry.tarball_url, entry.sha256, archive_path, bundle_dir)
             validate_bundle(bundle_dir, entry)
             return bundle_dir, entry
-        except ValueError:
-            logger.warning("cached sherpa_onnx bundle %r failed validation, re-fetching", model)
-            shutil.rmtree(bundle_dir, ignore_errors=True)
+        finally:
+            fcntl.flock(lock_file, fcntl.LOCK_UN)
 
-    archive_path = os.path.join(cache_dir(), "sherpa_onnx", f".{model}-{random_uuid()}.tar.bz2")
-    fetch_and_extract_archive(entry.tarball_url, entry.sha256, archive_path, bundle_dir)
-    validate_bundle(bundle_dir, entry)
-    return bundle_dir, entry
+
+def _is_valid(bundle_dir: str, entry: SherpaOnnxRegistryEntry) -> bool:
+    try:
+        validate_bundle(bundle_dir, entry)
+        return True
+    except ValueError:
+        return False
 
 
 def validate_bundle(bundle_dir: str, entry: SherpaOnnxRegistryEntry) -> None:

--- a/modelship/infer/sherpa_onnx/bundle.py
+++ b/modelship/infer/sherpa_onnx/bundle.py
@@ -38,11 +38,8 @@ def resolve_bundle_dir(model: str) -> tuple[str, SherpaOnnxRegistryEntry]:
 
 
 def validate_bundle(bundle_dir: str, entry: SherpaOnnxRegistryEntry) -> None:
-    """Raises ValueError with an actionable message if a declared file/dir is
-    missing. Used both right after a tarball extraction and directly against a
-    user-supplied local directory — same check either way. Existence only:
-    the tarball's own sha256 (checked before extraction) already catches a
-    corrupt/truncated download."""
+    """Raises ValueError if a declared file/dir is missing. Existence only —
+    the tarball's own sha256 already covers content integrity."""
     if not os.path.isdir(bundle_dir):
         raise ValueError(f"sherpa_onnx bundle directory not found: {bundle_dir!r}")
 

--- a/modelship/infer/sherpa_onnx/bundle.py
+++ b/modelship/infer/sherpa_onnx/bundle.py
@@ -1,16 +1,12 @@
 """Fetch, verify, and extract sherpa_onnx's curated model bundles into the
-shared cache dir. Mirrors modelship/launcher.py's llama.cpp tarball
-provisioning (download -> verify_sha256 -> extract), except extraction keeps
-the tarball's directory structure instead of flattening to basenames."""
+shared cache dir, via modelship.utils.fetch_and_extract_archive (also used by
+modelship/launcher.py for llama.cpp's binary tarball)."""
 
-import contextlib
 import os
-import shutil
-import tarfile
 
 from modelship.infer.sherpa_onnx.registry import REGISTRY, RegistryDir, RegistryFile, SherpaOnnxRegistryEntry
 from modelship.logging import get_logger
-from modelship.utils import cache_dir, download, random_uuid, verify_sha256
+from modelship.utils import cache_dir, fetch_and_extract_archive, verify_sha256
 
 logger = get_logger("infer.sherpa_onnx.bundle")
 
@@ -35,39 +31,10 @@ def resolve_bundle_dir(model: str) -> tuple[str, SherpaOnnxRegistryEntry]:
         except ValueError:
             logger.warning("cached sherpa_onnx bundle %r failed validation, re-fetching", model)
 
-    _fetch_and_extract(model, entry, bundle_dir)
+    archive_path = os.path.join(cache_dir(), "sherpa_onnx", f".{model}.tar.bz2")
+    fetch_and_extract_archive(entry.tarball_url, entry.sha256, archive_path, bundle_dir)
     validate_bundle(bundle_dir, entry)
     return bundle_dir, entry
-
-
-def _fetch_and_extract(name: str, entry: SherpaOnnxRegistryEntry, bundle_dir: str) -> None:
-    root = os.path.join(cache_dir(), "sherpa_onnx")
-    os.makedirs(root, exist_ok=True)
-    archive_path = os.path.join(root, f".{name}.tar.bz2")
-
-    download(entry.tarball_url, archive_path)
-    try:
-        verify_sha256(archive_path, entry.sha256)
-    except ValueError:
-        os.remove(archive_path)  # don't let a retry re-verify the same corrupt bytes
-        raise
-
-    tmp_dir = os.path.join(root, f".{name}-{random_uuid()}.tmp")
-    os.makedirs(tmp_dir, exist_ok=True)
-    try:
-        with tarfile.open(archive_path) as tar:
-            tar.extractall(tmp_dir, filter="data")
-        extracted_root = os.path.join(tmp_dir, name)
-        if not os.path.isdir(extracted_root):
-            raise ValueError(
-                f"sherpa_onnx bundle {name!r}: extracted tarball has no top-level {name!r} directory "
-                f"(found: {os.listdir(tmp_dir)})"
-            )
-        with contextlib.suppress(OSError):  # another replica on this node already extracted a valid bundle
-            os.replace(extracted_root, bundle_dir)
-    finally:
-        shutil.rmtree(tmp_dir, ignore_errors=True)
-    os.remove(archive_path)
 
 
 def validate_bundle(bundle_dir: str, entry: SherpaOnnxRegistryEntry) -> None:

--- a/modelship/infer/sherpa_onnx/registry.py
+++ b/modelship/infer/sherpa_onnx/registry.py
@@ -8,34 +8,21 @@ wheel installed, same as capabilities.py's LOADER_MODULES.
 from typing import NamedTuple
 
 
-class RegistryFile(NamedTuple):
-    """A file inside the extracted bundle, relative to its root. `sha256` is
-    None for files too large to hash on every deploy."""
-
-    path: str
-    size: int
-    sha256: str | None = None
-
-
-class RegistryDir(NamedTuple):
-    """A directory inside the extracted bundle, relative to its root."""
-
-    path: str
-    file_count: int
-
-
 class SherpaOnnxRegistryEntry(NamedTuple):
     """`files`/`dirs` keys are sherpa's own `OfflineTtsKokoroModelConfig`
-    attribute names. `lexicon` is the list form of sherpa's single comma-joined
-    field. `voice_names[i]` is the OpenAI voice name for sid i."""
+    attribute names, values are paths relative to the bundle root. `lexicon`
+    is the list form of sherpa's single comma-joined field. `voice_names[i]`
+    is the OpenAI voice name for sid i. `sha256` pins the tarball itself —
+    bundle contents are checked for presence only, not size/hash, since a
+    corrupt/truncated download is already caught before extraction."""
 
     tarball_url: str
     sha256: str
     family: str
     usecase: str
-    files: dict[str, RegistryFile]
-    dirs: dict[str, RegistryDir]
-    lexicon: tuple[RegistryFile, ...]
+    files: dict[str, str]
+    dirs: dict[str, str]
+    lexicon: tuple[str, ...]
     voice_names: tuple[str, ...]
 
 
@@ -48,16 +35,12 @@ REGISTRY: dict[str, SherpaOnnxRegistryEntry] = {
         family="kokoro",
         usecase="tts",
         files={
-            "model": RegistryFile("model.onnx", 345_555_491),
-            "tokens": RegistryFile(
-                "tokens.txt", 1_078, "4f31c71282d14af4e926cd12462078fe9d20d00c589e63fe2750a8f56d6d7f7b"
-            ),
-            "voices": RegistryFile(
-                "voices.bin", 5_755_904, "a372c67b056ef0b695c375d39b99630d23fb07ad4c8d87aa32a19a62fca523ad"
-            ),
+            "model": "model.onnx",
+            "tokens": "tokens.txt",
+            "voices": "voices.bin",
         },
         dirs={
-            "data_dir": RegistryDir("espeak-ng-data", 355),
+            "data_dir": "espeak-ng-data",
         },
         lexicon=(),
         voice_names=(
@@ -83,20 +66,16 @@ REGISTRY: dict[str, SherpaOnnxRegistryEntry] = {
         family="kokoro",
         usecase="tts",
         files={
-            "model": RegistryFile("model.onnx", 325_630_829),
-            "tokens": RegistryFile(
-                "tokens.txt", 687, "6ebb6bb288f20f3ae8d004d3c2ca27697da27c037d75e81a60e2a6a663f95425"
-            ),
-            "voices": RegistryFile(
-                "voices.bin", 27_678_720, "8a77c0d397026208d22211f37670b5b3b11e03f190756b25a1d24041fced82a9"
-            ),
+            "model": "model.onnx",
+            "tokens": "tokens.txt",
+            "voices": "voices.bin",
         },
         dirs={
-            "data_dir": RegistryDir("espeak-ng-data", 355),
+            "data_dir": "espeak-ng-data",
         },
         lexicon=(
-            RegistryFile("lexicon-us-en.txt", 5_956_885),
-            RegistryFile("lexicon-zh.txt", 2_364_621),
+            "lexicon-us-en.txt",
+            "lexicon-zh.txt",
         ),
         voice_names=(
             "af_alloy",

--- a/modelship/infer/sherpa_onnx/registry.py
+++ b/modelship/infer/sherpa_onnx/registry.py
@@ -12,9 +12,7 @@ class SherpaOnnxRegistryEntry(NamedTuple):
     """`files`/`dirs` keys are sherpa's own `OfflineTtsKokoroModelConfig`
     attribute names, values are paths relative to the bundle root. `lexicon`
     is the list form of sherpa's single comma-joined field. `voice_names[i]`
-    is the OpenAI voice name for sid i. `sha256` pins the tarball itself —
-    bundle contents are checked for presence only, not size/hash, since a
-    corrupt/truncated download is already caught before extraction."""
+    is the OpenAI voice name for sid i."""
 
     tarball_url: str
     sha256: str

--- a/modelship/infer/sherpa_onnx/registry.py
+++ b/modelship/infer/sherpa_onnx/registry.py
@@ -1,0 +1,161 @@
+"""Curated table of supported sherpa_onnx models, keyed by name. `model:` in
+config must be a name here, or a local directory whose basename is one.
+
+No network access and no `import sherpa_onnx` — must be importable without the
+wheel installed, same as capabilities.py's LOADER_MODULES.
+"""
+
+from typing import NamedTuple
+
+
+class RegistryFile(NamedTuple):
+    """A file inside the extracted bundle, relative to its root. `sha256` is
+    None for files too large to hash on every deploy."""
+
+    path: str
+    size: int
+    sha256: str | None = None
+
+
+class RegistryDir(NamedTuple):
+    """A directory inside the extracted bundle, relative to its root."""
+
+    path: str
+    file_count: int
+
+
+class SherpaOnnxRegistryEntry(NamedTuple):
+    """`files`/`dirs` keys are sherpa's own `OfflineTtsKokoroModelConfig`
+    attribute names. `lexicon` is the list form of sherpa's single comma-joined
+    field. `voice_names[i]` is the OpenAI voice name for sid i."""
+
+    tarball_url: str
+    sha256: str
+    family: str
+    usecase: str
+    files: dict[str, RegistryFile]
+    dirs: dict[str, RegistryDir]
+    lexicon: tuple[RegistryFile, ...]
+    voice_names: tuple[str, ...]
+
+
+_RELEASE_BASE = "https://github.com/k2-fsa/sherpa-onnx/releases/download/tts-models"
+
+REGISTRY: dict[str, SherpaOnnxRegistryEntry] = {
+    "kokoro-en-v0_19": SherpaOnnxRegistryEntry(
+        tarball_url=f"{_RELEASE_BASE}/kokoro-en-v0_19.tar.bz2",
+        sha256="912804855a04745fa77a30be545b3f9a5d15c4d66db00b88cbcd4921df605ac7",
+        family="kokoro",
+        usecase="tts",
+        files={
+            "model": RegistryFile("model.onnx", 345_555_491),
+            "tokens": RegistryFile(
+                "tokens.txt", 1_078, "4f31c71282d14af4e926cd12462078fe9d20d00c589e63fe2750a8f56d6d7f7b"
+            ),
+            "voices": RegistryFile(
+                "voices.bin", 5_755_904, "a372c67b056ef0b695c375d39b99630d23fb07ad4c8d87aa32a19a62fca523ad"
+            ),
+        },
+        dirs={
+            "data_dir": RegistryDir("espeak-ng-data", 355),
+        },
+        lexicon=(),
+        voice_names=(
+            "af",
+            "af_bella",
+            "af_nicole",
+            "af_sarah",
+            "af_sky",
+            "am_adam",
+            "am_michael",
+            "bf_emma",
+            "bf_isabella",
+            "bm_george",
+            "bm_lewis",
+        ),
+    ),
+    # lexicon order/set matches upstream's own example (kokoro multi-lang needs
+    # us-en + zh; gb-en is an alternative to us-en, not additive). dict/ and the
+    # *-zh.fst rule files are unused optional extras, left out on purpose.
+    "kokoro-multi-lang-v1_0": SherpaOnnxRegistryEntry(
+        tarball_url=f"{_RELEASE_BASE}/kokoro-multi-lang-v1_0.tar.bz2",
+        sha256="c133d26353d776da730870dac7da07dbfc9a5e3bc80cc5e8e83ab6e823be7046",
+        family="kokoro",
+        usecase="tts",
+        files={
+            "model": RegistryFile("model.onnx", 325_630_829),
+            "tokens": RegistryFile(
+                "tokens.txt", 687, "6ebb6bb288f20f3ae8d004d3c2ca27697da27c037d75e81a60e2a6a663f95425"
+            ),
+            "voices": RegistryFile(
+                "voices.bin", 27_678_720, "8a77c0d397026208d22211f37670b5b3b11e03f190756b25a1d24041fced82a9"
+            ),
+        },
+        dirs={
+            "data_dir": RegistryDir("espeak-ng-data", 355),
+        },
+        lexicon=(
+            RegistryFile("lexicon-us-en.txt", 5_956_885),
+            RegistryFile("lexicon-zh.txt", 2_364_621),
+        ),
+        voice_names=(
+            "af_alloy",
+            "af_aoede",
+            "af_bella",
+            "af_heart",
+            "af_jessica",
+            "af_kore",
+            "af_nicole",
+            "af_nova",
+            "af_river",
+            "af_sarah",
+            "af_sky",
+            "am_adam",
+            "am_echo",
+            "am_eric",
+            "am_fenrir",
+            "am_liam",
+            "am_michael",
+            "am_onyx",
+            "am_puck",
+            "am_santa",
+            "bf_alice",
+            "bf_emma",
+            "bf_isabella",
+            "bf_lily",
+            "bm_daniel",
+            "bm_fable",
+            "bm_george",
+            "bm_lewis",
+            "ef_dora",
+            "em_alex",
+            "ff_siwis",
+            "hf_alpha",
+            "hf_beta",
+            "hm_omega",
+            "hm_psi",
+            "if_sara",
+            "im_nicola",
+            "jf_alpha",
+            "jf_gongitsune",
+            "jf_nezumi",
+            "jf_tebukuro",
+            "jm_kumo",
+            "pf_dora",
+            "pm_alex",
+            "pm_santa",
+            "zf_xiaobei",
+            "zf_xiaoni",
+            "zf_xiaoxiao",
+            "zf_xiaoyi",
+            "zm_yunjian",
+            "zm_yunxi",
+            "zm_yunxia",
+            "zm_yunyang",
+        ),
+    ),
+}
+
+
+def registry_names() -> tuple[str, ...]:
+    return tuple(REGISTRY)

--- a/modelship/infer/sherpa_onnx/sherpa_onnx_infer.py
+++ b/modelship/infer/sherpa_onnx/sherpa_onnx_infer.py
@@ -23,8 +23,7 @@ logger = get_logger("infer.sherpa_onnx")
 
 
 class SherpaOnnxInfer(BaseInfer):
-    """In-process sherpa-onnx TTS loader. v1 scope: kokoro family only, CPU/CoreML
-    only (no CUDA wheel wired)."""
+    """In-process sherpa-onnx TTS loader. v1 scope: kokoro family only, CPU/CoreML only."""
 
     def __init__(self, model_config: ModelshipModelConfig):
         super().__init__(model_config)

--- a/modelship/infer/sherpa_onnx/sherpa_onnx_infer.py
+++ b/modelship/infer/sherpa_onnx/sherpa_onnx_infer.py
@@ -50,12 +50,12 @@ class SherpaOnnxInfer(BaseInfer):
             raise ModelDownloadError(f"Failed to resolve sherpa_onnx bundle for '{self.model_config.name}': {e}") from e
 
         cfg = sherpa_onnx.OfflineTtsConfig()
-        for slot, file in entry.files.items():
-            setattr(cfg.model.kokoro, slot, os.path.join(bundle_dir, file.path))
-        for slot, d in entry.dirs.items():
-            setattr(cfg.model.kokoro, slot, os.path.join(bundle_dir, d.path))
+        for slot, rel_path in entry.files.items():
+            setattr(cfg.model.kokoro, slot, os.path.join(bundle_dir, rel_path))
+        for slot, rel_path in entry.dirs.items():
+            setattr(cfg.model.kokoro, slot, os.path.join(bundle_dir, rel_path))
         if entry.lexicon:
-            cfg.model.kokoro.lexicon = ",".join(os.path.join(bundle_dir, f.path) for f in entry.lexicon)
+            cfg.model.kokoro.lexicon = ",".join(os.path.join(bundle_dir, rel_path) for rel_path in entry.lexicon)
         # Never take provider from config: an unsupported/typo'd value silently
         # falls back to CPU inside sherpa's C++ instead of raising.
         cfg.model.provider = "coreml" if platform.system() == "Darwin" else "cpu"

--- a/modelship/infer/sherpa_onnx/sherpa_onnx_infer.py
+++ b/modelship/infer/sherpa_onnx/sherpa_onnx_infer.py
@@ -23,7 +23,8 @@ logger = get_logger("infer.sherpa_onnx")
 
 
 class SherpaOnnxInfer(BaseInfer):
-    """In-process sherpa-onnx TTS loader. v1 scope: kokoro family only, CPU/CoreML only."""
+    """In-process sherpa-onnx TTS loader, generic across `OfflineTtsConfig`
+    families. v1 scope: the registry only curates kokoro, CPU/CoreML only."""
 
     def __init__(self, model_config: ModelshipModelConfig):
         super().__init__(model_config)
@@ -50,12 +51,13 @@ class SherpaOnnxInfer(BaseInfer):
             raise ModelDownloadError(f"Failed to resolve sherpa_onnx bundle for '{self.model_config.name}': {e}") from e
 
         cfg = sherpa_onnx.OfflineTtsConfig()
+        family_cfg = getattr(cfg.model, entry.family)
         for slot, rel_path in entry.files.items():
-            setattr(cfg.model.kokoro, slot, os.path.join(bundle_dir, rel_path))
+            setattr(family_cfg, slot, os.path.join(bundle_dir, rel_path))
         for slot, rel_path in entry.dirs.items():
-            setattr(cfg.model.kokoro, slot, os.path.join(bundle_dir, rel_path))
+            setattr(family_cfg, slot, os.path.join(bundle_dir, rel_path))
         if entry.lexicon:
-            cfg.model.kokoro.lexicon = ",".join(os.path.join(bundle_dir, rel_path) for rel_path in entry.lexicon)
+            family_cfg.lexicon = ",".join(os.path.join(bundle_dir, rel_path) for rel_path in entry.lexicon)
         # Never take provider from config: an unsupported/typo'd value silently
         # falls back to CPU inside sherpa's C++ instead of raising.
         cfg.model.provider = "coreml" if platform.system() == "Darwin" else "cpu"
@@ -118,7 +120,7 @@ class SherpaOnnxInfer(BaseInfer):
                 yield event
 
     async def _generate_chunks(self, text: str, sid: int, speed: float) -> AsyncGenerator[tuple[bytes, int], None]:
-        """callback fires once per sentence group (kokoro isn't autoregressive).
+        """callback fires once per sentence group (offline models aren't autoregressive).
         Return 0 to abort, nonzero to continue — inverted from the bundled docstring."""
         loop = asyncio.get_running_loop()
         queue: asyncio.Queue[Any] = asyncio.Queue()

--- a/modelship/infer/sherpa_onnx/sherpa_onnx_infer.py
+++ b/modelship/infer/sherpa_onnx/sherpa_onnx_infer.py
@@ -1,0 +1,154 @@
+import asyncio
+import contextlib
+import os
+import platform
+import threading
+from collections.abc import AsyncGenerator
+from typing import Any
+
+import numpy as np
+
+from modelship.infer.base_infer import BaseInfer, ClientDisconnectedError
+from modelship.infer.infer_config import ModelshipModelConfig, RawRequestProxy
+from modelship.infer.model_resolver import ModelDownloadError
+from modelship.infer.sherpa_onnx.bundle import resolve_bundle_dir
+from modelship.infer.sherpa_onnx.registry import SherpaOnnxRegistryEntry
+from modelship.logging import get_logger
+from modelship.openai.protocol import ErrorResponse, RawSpeechResponse, SpeechRequest, create_error_response
+from modelship.openai.utils.audio import sse_stream_speech
+from modelship.utils import base_request_id
+from modelship.utils.audio import to_pcm16, to_wav
+
+logger = get_logger("infer.sherpa_onnx")
+
+
+class SherpaOnnxInfer(BaseInfer):
+    """In-process sherpa-onnx TTS loader. v1 scope: kokoro family only, CPU/CoreML
+    only (no CUDA wheel wired)."""
+
+    def __init__(self, model_config: ModelshipModelConfig):
+        super().__init__(model_config)
+        self.tts: Any = None
+        self.entry: SherpaOnnxRegistryEntry | None = None
+
+    def shutdown(self) -> None:
+        self.tts = None
+
+    def __del__(self):
+        self.shutdown()
+
+    async def start(self) -> None:
+        loop = asyncio.get_running_loop()
+        self.tts, self.entry = await loop.run_in_executor(None, self._load)
+
+    def _load(self) -> tuple[Any, SherpaOnnxRegistryEntry]:
+        import sherpa_onnx
+
+        assert self.model_config.model is not None
+        try:
+            bundle_dir, entry = resolve_bundle_dir(self.model_config.model)
+        except Exception as e:
+            raise ModelDownloadError(f"Failed to resolve sherpa_onnx bundle for '{self.model_config.name}': {e}") from e
+
+        cfg = sherpa_onnx.OfflineTtsConfig()
+        for slot, file in entry.files.items():
+            setattr(cfg.model.kokoro, slot, os.path.join(bundle_dir, file.path))
+        for slot, d in entry.dirs.items():
+            setattr(cfg.model.kokoro, slot, os.path.join(bundle_dir, d.path))
+        if entry.lexicon:
+            cfg.model.kokoro.lexicon = ",".join(os.path.join(bundle_dir, f.path) for f in entry.lexicon)
+        # Never take provider from config: an unsupported/typo'd value silently
+        # falls back to CPU inside sherpa's C++ instead of raising.
+        cfg.model.provider = "coreml" if platform.system() == "Darwin" else "cpu"
+        cfg.model.num_threads = max(1, round(self.model_config.num_cpus))
+
+        logger.info("loading sherpa_onnx model %r for '%s'", self.model_config.model, self.model_config.name)
+        tts = sherpa_onnx.OfflineTts(cfg)
+        if tts.num_speakers != len(entry.voice_names):
+            raise ValueError(
+                f"sherpa_onnx deployment '{self.model_config.name}': bundle reports {tts.num_speakers} speakers, "
+                f"registry entry {self.model_config.model!r} expects {len(entry.voice_names)}. The bundle on disk "
+                f"doesn't match this registry entry."
+            )
+        return tts, entry
+
+    async def warmup(self) -> None:
+        pass
+
+    def _resolve_sid(self, voice: str) -> int | None:
+        assert self.entry is not None
+        if voice in self.entry.voice_names:
+            return self.entry.voice_names.index(voice)
+        if voice.isdigit():
+            sid = int(voice)
+            if 0 <= sid < len(self.entry.voice_names):
+                return sid
+        return None
+
+    async def create_speech(
+        self, request: SpeechRequest, raw_request: RawRequestProxy
+    ) -> ErrorResponse | RawSpeechResponse | AsyncGenerator[str, None]:
+        request_id = f"tts-{base_request_id(raw_request)}"
+        assert self.entry is not None
+        sid = self._resolve_sid(request.voice)
+        if sid is None:
+            return create_error_response(
+                f"unknown voice {request.voice!r}. Valid voices: {', '.join(self.entry.voice_names)}"
+            )
+
+        if "stream_format" in request.model_fields_set and request.stream_format == "sse":
+            logger.info("%s: voice=%s sid=%d stream=sse", request_id, request.voice, sid)
+            return self.run_cancellable_stream(self._stream(request.input, sid, request.speed), raw_request)
+
+        logger.info("%s: voice=%s sid=%d", request_id, request.voice, sid)
+        try:
+            wav = await self.run_cancellable(self._generate(request.input, sid, request.speed), raw_request)
+        except ClientDisconnectedError:
+            logger.info("%s aborted: client disconnected", request_id)
+            return create_error_response("Client disconnected")
+        return RawSpeechResponse(audio=wav)
+
+    async def _generate(self, text: str, sid: int, speed: float) -> bytes:
+        result = await asyncio.to_thread(self.tts.generate, text, sid, speed)
+        samples = np.asarray(result.samples, dtype=np.float32)
+        return to_wav(samples, result.sample_rate)
+
+    async def _stream(self, text: str, sid: int, speed: float) -> AsyncGenerator[str, None]:
+        async with contextlib.aclosing(self._generate_chunks(text, sid, speed)) as chunks:
+            async for event in sse_stream_speech(chunks):
+                yield event
+
+    async def _generate_chunks(self, text: str, sid: int, speed: float) -> AsyncGenerator[tuple[bytes, int], None]:
+        """callback fires once per sentence group (kokoro isn't autoregressive).
+        Return 0 to abort, nonzero to continue — inverted from the bundled docstring."""
+        loop = asyncio.get_running_loop()
+        queue: asyncio.Queue[Any] = asyncio.Queue()
+        abort_event = threading.Event()
+        sample_rate = self.tts.sample_rate
+        _done = object()
+
+        def on_chunk(samples: Any, _progress: float) -> int:
+            pcm = to_pcm16(np.asarray(samples, dtype=np.float32))
+            loop.call_soon_threadsafe(queue.put_nowait, pcm)
+            return 0 if abort_event.is_set() else 1
+
+        def run() -> None:
+            try:
+                self.tts.generate(text, sid, speed, callback=on_chunk)
+            except BaseException as exc:
+                loop.call_soon_threadsafe(queue.put_nowait, exc)
+            finally:
+                loop.call_soon_threadsafe(queue.put_nowait, _done)
+
+        worker = asyncio.create_task(asyncio.to_thread(run))
+        try:
+            while True:
+                item = await queue.get()
+                if item is _done:
+                    break
+                if isinstance(item, BaseException):
+                    raise item
+                yield item, sample_rate
+        finally:
+            abort_event.set()
+            await worker

--- a/modelship/launcher.py
+++ b/modelship/launcher.py
@@ -12,7 +12,7 @@ import stat
 import sys
 
 from modelship.deploy.capabilities import LOADER_MODULES
-from modelship.utils import download, extract_tar, verify_sha256
+from modelship.utils import fetch_and_extract_archive
 from modelship.utils.accelerator import detect_accelerator
 from modelship.utils.cache import resolve_cache_root
 
@@ -117,13 +117,16 @@ def _resolve_llama_server_bin() -> str:
     extract_dir = os.path.join(tag_dir, "extracted")
     wrapper_path = os.path.join(tag_dir, "llama-server.sh")
 
-    os.makedirs(tag_dir, exist_ok=True)
-    download(_LLAMA_CPP_METAL_ASSET_URL, archive_path)
-    verify_sha256(archive_path, _LLAMA_CPP_METAL_SHA256)
-
-    if not os.path.isfile(os.path.join(extract_dir, "llama-server")):
-        extract_tar(archive_path, extract_dir)
-        binary = os.path.join(extract_dir, "llama-server")
+    binary = os.path.join(extract_dir, "llama-server")
+    if not os.path.isfile(binary):
+        fetch_and_extract_archive(
+            _LLAMA_CPP_METAL_ASSET_URL,
+            _LLAMA_CPP_METAL_SHA256,
+            archive_path,
+            extract_dir,
+            flatten=True,
+            keep_archive=True,
+        )
         os.chmod(binary, os.stat(binary).st_mode | stat.S_IEXEC)
 
     _write_wrapper(wrapper_path, extract_dir)

--- a/modelship/launcher.py
+++ b/modelship/launcher.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 import importlib.util
 import os
 import platform
+import shutil
 import stat
 import sys
 
@@ -119,6 +120,8 @@ def _resolve_llama_server_bin() -> str:
 
     binary = os.path.join(extract_dir, "llama-server")
     if not os.path.isfile(binary):
+        if os.path.isdir(extract_dir):
+            shutil.rmtree(extract_dir, ignore_errors=True)
         fetch_and_extract_archive(
             _LLAMA_CPP_METAL_ASSET_URL,
             _LLAMA_CPP_METAL_SHA256,

--- a/modelship/openai/utils/audio.py
+++ b/modelship/openai/utils/audio.py
@@ -1,0 +1,16 @@
+import base64
+from collections.abc import AsyncGenerator
+
+from modelship.openai.protocol import SpeechResponse
+
+
+async def sse_stream_speech(chunks: AsyncGenerator[tuple[bytes, int], None]) -> AsyncGenerator[str, None]:
+    """Frame a stream of `(pcm16_bytes, sample_rate)` chunks as
+    `speech.audio.delta`/`speech.audio.done` SSE events. Shared by every
+    loader/plugin that streams TTS output."""
+    async for pcm, _sample_rate in chunks:
+        audio_b64 = base64.b64encode(pcm).decode("ascii")
+        event = SpeechResponse(type="speech.audio.delta", audio=audio_b64)
+        yield f"data: {event.model_dump_json()}\n\n"
+    done = SpeechResponse(type="speech.audio.done")
+    yield f"data: {done.model_dump_json()}\n\n"

--- a/modelship/utils/__init__.py
+++ b/modelship/utils/__init__.py
@@ -55,6 +55,12 @@ def rand_suffix(length: int = 5) -> str:
     return "".join(random.choices(_RAND_CHARS, k=length))
 
 
+def is_pathy(s: str) -> bool:
+    """A local-path-shaped string (`/...`, `./...`, `~...`), as opposed to an
+    HF repo id, registry name, or other bare identifier."""
+    return s.startswith(("/", "./", "~"))
+
+
 def download(url: str, file_path: str, overwrite: bool = False):
     """Download ``url`` to ``file_path``, skipping if it already exists.
 

--- a/modelship/utils/__init__.py
+++ b/modelship/utils/__init__.py
@@ -1,8 +1,10 @@
+import contextlib
 import hashlib
 import logging
 import os
 import random
 import re
+import shutil
 import string
 import tarfile
 from collections.abc import Iterable
@@ -87,18 +89,69 @@ def verify_sha256(path: str, expected: str) -> None:
         raise ValueError(f"{path} failed sha256 verification: expected {expected}, got {actual}")
 
 
-def extract_tar(archive_path: str, extract_dir: str) -> None:
-    """Extract every member of a .tar.gz into extract_dir, flattened to its
-    basename — drops whatever containing directory the archive was packaged
-    with, so callers don't need to know that layout up front."""
-    os.makedirs(extract_dir, exist_ok=True)
-    with tarfile.open(archive_path) as tar:
-        for member in tar.getmembers():
-            name = os.path.basename(member.name)
-            if not name:
-                continue
-            member.name = name
-            tar.extract(member, path=extract_dir, filter="data")
+def fetch_and_extract_archive(
+    url: str,
+    sha256: str,
+    archive_path: str,
+    extract_dir: str,
+    *,
+    flatten: bool = False,
+    keep_archive: bool = False,
+) -> None:
+    """Download `url` to `archive_path`, verify its sha256, and extract into
+    `extract_dir`.
+
+    Extraction happens in a private tmp dir first and is moved into place with
+    `os.replace`, so no reader ever sees a partial extraction and concurrent
+    callers (e.g. multiple replicas on one node) can't corrupt each other — a
+    losing replica's `os.replace` onto an already-populated `extract_dir` is
+    swallowed. A sha256 mismatch deletes the archive so a retry doesn't
+    re-verify the same corrupt bytes.
+
+    `flatten=True` extracts every member to its basename directly under
+    `extract_dir`, discarding the archive's own directory structure.
+    `flatten=False` (default) preserves it, stripping one leading path
+    component when every member shares a single top-level directory (the
+    common release-tarball convention) so `extract_dir` ends up holding that
+    directory's contents directly.
+    """
+    os.makedirs(os.path.dirname(archive_path) or ".", exist_ok=True)
+    os.makedirs(os.path.dirname(extract_dir) or ".", exist_ok=True)
+
+    download(url, archive_path)
+    try:
+        verify_sha256(archive_path, sha256)
+    except ValueError:
+        os.remove(archive_path)  # don't let a retry re-verify the same corrupt bytes
+        raise
+
+    tmp_dir = f"{extract_dir}.{random_uuid()}.tmp"
+    os.makedirs(tmp_dir, exist_ok=True)
+    try:
+        with tarfile.open(archive_path) as tar:
+            if flatten:
+                for member in tar.getmembers():
+                    name = os.path.basename(member.name)
+                    if not name:
+                        continue
+                    member.name = name
+                    tar.extract(member, path=tmp_dir, filter="data")
+            else:
+                tar.extractall(tmp_dir, filter="data")
+
+        root = tmp_dir
+        if not flatten:
+            entries = os.listdir(tmp_dir)
+            if len(entries) == 1 and os.path.isdir(os.path.join(tmp_dir, entries[0])):
+                root = os.path.join(tmp_dir, entries[0])
+
+        with contextlib.suppress(OSError):  # a concurrent extractor already won
+            os.replace(root, extract_dir)
+    finally:
+        shutil.rmtree(tmp_dir, ignore_errors=True)
+
+    if not keep_archive:
+        os.remove(archive_path)
 
 
 def cache_dir() -> str:

--- a/modelship/utils/__init__.py
+++ b/modelship/utils/__init__.py
@@ -99,22 +99,13 @@ def fetch_and_extract_archive(
     keep_archive: bool = False,
 ) -> None:
     """Download `url` to `archive_path`, verify its sha256, and extract into
-    `extract_dir`.
+    `extract_dir` via a private tmp dir + atomic `os.replace` (safe against
+    concurrent extractors and partial reads). A sha256 mismatch deletes the
+    archive so a retry doesn't re-verify the same bytes.
 
-    Extraction happens in a private tmp dir first and is moved into place with
-    `os.replace`, so no reader ever sees a partial extraction and concurrent
-    callers (e.g. multiple replicas on one node) can't corrupt each other — a
-    losing replica's `os.replace` onto an already-populated `extract_dir` is
-    swallowed. A sha256 mismatch deletes the archive so a retry doesn't
-    re-verify the same corrupt bytes.
-
-    `flatten=True` extracts every member to its basename directly under
-    `extract_dir`, discarding the archive's own directory structure.
-    `flatten=False` (default) preserves it, stripping one leading path
-    component when every member shares a single top-level directory (the
-    common release-tarball convention) so `extract_dir` ends up holding that
-    directory's contents directly.
-    """
+    `flatten=True` extracts every member to its basename; otherwise a single
+    shared top-level directory is stripped so `extract_dir` holds its
+    contents directly."""
     os.makedirs(os.path.dirname(archive_path) or ".", exist_ok=True)
     os.makedirs(os.path.dirname(extract_dir) or ".", exist_ok=True)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,6 +48,8 @@ metal = [
     "onnxruntime>=1.28.0",
     "stable-diffusion-cpp-python>=0.4.7",
     "pywhispercpp>=1.5.0",
+    "sherpa-onnx>=1.13.4",
+    "sherpa-onnx-core==1.13.4",
 ]
 cuda = [
     "torch>=2.10.0",
@@ -66,6 +68,8 @@ cuda = [
     "scipy>=1.16.1",
     "soundfile>=0.13.0",
     "pywhispercpp>=1.5.0",
+    "sherpa-onnx>=1.13.4",
+    "sherpa-onnx-core==1.13.4",
 ]
 cpu = [
     "torch>=2.10.0",
@@ -80,6 +84,8 @@ cpu = [
     "scipy>=1.16.1",
     "soundfile>=0.13.0",
     "pywhispercpp>=1.5.0",
+    "sherpa-onnx>=1.13.4",
+    "sherpa-onnx-core==1.13.4",
 ]
 kokoroonnx = ["kokoroonnx"]
 orpheus = ["orpheus"]
@@ -197,6 +203,7 @@ markers = [
     "diffusers: integration tests that exercise the diffusers loader",
     "stable_diffusion_cpp: integration tests that exercise the stable_diffusion_cpp loader",
     "whispercpp: integration tests that exercise the whispercpp loader",
+    "sherpa_onnx: integration tests that exercise the sherpa_onnx loader",
     "autoscaling: integration test that exercises Ray Serve autoscaling (scale out/in under load)",
     "gateway_ha: integration test that exercises multi-replica gateway routing consistency",
     "blue_green: integration test that exercises the blue_green replace-strategy cutover",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -192,12 +192,10 @@ MODEL_CONFIGS: dict[str, dict] = {
     },
     "tts-model": {
         "name": "tts-model",
-        "model": "hexgrad/Kokoro-82M",
+        "model": "kokoro-en-v0_19",
         "usecase": "tts",
-        "loader": "custom",
-        "plugin": "kokoroonnx",
+        "loader": "sherpa_onnx",
         "num_cpus": 1,
-        "plugin_config": {"onnx_provider": "CPUExecutionProvider"},
     },
     "image-model": {
         "name": "image-model",

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -392,9 +392,16 @@ class TestModelshipModelConfig:
     def test_all_loaders_valid(self):
         image_only = (ModelLoader.diffusers, ModelLoader.stable_diffusion_cpp)
         for loader in ModelLoader:
-            # diffusers / stable_diffusion_cpp are image-only; the rest support generate.
-            usecase = ModelUsecase.image if loader in image_only else ModelUsecase.generate
-            kwargs = {"name": "test", "model": "some-model", "usecase": usecase}
+            # diffusers / stable_diffusion_cpp are image-only; sherpa_onnx is tts-only
+            # (and needs a registry name, not an arbitrary model string); the rest
+            # support generate.
+            if loader is ModelLoader.sherpa_onnx:
+                usecase, model = ModelUsecase.tts, "kokoro-en-v0_19"
+            elif loader in image_only:
+                usecase, model = ModelUsecase.image, "some-model"
+            else:
+                usecase, model = ModelUsecase.generate, "some-model"
+            kwargs = {"name": "test", "model": model, "usecase": usecase}
             if loader == ModelLoader.custom:
                 kwargs["plugin"] = "test-plugin"
             config = ModelshipModelConfig(loader=loader, **kwargs)

--- a/tests/test_launcher.py
+++ b/tests/test_launcher.py
@@ -137,7 +137,7 @@ class TestResolveLlamaServerBin:
             patch.object(launcher.platform, "system", return_value="Darwin"),
             patch.object(launcher, "resolve_cache_root", return_value=cache_root),
             patch.object(launcher, "_LLAMA_CPP_METAL_SHA256", digest),
-            patch.object(launcher, "download", side_effect=fake_download) as mock_download,
+            patch("modelship.utils.download", side_effect=fake_download) as mock_download,
         ):
             wrapper = launcher._resolve_llama_server_bin()
 
@@ -160,7 +160,7 @@ class TestResolveLlamaServerBin:
             patch.object(launcher.platform, "system", return_value="Darwin"),
             patch.object(launcher, "resolve_cache_root", return_value=cache_root),
             patch.object(launcher, "_LLAMA_CPP_METAL_SHA256", "0" * 64),
-            patch.object(launcher, "download", side_effect=fake_download),
+            patch("modelship.utils.download", side_effect=fake_download),
             pytest.raises(ValueError, match="sha256 verification"),
         ):
             launcher._resolve_llama_server_bin()

--- a/tests/test_launcher.py
+++ b/tests/test_launcher.py
@@ -147,6 +147,32 @@ class TestResolveLlamaServerBin:
         extracted_bin = os.path.join(os.path.dirname(wrapper), "extracted", "llama-server")
         assert os.path.isfile(extracted_bin)
 
+    def test_stale_extract_dir_is_cleared_and_refetched(self, tmp_path):
+        archive, digest = _make_archive(tmp_path)
+        cache_root = str(tmp_path / "cache")
+
+        def fake_download(url, dest):
+            os.makedirs(os.path.dirname(dest), exist_ok=True)
+            with open(archive, "rb") as src, open(dest, "wb") as dst:
+                dst.write(src.read())
+
+        extract_dir = os.path.join(cache_root, "llama.cpp", launcher._LLAMA_CPP_TAG, "extracted")
+        os.makedirs(extract_dir)
+        with open(os.path.join(extract_dir, "leftover_junk.txt"), "wb") as f:
+            f.write(b"junk")
+
+        with (
+            patch.object(launcher.platform, "system", return_value="Darwin"),
+            patch.object(launcher, "resolve_cache_root", return_value=cache_root),
+            patch.object(launcher, "_LLAMA_CPP_METAL_SHA256", digest),
+            patch("modelship.utils.download", side_effect=fake_download),
+        ):
+            wrapper = launcher._resolve_llama_server_bin()
+
+        assert os.path.isfile(wrapper)
+        assert os.path.isfile(os.path.join(extract_dir, "llama-server"))
+        assert not os.path.exists(os.path.join(extract_dir, "leftover_junk.txt"))
+
     def test_digest_mismatch_raises(self, tmp_path):
         archive, _real_digest = _make_archive(tmp_path)
         cache_root = str(tmp_path / "cache")

--- a/tests/test_sherpa_onnx_bundle.py
+++ b/tests/test_sherpa_onnx_bundle.py
@@ -1,0 +1,71 @@
+"""resolve_bundle_dir()'s cache-hit and re-fetch-on-invalid-cache paths."""
+
+import hashlib
+import os
+import tarfile
+from unittest.mock import patch
+
+from modelship.infer.sherpa_onnx import bundle
+from modelship.infer.sherpa_onnx.registry import REGISTRY
+
+_ENTRY = REGISTRY["kokoro-en-v0_19"]
+
+
+def _make_valid_archive(tmp_path) -> tuple[str, str]:
+    src_dir = tmp_path / "src" / "kokoro-en-v0_19"
+    src_dir.mkdir(parents=True)
+    (src_dir / "model.onnx").write_bytes(b"m")
+    (src_dir / "tokens.txt").write_bytes(b"t")
+    (src_dir / "voices.bin").write_bytes(b"v")
+    data_dir = src_dir / "espeak-ng-data"
+    data_dir.mkdir()
+    (data_dir / "a").write_bytes(b"1")
+
+    archive = tmp_path / "src_archive.tar.bz2"
+    with tarfile.open(archive, "w:bz2") as tar:
+        tar.add(src_dir, arcname="kokoro-en-v0_19")
+    digest = hashlib.sha256(archive.read_bytes()).hexdigest()
+    return str(archive), digest
+
+
+def _fake_download(src_archive: str):
+    def fake(url, dest):
+        with open(src_archive, "rb") as f, open(dest, "wb") as out:
+            out.write(f.read())
+
+    return fake
+
+
+def test_fetches_when_no_cached_bundle(tmp_path, monkeypatch):
+    src_archive, digest = _make_valid_archive(tmp_path)
+    monkeypatch.setattr(bundle, "cache_dir", lambda: str(tmp_path / "cache"))
+    entry = _ENTRY._replace(sha256=digest)
+
+    with (
+        patch.dict(bundle.REGISTRY, {"kokoro-en-v0_19": entry}),
+        patch("modelship.utils.download", side_effect=_fake_download(src_archive)),
+    ):
+        bundle_dir, resolved_entry = bundle.resolve_bundle_dir("kokoro-en-v0_19")
+
+    assert resolved_entry is entry
+    assert os.path.isfile(os.path.join(bundle_dir, "model.onnx"))
+
+
+def test_stale_cached_bundle_is_cleared_and_refetched(tmp_path, monkeypatch):
+    src_archive, digest = _make_valid_archive(tmp_path)
+    cache_root = tmp_path / "cache"
+    monkeypatch.setattr(bundle, "cache_dir", lambda: str(cache_root))
+    entry = _ENTRY._replace(sha256=digest)
+
+    stale_dir = cache_root / "sherpa_onnx" / "kokoro-en-v0_19"
+    stale_dir.mkdir(parents=True)
+    (stale_dir / "leftover_junk.txt").write_bytes(b"junk")
+
+    with (
+        patch.dict(bundle.REGISTRY, {"kokoro-en-v0_19": entry}),
+        patch("modelship.utils.download", side_effect=_fake_download(src_archive)),
+    ):
+        bundle_dir, _resolved_entry = bundle.resolve_bundle_dir("kokoro-en-v0_19")
+
+    assert os.path.isfile(os.path.join(bundle_dir, "model.onnx"))
+    assert not os.path.exists(os.path.join(bundle_dir, "leftover_junk.txt"))

--- a/tests/test_sherpa_onnx_bundle.py
+++ b/tests/test_sherpa_onnx_bundle.py
@@ -5,6 +5,8 @@ import os
 import tarfile
 from unittest.mock import patch
 
+import pytest
+
 from modelship.infer.sherpa_onnx import bundle
 from modelship.infer.sherpa_onnx.registry import REGISTRY
 
@@ -69,3 +71,19 @@ def test_stale_cached_bundle_is_cleared_and_refetched(tmp_path, monkeypatch):
 
     assert os.path.isfile(os.path.join(bundle_dir, "model.onnx"))
     assert not os.path.exists(os.path.join(bundle_dir, "leftover_junk.txt"))
+
+
+def test_concurrent_fetches_use_distinct_archive_paths(tmp_path, monkeypatch):
+    monkeypatch.setattr(bundle, "cache_dir", lambda: str(tmp_path / "cache"))
+    archive_paths = []
+
+    def fake_fetch(url, sha256, archive_path, extract_dir):
+        archive_paths.append(archive_path)
+
+    with patch.object(bundle, "fetch_and_extract_archive", side_effect=fake_fetch):
+        for _ in range(2):
+            with pytest.raises(ValueError, match="not found"):
+                bundle.resolve_bundle_dir("kokoro-en-v0_19")
+
+    assert len(archive_paths) == 2
+    assert archive_paths[0] != archive_paths[1]

--- a/tests/test_sherpa_onnx_bundle.py
+++ b/tests/test_sherpa_onnx_bundle.py
@@ -1,11 +1,12 @@
-"""resolve_bundle_dir()'s cache-hit and re-fetch-on-invalid-cache paths."""
+"""resolve_bundle_dir()'s cache-hit, re-fetch-on-invalid-cache, and
+concurrent-caller single-flight paths."""
 
 import hashlib
 import os
 import tarfile
+import threading
+import time
 from unittest.mock import patch
-
-import pytest
 
 from modelship.infer.sherpa_onnx import bundle
 from modelship.infer.sherpa_onnx.registry import REGISTRY
@@ -73,17 +74,53 @@ def test_stale_cached_bundle_is_cleared_and_refetched(tmp_path, monkeypatch):
     assert not os.path.exists(os.path.join(bundle_dir, "leftover_junk.txt"))
 
 
-def test_concurrent_fetches_use_distinct_archive_paths(tmp_path, monkeypatch):
-    monkeypatch.setattr(bundle, "cache_dir", lambda: str(tmp_path / "cache"))
-    archive_paths = []
+def test_concurrent_callers_only_fetch_once(tmp_path, monkeypatch):
+    cache_root = tmp_path / "cache"
+    monkeypatch.setattr(bundle, "cache_dir", lambda: str(cache_root))
+    entry = _ENTRY
+
+    call_count = 0
+    count_lock = threading.Lock()
+    start_barrier = threading.Barrier(3)
 
     def fake_fetch(url, sha256, archive_path, extract_dir):
-        archive_paths.append(archive_path)
+        nonlocal call_count
+        with count_lock:
+            call_count += 1
+        time.sleep(0.05)  # widen the window so other threads reach the same branch
+        _write_valid_bundle_dir(extract_dir)
 
-    with patch.object(bundle, "fetch_and_extract_archive", side_effect=fake_fetch):
-        for _ in range(2):
-            with pytest.raises(ValueError, match="not found"):
-                bundle.resolve_bundle_dir("kokoro-en-v0_19")
+    results: list[tuple[str, object]] = []
 
-    assert len(archive_paths) == 2
-    assert archive_paths[0] != archive_paths[1]
+    def worker():
+        start_barrier.wait()
+        results.append(bundle.resolve_bundle_dir("kokoro-en-v0_19"))
+
+    with (
+        patch.dict(bundle.REGISTRY, {"kokoro-en-v0_19": entry}),
+        patch.object(bundle, "fetch_and_extract_archive", side_effect=fake_fetch),
+    ):
+        threads = [threading.Thread(target=worker) for _ in range(3)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+    assert call_count == 1
+    assert len(results) == 3
+    for bundle_dir, _resolved_entry in results:
+        assert os.path.isfile(os.path.join(bundle_dir, "model.onnx"))
+
+
+def _write_valid_bundle_dir(root: str) -> None:
+    os.makedirs(root, exist_ok=True)
+    with open(os.path.join(root, "model.onnx"), "wb") as f:
+        f.write(b"m")
+    with open(os.path.join(root, "tokens.txt"), "wb") as f:
+        f.write(b"t")
+    with open(os.path.join(root, "voices.bin"), "wb") as f:
+        f.write(b"v")
+    data_dir = os.path.join(root, "espeak-ng-data")
+    os.makedirs(data_dir, exist_ok=True)
+    with open(os.path.join(data_dir, "a"), "wb") as f:
+        f.write(b"1")

--- a/tests/test_sherpa_onnx_infer.py
+++ b/tests/test_sherpa_onnx_infer.py
@@ -1,0 +1,241 @@
+"""Unit tests for the sherpa_onnx loader: voice->sid resolution, provider
+derivation, config-builder setattr routing, num_speakers mismatch, and
+streaming — all against a stubbed `sherpa_onnx` module. Nothing here
+downloads a bundle."""
+
+import sys
+import time
+import types
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import numpy as np
+import pytest
+
+from modelship.infer.infer_config import ModelLoader, ModelshipModelConfig, ModelUsecase, RawRequestProxy
+from modelship.infer.sherpa_onnx.registry import REGISTRY, SherpaOnnxRegistryEntry
+from modelship.infer.sherpa_onnx.sherpa_onnx_infer import SherpaOnnxInfer
+from modelship.openai.protocol import ErrorResponse, RawSpeechResponse, SpeechRequest
+
+_ENTRY: SherpaOnnxRegistryEntry = REGISTRY["kokoro-en-v0_19"]
+
+
+class _FakeKokoroConfig:
+    def __init__(self):
+        self.model = ""
+        self.voices = ""
+        self.tokens = ""
+        self.data_dir = ""
+        self.lexicon = ""
+
+
+class _FakeModelConfig:
+    def __init__(self):
+        self.kokoro = _FakeKokoroConfig()
+        self.provider = ""
+        self.num_threads = 0
+
+
+class _FakeTtsConfig:
+    def __init__(self):
+        self.model = _FakeModelConfig()
+
+
+class _FakeOfflineTts:
+    """`chunks`, if given, is emitted one per `callback=` call, gated on the
+    previous call's return value (0 aborts)."""
+
+    def __init__(self, cfg, num_speakers, chunks: list[np.ndarray] | None = None):
+        self.cfg = cfg
+        self.num_speakers = num_speakers
+        self.sample_rate = 24000
+        self.generate_calls: list[tuple] = []
+        self.chunks = chunks or []
+        self.aborted_early = False
+
+    def generate(self, text, sid=0, speed=1.0, callback=None):
+        self.generate_calls.append((text, sid, speed))
+        if callback is None:
+            return SimpleNamespace(samples=[0.0, 0.1, -0.1], sample_rate=self.sample_rate)
+        for i, chunk in enumerate(self.chunks):
+            if not callback(chunk, (i + 1) / len(self.chunks)):
+                self.aborted_early = True
+                break
+            time.sleep(0.05)  # gives the consumer a window to aclose() mid-loop
+        return SimpleNamespace(samples=[], sample_rate=self.sample_rate)
+
+
+def _fake_sherpa_onnx_module(num_speakers: int) -> types.ModuleType:
+    mod = types.ModuleType("sherpa_onnx")
+    mod.OfflineTtsConfig = _FakeTtsConfig
+    mod.OfflineTts = lambda cfg: _FakeOfflineTts(cfg, num_speakers)
+    return mod
+
+
+def _config(**overrides) -> ModelshipModelConfig:
+    defaults = {
+        "name": "tts",
+        "model": "kokoro-en-v0_19",
+        "usecase": ModelUsecase.tts,
+        "loader": ModelLoader.sherpa_onnx,
+        "num_cpus": 2,
+    }
+    return ModelshipModelConfig(**{**defaults, **overrides})
+
+
+def _infer(entry: SherpaOnnxRegistryEntry = _ENTRY, tts: _FakeOfflineTts | None = None) -> SherpaOnnxInfer:
+    infer = SherpaOnnxInfer(_config())
+    infer.entry = entry
+    infer.tts = tts or _FakeOfflineTts(_FakeTtsConfig(), num_speakers=len(entry.voice_names))
+    return infer
+
+
+class TestResolveSid:
+    def test_known_voice_name(self):
+        infer = _infer()
+        assert infer._resolve_sid("af_bella") == _ENTRY.voice_names.index("af_bella")
+
+    def test_numeric_sid_in_range(self):
+        infer = _infer()
+        assert infer._resolve_sid("3") == 3
+
+    def test_numeric_sid_out_of_range(self):
+        infer = _infer()
+        assert infer._resolve_sid(str(len(_ENTRY.voice_names))) is None
+
+    def test_unknown_name(self):
+        infer = _infer()
+        assert infer._resolve_sid("not_a_voice") is None
+
+
+class TestLoad:
+    def test_provider_and_threads_and_path_routing(self, monkeypatch):
+        monkeypatch.setitem(sys.modules, "sherpa_onnx", _fake_sherpa_onnx_module(len(_ENTRY.voice_names)))
+        infer = SherpaOnnxInfer(_config(num_cpus=3))
+        with (
+            patch(
+                "modelship.infer.sherpa_onnx.sherpa_onnx_infer.resolve_bundle_dir",
+                return_value=("/bundle", _ENTRY),
+            ),
+            patch("modelship.infer.sherpa_onnx.sherpa_onnx_infer.platform.system", return_value="Linux"),
+        ):
+            tts, entry = infer._load()
+        assert entry is _ENTRY
+        assert tts.cfg.model.provider == "cpu"
+        assert tts.cfg.model.num_threads == 3
+        assert tts.cfg.model.kokoro.model == "/bundle/model.onnx"
+        assert tts.cfg.model.kokoro.voices == "/bundle/voices.bin"
+        assert tts.cfg.model.kokoro.tokens == "/bundle/tokens.txt"
+        assert tts.cfg.model.kokoro.data_dir == "/bundle/espeak-ng-data"
+
+    def test_darwin_uses_coreml(self, monkeypatch):
+        monkeypatch.setitem(sys.modules, "sherpa_onnx", _fake_sherpa_onnx_module(len(_ENTRY.voice_names)))
+        infer = SherpaOnnxInfer(_config())
+        with (
+            patch(
+                "modelship.infer.sherpa_onnx.sherpa_onnx_infer.resolve_bundle_dir",
+                return_value=("/bundle", _ENTRY),
+            ),
+            patch("modelship.infer.sherpa_onnx.sherpa_onnx_infer.platform.system", return_value="Darwin"),
+        ):
+            tts, _entry = infer._load()
+        assert tts.cfg.model.provider == "coreml"
+
+    def test_lexicon_joined_with_commas(self, monkeypatch):
+        entry = REGISTRY["kokoro-multi-lang-v1_0"]
+        monkeypatch.setitem(sys.modules, "sherpa_onnx", _fake_sherpa_onnx_module(len(entry.voice_names)))
+        infer = SherpaOnnxInfer(_config(model="kokoro-multi-lang-v1_0"))
+        with (
+            patch("modelship.infer.sherpa_onnx.sherpa_onnx_infer.resolve_bundle_dir", return_value=("/bundle", entry)),
+            patch("modelship.infer.sherpa_onnx.sherpa_onnx_infer.platform.system", return_value="Linux"),
+        ):
+            tts, _entry2 = infer._load()
+        assert tts.cfg.model.kokoro.lexicon == "/bundle/lexicon-us-en.txt,/bundle/lexicon-zh.txt"
+
+    def test_num_speakers_mismatch_raises(self, monkeypatch):
+        monkeypatch.setitem(sys.modules, "sherpa_onnx", _fake_sherpa_onnx_module(num_speakers=999))
+        infer = SherpaOnnxInfer(_config())
+        with (
+            patch(
+                "modelship.infer.sherpa_onnx.sherpa_onnx_infer.resolve_bundle_dir",
+                return_value=("/bundle", _ENTRY),
+            ),
+            patch("modelship.infer.sherpa_onnx.sherpa_onnx_infer.platform.system", return_value="Linux"),
+            pytest.raises(ValueError, match="999"),
+        ):
+            infer._load()
+
+    def test_bundle_resolution_failure_is_a_download_error(self, monkeypatch):
+        from modelship.infer.model_resolver import ModelDownloadError
+
+        monkeypatch.setitem(sys.modules, "sherpa_onnx", _fake_sherpa_onnx_module(len(_ENTRY.voice_names)))
+        infer = SherpaOnnxInfer(_config())
+        with (
+            patch(
+                "modelship.infer.sherpa_onnx.sherpa_onnx_infer.resolve_bundle_dir", side_effect=OSError("network down")
+            ),
+            pytest.raises(ModelDownloadError),
+        ):
+            infer._load()
+
+
+class TestCreateSpeech:
+    @pytest.mark.asyncio
+    async def test_unknown_voice_returns_400(self):
+        infer = _infer()
+        req = SpeechRequest(input="hi", model="tts", voice="not_a_voice")
+        result = await infer.create_speech(req, RawRequestProxy(None, {}))
+        assert isinstance(result, ErrorResponse)
+        assert "not_a_voice" in result.error.message
+
+    @pytest.mark.asyncio
+    async def test_generates_wav_for_known_voice(self):
+        tts = _FakeOfflineTts(_FakeTtsConfig(), num_speakers=len(_ENTRY.voice_names))
+        infer = _infer(tts=tts)
+        req = SpeechRequest(input="hello world", model="tts", voice="af_bella", speed=1.5)
+        result = await infer.create_speech(req, RawRequestProxy(None, {}))
+        assert isinstance(result, RawSpeechResponse)
+        assert result.audio[:4] == b"RIFF"
+        assert tts.generate_calls == [("hello world", _ENTRY.voice_names.index("af_bella"), 1.5)]
+
+    @pytest.mark.asyncio
+    async def test_numeric_voice_resolves_to_sid(self):
+        tts = _FakeOfflineTts(_FakeTtsConfig(), num_speakers=len(_ENTRY.voice_names))
+        infer = _infer(tts=tts)
+        req = SpeechRequest(input="hi", model="tts", voice="2")
+        result = await infer.create_speech(req, RawRequestProxy(None, {}))
+        assert isinstance(result, RawSpeechResponse)
+        assert tts.generate_calls[0][1] == 2
+
+    @pytest.mark.asyncio
+    async def test_unknown_voice_returns_400_even_when_streaming(self):
+        infer = _infer()
+        req = SpeechRequest(input="hi", model="tts", voice="not_a_voice", stream_format="sse")
+        result = await infer.create_speech(req, RawRequestProxy(None, {}))
+        assert isinstance(result, ErrorResponse)
+
+
+class TestStreaming:
+    @pytest.mark.asyncio
+    async def test_yields_delta_per_chunk_then_done(self):
+        chunks = [np.array([0.0, 0.1], dtype=np.float32), np.array([0.2, -0.2], dtype=np.float32)]
+        tts = _FakeOfflineTts(_FakeTtsConfig(), num_speakers=len(_ENTRY.voice_names), chunks=chunks)
+        infer = _infer(tts=tts)
+        req = SpeechRequest(input="hi there", model="tts", voice="af_bella", stream_format="sse")
+        result = await infer.create_speech(req, RawRequestProxy(None, {}))
+        events = [e async for e in result]
+        assert len(events) == 3  # 2 deltas + 1 done
+        assert '"type":"speech.audio.delta"' in events[0]
+        assert '"type":"speech.audio.delta"' in events[1]
+        assert '"type":"speech.audio.done"' in events[2]
+
+    @pytest.mark.asyncio
+    async def test_early_aclose_stops_generation_before_all_chunks_sent(self):
+        chunks = [np.zeros(2, dtype=np.float32) for _ in range(5)]
+        tts = _FakeOfflineTts(_FakeTtsConfig(), num_speakers=len(_ENTRY.voice_names), chunks=chunks)
+        infer = _infer(tts=tts)
+        req = SpeechRequest(input="hi", model="tts", voice="af_bella", stream_format="sse")
+        result = await infer.create_speech(req, RawRequestProxy(None, {}))
+        await result.__anext__()  # first delta
+        await result.aclose()
+        assert tts.aborted_early

--- a/tests/test_sherpa_onnx_integration.py
+++ b/tests/test_sherpa_onnx_integration.py
@@ -1,0 +1,105 @@
+"""End-to-end coverage for the sherpa_onnx loader against a real sherpa-onnx
+binding and a real downloaded kokoro bundle. `test_sherpa_onnx_infer.py` covers
+the same logic against a stub."""
+
+import io
+import json
+import wave
+
+import httpx
+import pytest
+
+import openai
+from modelship.infer.sherpa_onnx.registry import REGISTRY
+
+OPENAI_API_BASE = "http://localhost:8000/v1"
+_VOICE_NAMES = REGISTRY["kokoro-en-v0_19"].voice_names
+
+
+def _post_speech(**fields) -> httpx.Response:
+    return httpx.post(f"{OPENAI_API_BASE}/audio/speech", json={"model": "tts-model", **fields}, timeout=120)
+
+
+def _sse_events(body: str) -> list[dict]:
+    return [
+        json.loads(line[len("data: ") :])
+        for line in body.splitlines()
+        if line.startswith("data: ") and line[len("data: ") :].strip() not in ("", "[DONE]")
+    ]
+
+
+def _wav_frames_and_rate(audio: bytes) -> tuple[int, int]:
+    with wave.open(io.BytesIO(audio)) as w:
+        return w.getnframes(), w.getframerate()
+
+
+@pytest.mark.integration
+@pytest.mark.sherpa_onnx
+class TestSherpaOnnx:
+    @pytest.fixture(autouse=True, scope="class")
+    def _deploy(self, model_deployer):
+        model_deployer.deploy("tts-model")
+
+    def test_speech_returns_valid_wav_audio(self, client):
+        response = client.audio.speech.create(
+            model="tts-model", voice="af_bella", input="Hello from an integration test."
+        )
+        audio = response.content
+        assert audio.startswith(b"RIFF") and b"WAVE" in audio[:16]
+        with wave.open(io.BytesIO(audio)) as w:
+            assert w.getnchannels() == 1
+            assert w.getsampwidth() == 2
+            assert w.getnframes() > 0
+
+    def test_multiple_voices_produce_distinct_audio(self, client):
+        # A sample across the registry, not all 11 — enough to prove sid
+        # resolution actually varies the speaker, not exhaustive coverage.
+        sample = (_VOICE_NAMES[0], _VOICE_NAMES[len(_VOICE_NAMES) // 2], _VOICE_NAMES[-1])
+        clips = [
+            client.audio.speech.create(model="tts-model", voice=voice, input="The quick brown fox.").content
+            for voice in sample
+        ]
+        assert len({clips[0], clips[1], clips[2]}) == len(sample)
+
+    def test_numeric_voice_is_accepted(self, client):
+        # sherpa's kokoro model isn't byte-deterministic call-to-call (stochastic
+        # vocoder), so this can't assert equality against the named-voice
+        # request — only that the digit path round-trips through the API to
+        # real inference instead of being rejected somewhere along the way.
+        audio = client.audio.speech.create(model="tts-model", voice="0", input="Numeric voice.").content
+        assert audio.startswith(b"RIFF")
+        assert _wav_frames_and_rate(audio)[0] > 0
+
+    def test_unknown_voice_returns_error(self, client):
+        with pytest.raises(openai.BadRequestError, match="unknown voice"):
+            client.audio.speech.create(model="tts-model", voice="not-a-real-voice", input="hi")
+
+    def test_speed_parameter_changes_duration(self, client):
+        normal = client.audio.speech.create(
+            model="tts-model", voice="af_bella", input="This sentence has a normal speaking speed.", speed=1.0
+        ).content
+        fast = client.audio.speech.create(
+            model="tts-model", voice="af_bella", input="This sentence has a normal speaking speed.", speed=2.0
+        ).content
+        normal_frames, normal_rate = _wav_frames_and_rate(normal)
+        fast_frames, fast_rate = _wav_frames_and_rate(fast)
+        assert (fast_frames / fast_rate) < (normal_frames / normal_rate)
+
+    def test_streaming_sse_speech(self):
+        response = _post_speech(voice="af_bella", input="Streaming synthesis test.", stream_format="sse")
+        assert response.status_code == 200
+        events = _sse_events(response.text)
+        assert events, "expected at least one SSE event"
+        assert events[-1]["type"] == "speech.audio.done"
+        deltas = [e for e in events[:-1] if e["type"] == "speech.audio.delta"]
+        assert deltas, "expected at least one speech.audio.delta event"
+        assert all(e["audio"] for e in deltas)
+
+    def test_response_format_is_accepted_but_audio_is_always_wav(self):
+        # SherpaOnnxInfer's RawSpeechResponse always carries media_type
+        # audio/wav; response_format is accepted by the request schema but
+        # not currently used to transcode the output.
+        response = _post_speech(voice="af_bella", input="Format check.", response_format="mp3")
+        assert response.status_code == 200
+        assert response.headers["content-type"] == "audio/wav"
+        assert response.content.startswith(b"RIFF")

--- a/tests/test_sherpa_onnx_integration.py
+++ b/tests/test_sherpa_onnx_integration.py
@@ -33,23 +33,19 @@ def _wav_frames_and_rate(audio: bytes) -> tuple[int, int]:
         return w.getnframes(), w.getframerate()
 
 
+def _transcribe(client, audio: bytes, tmp_path) -> str:
+    audio_file = tmp_path / "speech.wav"
+    audio_file.write_bytes(audio)
+    with open(audio_file, "rb") as f:
+        return client.audio.transcriptions.create(model="stt-cpp-model", file=f).text.lower()
+
+
 @pytest.mark.integration
 @pytest.mark.sherpa_onnx
 class TestSherpaOnnx:
     @pytest.fixture(autouse=True, scope="class")
     def _deploy(self, model_deployer):
-        model_deployer.deploy("tts-model")
-
-    def test_speech_returns_valid_wav_audio(self, client):
-        response = client.audio.speech.create(
-            model="tts-model", voice="af_bella", input="Hello from an integration test."
-        )
-        audio = response.content
-        assert audio.startswith(b"RIFF") and b"WAVE" in audio[:16]
-        with wave.open(io.BytesIO(audio)) as w:
-            assert w.getnchannels() == 1
-            assert w.getsampwidth() == 2
-            assert w.getnframes() > 0
+        model_deployer.deploy("tts-model", "stt-cpp-model")
 
     def test_multiple_voices_produce_distinct_audio(self, client):
         # A sample across the registry, not all 11 — enough to prove sid
@@ -61,14 +57,35 @@ class TestSherpaOnnx:
         ]
         assert len({clips[0], clips[1], clips[2]}) == len(sample)
 
-    def test_numeric_voice_is_accepted(self, client):
+    def test_speech_is_intelligible_via_transcription(self, client, tmp_path):
+        # Structural WAV checks alone don't prove the audio is clean speech
+        # rather than silence/noise that happens to be shaped like a WAV file
+        # — round-trip it through a real STT model (whispercpp, CPU-only so
+        # it can run alongside sherpa_onnx without a GPU) to confirm it is.
+        audio = client.audio.speech.create(
+            model="tts-model", voice="af_bella", input="The wizard counted seventeen purple bananas."
+        ).content
+        text = _transcribe(client, audio, tmp_path)
+        assert "wizard" in text
+        assert "banana" in text
+
+    def test_different_voices_are_all_intelligible(self, client, tmp_path):
+        sample = (_VOICE_NAMES[0], _VOICE_NAMES[len(_VOICE_NAMES) // 2], _VOICE_NAMES[-1])
+        for voice in sample:
+            audio = client.audio.speech.create(
+                model="tts-model", voice=voice, input="Open the door and turn on the light."
+            ).content
+            text = _transcribe(client, audio, tmp_path)
+            assert "door" in text or "light" in text, f"voice {voice!r} transcribed to unintelligible text: {text!r}"
+
+    def test_numeric_voice_is_accepted(self, client, tmp_path):
         # sherpa's kokoro model isn't byte-deterministic call-to-call (stochastic
         # vocoder), so this can't assert equality against the named-voice
         # request — only that the digit path round-trips through the API to
-        # real inference instead of being rejected somewhere along the way.
-        audio = client.audio.speech.create(model="tts-model", voice="0", input="Numeric voice.").content
-        assert audio.startswith(b"RIFF")
-        assert _wav_frames_and_rate(audio)[0] > 0
+        # real, intelligible inference instead of being rejected somewhere
+        # along the way.
+        audio = client.audio.speech.create(model="tts-model", voice="0", input="Numeric voice selection.").content
+        assert "numeric" in _transcribe(client, audio, tmp_path)
 
     def test_unknown_voice_returns_error(self, client):
         with pytest.raises(openai.BadRequestError, match="unknown voice"):

--- a/tests/test_sherpa_onnx_model_source.py
+++ b/tests/test_sherpa_onnx_model_source.py
@@ -1,0 +1,37 @@
+"""Driver preflight: a bare registry name has nothing to pin (the actor fetches
+the tarball itself); a local directory gets validated against the registry
+entry its basename names, before any actor starts."""
+
+import pytest
+
+from modelship.deploy.config import resolve_all_model_sources
+from modelship.infer.infer_config import ModelLoader, ModelshipConfig, ModelshipModelConfig, ModelUsecase
+
+
+def _cfg(model: str) -> ModelshipModelConfig:
+    return ModelshipModelConfig(
+        name="tts", model=model, usecase=ModelUsecase.tts, loader=ModelLoader.sherpa_onnx, num_gpus=0
+    )
+
+
+def test_registry_name_skips_source_check():
+    cfg = _cfg("kokoro-en-v0_19")
+    resolve_all_model_sources(ModelshipConfig(models=[cfg]))
+    assert cfg._pinned_source is None
+
+
+def test_local_dir_is_validated_at_preflight(tmp_path):
+    bundle = tmp_path / "kokoro-en-v0_19"
+    bundle.mkdir()
+    cfg = _cfg(str(bundle))
+    with pytest.raises(ValueError, match="missing"):
+        resolve_all_model_sources(ModelshipConfig(models=[cfg]))
+
+
+def test_local_dir_basename_must_match_a_registry_name(tmp_path):
+    # Config validation (not preflight) is what catches this — a mismatched
+    # basename never resolves to a registry entry in the first place.
+    bad_dir = tmp_path / "not-a-registered-model"
+    bad_dir.mkdir()
+    with pytest.raises(ValueError, match="not a supported registry name"):
+        _cfg(str(bad_dir))

--- a/tests/test_sherpa_onnx_registry.py
+++ b/tests/test_sherpa_onnx_registry.py
@@ -1,0 +1,57 @@
+"""Every curated sherpa_onnx registry entry must be internally consistent:
+well-formed paths/sizes, a speaker count matching voice_names, and a
+provenance URL under the k2-fsa org."""
+
+from modelship.infer.sherpa_onnx.registry import REGISTRY, registry_names
+
+
+def test_registry_names_are_unique_and_nonempty():
+    names = registry_names()
+    assert len(names) > 0
+    assert len(names) == len(set(names))
+
+
+class TestEntries:
+    def test_tarball_url_is_k2_fsa_release(self):
+        for name, entry in REGISTRY.items():
+            assert entry.tarball_url.startswith("https://github.com/k2-fsa/sherpa-onnx/releases/download/"), (
+                f"{name}: {entry.tarball_url}"
+            )
+
+    def test_sha256_is_a_valid_hex_digest(self):
+        for name, entry in REGISTRY.items():
+            assert len(entry.sha256) == 64, name
+            int(entry.sha256, 16)  # raises ValueError if not hex
+
+    def test_files_and_dirs_have_positive_sizes(self):
+        for name, entry in REGISTRY.items():
+            for slot, file in entry.files.items():
+                assert file.path, f"{name}.files[{slot}]"
+                assert file.size > 0, f"{name}.files[{slot}]"
+            for slot, d in entry.dirs.items():
+                assert d.path, f"{name}.dirs[{slot}]"
+                assert d.file_count > 0, f"{name}.dirs[{slot}]"
+            for i, file in enumerate(entry.lexicon):
+                assert file.path, f"{name}.lexicon[{i}]"
+                assert file.size > 0, f"{name}.lexicon[{i}]"
+
+    def test_required_kokoro_slots_present(self):
+        for name, entry in REGISTRY.items():
+            assert entry.family == "kokoro"
+            assert set(entry.files) == {"model", "tokens", "voices"}, name
+
+    def test_voice_names_nonempty_and_unique(self):
+        for name, entry in REGISTRY.items():
+            assert len(entry.voice_names) > 0, name
+            assert len(entry.voice_names) == len(set(entry.voice_names)), name
+
+    def test_af_bella_present_for_plugin_parity(self):
+        for name, entry in REGISTRY.items():
+            assert "af_bella" in entry.voice_names, name
+
+    def test_small_files_carry_a_sha256_pin(self):
+        # model.onnx is too large to hash per deploy; tokens/voices aren't.
+        for name, entry in REGISTRY.items():
+            assert entry.files["tokens"].sha256 is not None, name
+            assert entry.files["voices"].sha256 is not None, name
+            assert entry.files["model"].sha256 is None, name

--- a/tests/test_sherpa_onnx_registry.py
+++ b/tests/test_sherpa_onnx_registry.py
@@ -1,6 +1,6 @@
 """Every curated sherpa_onnx registry entry must be internally consistent:
-well-formed paths/sizes, a speaker count matching voice_names, and a
-provenance URL under the k2-fsa org."""
+well-formed paths, a speaker count matching voice_names, and a provenance URL
+under the k2-fsa org."""
 
 from modelship.infer.sherpa_onnx.registry import REGISTRY, registry_names
 
@@ -23,17 +23,14 @@ class TestEntries:
             assert len(entry.sha256) == 64, name
             int(entry.sha256, 16)  # raises ValueError if not hex
 
-    def test_files_and_dirs_have_positive_sizes(self):
+    def test_files_and_dirs_have_nonempty_paths(self):
         for name, entry in REGISTRY.items():
-            for slot, file in entry.files.items():
-                assert file.path, f"{name}.files[{slot}]"
-                assert file.size > 0, f"{name}.files[{slot}]"
-            for slot, d in entry.dirs.items():
-                assert d.path, f"{name}.dirs[{slot}]"
-                assert d.file_count > 0, f"{name}.dirs[{slot}]"
-            for i, file in enumerate(entry.lexicon):
-                assert file.path, f"{name}.lexicon[{i}]"
-                assert file.size > 0, f"{name}.lexicon[{i}]"
+            for slot, path in entry.files.items():
+                assert path, f"{name}.files[{slot}]"
+            for slot, path in entry.dirs.items():
+                assert path, f"{name}.dirs[{slot}]"
+            for i, path in enumerate(entry.lexicon):
+                assert path, f"{name}.lexicon[{i}]"
 
     def test_required_kokoro_slots_present(self):
         for name, entry in REGISTRY.items():
@@ -48,10 +45,3 @@ class TestEntries:
     def test_af_bella_present_for_plugin_parity(self):
         for name, entry in REGISTRY.items():
             assert "af_bella" in entry.voice_names, name
-
-    def test_small_files_carry_a_sha256_pin(self):
-        # model.onnx is too large to hash per deploy; tokens/voices aren't.
-        for name, entry in REGISTRY.items():
-            assert entry.files["tokens"].sha256 is not None, name
-            assert entry.files["voices"].sha256 is not None, name
-            assert entry.files["model"].sha256 is None, name

--- a/tests/test_sherpa_onnx_validation.py
+++ b/tests/test_sherpa_onnx_validation.py
@@ -1,0 +1,82 @@
+"""validate_bundle() against synthetic bundle trees — the failure modes a real
+tarball extraction or a hand-placed local directory can hit."""
+
+import hashlib
+
+import pytest
+
+from modelship.infer.sherpa_onnx.bundle import validate_bundle
+from modelship.infer.sherpa_onnx.registry import RegistryDir, RegistryFile, SherpaOnnxRegistryEntry
+
+
+def _entry(**overrides) -> SherpaOnnxRegistryEntry:
+    defaults = dict(
+        tarball_url="https://github.com/k2-fsa/sherpa-onnx/releases/download/tts-models/fake.tar.bz2",
+        sha256="0" * 64,
+        family="kokoro",
+        usecase="tts",
+        files={
+            "model": RegistryFile("model.onnx", 8),
+            "tokens": RegistryFile("tokens.txt", 5, hashlib.sha256(b"hello").hexdigest()),
+            "voices": RegistryFile("voices.bin", 4),
+        },
+        dirs={"data_dir": RegistryDir("espeak-ng-data", 2)},
+        lexicon=(),
+        voice_names=("af_bella",),
+    )
+    return SherpaOnnxRegistryEntry(**{**defaults, **overrides})
+
+
+def _write_valid_bundle(root):
+    (root / "model.onnx").write_bytes(b"x" * 8)
+    (root / "tokens.txt").write_bytes(b"hello")
+    (root / "voices.bin").write_bytes(b"x" * 4)
+    data_dir = root / "espeak-ng-data"
+    data_dir.mkdir()
+    (data_dir / "a").write_bytes(b"1")
+    (data_dir / "b").write_bytes(b"1")
+
+
+def test_valid_bundle_passes(tmp_path):
+    _write_valid_bundle(tmp_path)
+    validate_bundle(str(tmp_path), _entry())  # no raise
+
+
+def test_missing_file(tmp_path):
+    _write_valid_bundle(tmp_path)
+    (tmp_path / "tokens.txt").unlink()
+    with pytest.raises(ValueError, match="missing"):
+        validate_bundle(str(tmp_path), _entry())
+
+
+def test_wrong_size_lfs_pointer(tmp_path):
+    _write_valid_bundle(tmp_path)
+    (tmp_path / "model.onnx").write_bytes(b"git-lfs pointer, not the real file")
+    with pytest.raises(ValueError, match="bytes"):
+        validate_bundle(str(tmp_path), _entry())
+
+
+def test_short_dir_file_count(tmp_path):
+    _write_valid_bundle(tmp_path)
+    (tmp_path / "espeak-ng-data" / "b").unlink()
+    with pytest.raises(ValueError, match="espeak-ng-data"):
+        validate_bundle(str(tmp_path), _entry())
+
+
+def test_bad_small_file_hash(tmp_path):
+    _write_valid_bundle(tmp_path)
+    (tmp_path / "tokens.txt").write_bytes(b"wrong")  # same size, different content
+    with pytest.raises(ValueError, match="sha256"):
+        validate_bundle(str(tmp_path), _entry())
+
+
+def test_missing_lexicon_file(tmp_path):
+    _write_valid_bundle(tmp_path)
+    entry = _entry(lexicon=(RegistryFile("lexicon-us-en.txt", 3),))
+    with pytest.raises(ValueError, match="lexicon"):
+        validate_bundle(str(tmp_path), entry)
+
+
+def test_missing_bundle_dir(tmp_path):
+    with pytest.raises(ValueError, match="not found"):
+        validate_bundle(str(tmp_path / "does-not-exist"), _entry())

--- a/tests/test_sherpa_onnx_validation.py
+++ b/tests/test_sherpa_onnx_validation.py
@@ -1,12 +1,10 @@
 """validate_bundle() against synthetic bundle trees — the failure modes a real
 tarball extraction or a hand-placed local directory can hit."""
 
-import hashlib
-
 import pytest
 
 from modelship.infer.sherpa_onnx.bundle import validate_bundle
-from modelship.infer.sherpa_onnx.registry import RegistryDir, RegistryFile, SherpaOnnxRegistryEntry
+from modelship.infer.sherpa_onnx.registry import SherpaOnnxRegistryEntry
 
 
 def _entry(**overrides) -> SherpaOnnxRegistryEntry:
@@ -15,12 +13,8 @@ def _entry(**overrides) -> SherpaOnnxRegistryEntry:
         sha256="0" * 64,
         family="kokoro",
         usecase="tts",
-        files={
-            "model": RegistryFile("model.onnx", 8),
-            "tokens": RegistryFile("tokens.txt", 5, hashlib.sha256(b"hello").hexdigest()),
-            "voices": RegistryFile("voices.bin", 4),
-        },
-        dirs={"data_dir": RegistryDir("espeak-ng-data", 2)},
+        files={"model": "model.onnx", "tokens": "tokens.txt", "voices": "voices.bin"},
+        dirs={"data_dir": "espeak-ng-data"},
         lexicon=(),
         voice_names=("af_bella",),
     )
@@ -34,7 +28,6 @@ def _write_valid_bundle(root):
     data_dir = root / "espeak-ng-data"
     data_dir.mkdir()
     (data_dir / "a").write_bytes(b"1")
-    (data_dir / "b").write_bytes(b"1")
 
 
 def test_valid_bundle_passes(tmp_path):
@@ -49,30 +42,17 @@ def test_missing_file(tmp_path):
         validate_bundle(str(tmp_path), _entry())
 
 
-def test_wrong_size_lfs_pointer(tmp_path):
+def test_missing_dir(tmp_path):
     _write_valid_bundle(tmp_path)
-    (tmp_path / "model.onnx").write_bytes(b"git-lfs pointer, not the real file")
-    with pytest.raises(ValueError, match="bytes"):
-        validate_bundle(str(tmp_path), _entry())
-
-
-def test_short_dir_file_count(tmp_path):
-    _write_valid_bundle(tmp_path)
-    (tmp_path / "espeak-ng-data" / "b").unlink()
+    (tmp_path / "espeak-ng-data" / "a").unlink()
+    (tmp_path / "espeak-ng-data").rmdir()
     with pytest.raises(ValueError, match="espeak-ng-data"):
-        validate_bundle(str(tmp_path), _entry())
-
-
-def test_bad_small_file_hash(tmp_path):
-    _write_valid_bundle(tmp_path)
-    (tmp_path / "tokens.txt").write_bytes(b"wrong")  # same size, different content
-    with pytest.raises(ValueError, match="sha256"):
         validate_bundle(str(tmp_path), _entry())
 
 
 def test_missing_lexicon_file(tmp_path):
     _write_valid_bundle(tmp_path)
-    entry = _entry(lexicon=(RegistryFile("lexicon-us-en.txt", 3),))
+    entry = _entry(lexicon=("lexicon-us-en.txt",))
     with pytest.raises(ValueError, match="lexicon"):
         validate_bundle(str(tmp_path), entry)
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,9 +1,10 @@
 import hashlib
 import tarfile
+from unittest.mock import patch
 
 import pytest
 
-from modelship.utils import extract_tar, verify_sha256
+from modelship.utils import fetch_and_extract_archive, verify_sha256
 
 
 class TestVerifySha256:
@@ -19,17 +20,73 @@ class TestVerifySha256:
             verify_sha256(str(path), "0" * 64)
 
 
-class TestExtractTar:
-    def test_flattens_nested_members_to_basename(self, tmp_path):
-        src_dir = tmp_path / "nested" / "dir"
-        src_dir.mkdir(parents=True)
-        (src_dir / "file.txt").write_bytes(b"contents")
-        archive = tmp_path / "archive.tar.gz"
-        with tarfile.open(archive, "w:gz") as tar:
-            tar.add(src_dir / "file.txt", arcname="nested/dir/file.txt")
+def _make_archive(tmp_path, members: dict[str, bytes]) -> tuple[str, str]:
+    archive = tmp_path / "src_archive.tar.gz"
+    src_dir = tmp_path / "src"
+    with tarfile.open(archive, "w:gz") as tar:
+        for arcname, contents in members.items():
+            src = src_dir / arcname
+            src.parent.mkdir(parents=True, exist_ok=True)
+            src.write_bytes(contents)
+            tar.add(src, arcname=arcname)
+    digest = hashlib.sha256(archive.read_bytes()).hexdigest()
+    return str(archive), digest
 
+
+def _fake_download(src_archive: str):
+    def fake_download(url, dest):
+        with open(src_archive, "rb") as f, open(dest, "wb") as out:
+            out.write(f.read())
+
+    return fake_download
+
+
+class TestFetchAndExtractArchive:
+    def test_flatten_discards_nested_dirs(self, tmp_path):
+        src_archive, digest = _make_archive(tmp_path, {"nested/dir/file.txt": b"contents"})
         extract_dir = tmp_path / "extracted"
-        extract_tar(str(archive), str(extract_dir))
+        with patch("modelship.utils.download", side_effect=_fake_download(src_archive)):
+            fetch_and_extract_archive(
+                "http://x", digest, str(tmp_path / "archive.tar.gz"), str(extract_dir), flatten=True
+            )
 
         assert (extract_dir / "file.txt").read_bytes() == b"contents"
         assert not (extract_dir / "nested").exists()
+
+    def test_preserves_structure_and_strips_single_top_level_dir(self, tmp_path):
+        src_archive, digest = _make_archive(
+            tmp_path, {"bundle/model.onnx": b"weights", "bundle/sub/tokens.txt": b"tokens"}
+        )
+        extract_dir = tmp_path / "extracted"
+        with patch("modelship.utils.download", side_effect=_fake_download(src_archive)):
+            fetch_and_extract_archive("http://x", digest, str(tmp_path / "archive.tar.gz"), str(extract_dir))
+
+        assert (extract_dir / "model.onnx").read_bytes() == b"weights"
+        assert (extract_dir / "sub" / "tokens.txt").read_bytes() == b"tokens"
+        assert not (extract_dir / "bundle").exists()
+
+    def test_deletes_archive_by_default(self, tmp_path):
+        src_archive, digest = _make_archive(tmp_path, {"file.txt": b"x"})
+        archive_path = tmp_path / "archive.tar.gz"
+        with patch("modelship.utils.download", side_effect=_fake_download(src_archive)):
+            fetch_and_extract_archive("http://x", digest, str(archive_path), str(tmp_path / "extracted"))
+        assert not archive_path.exists()
+
+    def test_keep_archive_preserves_it(self, tmp_path):
+        src_archive, digest = _make_archive(tmp_path, {"file.txt": b"x"})
+        archive_path = tmp_path / "archive.tar.gz"
+        with patch("modelship.utils.download", side_effect=_fake_download(src_archive)):
+            fetch_and_extract_archive(
+                "http://x", digest, str(archive_path), str(tmp_path / "extracted"), keep_archive=True
+            )
+        assert archive_path.exists()
+
+    def test_sha256_mismatch_deletes_archive_and_raises(self, tmp_path):
+        src_archive, _digest = _make_archive(tmp_path, {"file.txt": b"x"})
+        archive_path = tmp_path / "archive.tar.gz"
+        with (
+            patch("modelship.utils.download", side_effect=_fake_download(src_archive)),
+            pytest.raises(ValueError, match="sha256 verification"),
+        ):
+            fetch_and_extract_archive("http://x", "0" * 64, str(archive_path), str(tmp_path / "extracted"))
+        assert not archive_path.exists()

--- a/uv.lock
+++ b/uv.lock
@@ -1789,6 +1789,8 @@ cpu = [
     { name = "onnxruntime" },
     { name = "pywhispercpp" },
     { name = "scipy" },
+    { name = "sherpa-onnx" },
+    { name = "sherpa-onnx-core" },
     { name = "soundfile" },
     { name = "stable-diffusion-cpp-python" },
     { name = "torch", version = "2.11.0", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "(platform_machine != 'aarch64' and platform_machine != 's390x' and platform_machine != 'x86_64' and sys_platform == 'darwin' and extra == 'extra-5-mship-cpu') or (platform_machine != 'ppc64le' and platform_machine != 'riscv64' and sys_platform != 'darwin' and extra == 'extra-5-mship-cpu' and extra == 'extra-5-mship-cuda') or (platform_machine != 'ppc64le' and platform_machine != 'riscv64' and sys_platform != 'darwin' and extra == 'extra-5-mship-cuda' and extra == 'extra-5-mship-metal') or (platform_machine == 'ppc64le' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32' and extra == 'extra-5-mship-cpu') or (platform_machine == 'riscv64' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32' and extra == 'extra-5-mship-cpu') or (platform_machine == 'aarch64' and sys_platform == 'darwin' and extra == 'extra-5-mship-cpu' and extra == 'extra-5-mship-cuda') or (platform_machine == 's390x' and sys_platform == 'darwin' and extra == 'extra-5-mship-cpu' and extra == 'extra-5-mship-cuda') or (platform_machine == 'x86_64' and sys_platform == 'darwin' and extra == 'extra-5-mship-cpu' and extra == 'extra-5-mship-cuda') or (platform_machine == 'ppc64le' and sys_platform != 'darwin' and extra != 'extra-5-mship-cpu' and extra == 'extra-5-mship-cuda' and extra == 'extra-5-mship-metal') or (platform_machine == 'riscv64' and sys_platform != 'darwin' and extra != 'extra-5-mship-cpu' and extra == 'extra-5-mship-cuda' and extra == 'extra-5-mship-metal') or (sys_platform == 'emscripten' and extra == 'extra-5-mship-cpu' and extra == 'extra-5-mship-cuda') or (sys_platform == 'emscripten' and extra == 'extra-5-mship-cuda' and extra == 'extra-5-mship-metal') or (sys_platform == 'win32' and extra == 'extra-5-mship-cpu' and extra == 'extra-5-mship-cuda') or (sys_platform == 'win32' and extra == 'extra-5-mship-cuda' and extra == 'extra-5-mship-metal') or (sys_platform == 'darwin' and extra != 'extra-5-mship-cpu' and extra == 'extra-5-mship-cuda' and extra == 'extra-5-mship-metal')" },
@@ -1808,6 +1810,8 @@ cuda = [
     { name = "onnxruntime-gpu" },
     { name = "pywhispercpp" },
     { name = "scipy" },
+    { name = "sherpa-onnx" },
+    { name = "sherpa-onnx-core" },
     { name = "soundfile" },
     { name = "stable-diffusion-cpp-python" },
     { name = "torch", version = "2.11.0+cu130", source = { registry = "https://download.pytorch.org/whl/cu130" } },
@@ -1835,6 +1839,8 @@ metal = [
     { name = "onnxruntime" },
     { name = "pywhispercpp" },
     { name = "scipy" },
+    { name = "sherpa-onnx" },
+    { name = "sherpa-onnx-core" },
     { name = "soundfile" },
     { name = "stable-diffusion-cpp-python" },
 ]
@@ -1897,6 +1903,12 @@ requires-dist = [
     { name = "scipy", marker = "extra == 'cpu'", specifier = ">=1.16.1" },
     { name = "scipy", marker = "extra == 'cuda'", specifier = ">=1.16.1" },
     { name = "scipy", marker = "extra == 'metal'", specifier = ">=1.16.1" },
+    { name = "sherpa-onnx", marker = "extra == 'cpu'", specifier = ">=1.13.4" },
+    { name = "sherpa-onnx", marker = "extra == 'cuda'", specifier = ">=1.13.4" },
+    { name = "sherpa-onnx", marker = "extra == 'metal'", specifier = ">=1.13.4" },
+    { name = "sherpa-onnx-core", marker = "extra == 'cpu'", specifier = "==1.13.4" },
+    { name = "sherpa-onnx-core", marker = "extra == 'cuda'", specifier = "==1.13.4" },
+    { name = "sherpa-onnx-core", marker = "extra == 'metal'", specifier = "==1.13.4" },
     { name = "soundfile", marker = "extra == 'cpu'", specifier = ">=0.13.0" },
     { name = "soundfile", marker = "extra == 'cuda'", specifier = ">=0.13.0" },
     { name = "soundfile", marker = "extra == 'metal'", specifier = ">=0.13.0" },
@@ -3784,6 +3796,37 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/58/15/8b3609fd3830ef7b27b655beb4b4e9c62313a4e8da8c676e142cc210d58e/shellingham-1.5.4.tar.gz", hash = "sha256:8dbca0739d487e5bd35ab3ca4b36e11c4078f3a234bfce294b0a0291363404de", size = 10310, upload-time = "2023-10-24T04:13:40.426Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e0/f9/0595336914c5619e5f28a1fb793285925a8cd4b432c9da0a987836c7f822/shellingham-1.5.4-py2.py3-none-any.whl", hash = "sha256:7ecfff8f2fd72616f7481040475a65b2bf8af90a56c89140852d1120324e8686", size = 9755, upload-time = "2023-10-24T04:13:38.866Z" },
+]
+
+[[package]]
+name = "sherpa-onnx"
+version = "1.13.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ca/f8/735244770b4bc63f85fabdad0e46d6ec1f4cc24e64f6e082c2e0fea92b8c/sherpa_onnx-1.13.4.tar.gz", hash = "sha256:29547692418513ad88034c2b5f98985e33042b2351e4ab375469f19a8de18c5f", size = 982750, upload-time = "2026-07-07T13:04:55.145Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8e/57/179e3a6c1fec33aa6535051feddd5da36e5622d35630b12a67a2805b76b3/sherpa_onnx-1.13.4-cp312-cp312-linux_armv7l.whl", hash = "sha256:bcf64f2d853a1afe236e9e220df62f2f53ef6ad792ca7e406d6173ec003319b8", size = 11933213, upload-time = "2026-07-07T13:50:35.989Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/34/b6d3483b08ec8a4a141e978c4b92530fd0a61dd571a575c1fe24bee300d7/sherpa_onnx-1.13.4-cp312-cp312-macosx_10_15_universal2.whl", hash = "sha256:2257545ea170f58b7977309793979d6d078761b7fdb0528561285f8ead4169db", size = 4422157, upload-time = "2026-07-07T12:29:40.234Z" },
+    { url = "https://files.pythonhosted.org/packages/82/37/07f03e97f157b206f6e62d722ec7c5ff41c7e9dc6aa2dc7de69b57e39b5a/sherpa_onnx-1.13.4-cp312-cp312-macosx_10_15_x86_64.whl", hash = "sha256:02b57dc2c829976eb842e6aee6a0e4ac3b9991aeb5afa89fd44eb71d848a4ecd", size = 2345135, upload-time = "2026-07-07T12:10:19.957Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/79/ee999f0c3b7789077d0939716a38234573d139f851a31409aa028fe2c610/sherpa_onnx-1.13.4-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:84e58b5a074b97c5307c9b6221d1d20fbf412a1a5dff4960ca9c32bb5184219f", size = 2105219, upload-time = "2026-07-07T11:48:22.518Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/90/9b67ed3e7adc79daf0ba49c4936a691521488125b04fe469b64a8b5398ff/sherpa_onnx-1.13.4-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:f709e6dd02ebf7d37dcb02d5eadc5fb66c9922dd5809df770c1ef5d625ae7a44", size = 4135963, upload-time = "2026-07-07T11:58:30.98Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/b1/8dfe5d1d72c92ea1c95db999a95b61bfbb9769f1c569f06e572eda095c52/sherpa_onnx-1.13.4-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:5f0158f3513d3adab1ebba0c26f0c815e53ba13b96846d92ef095ae25d648860", size = 4358555, upload-time = "2026-07-07T12:58:59.654Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/04/cfd543933ae24430d124e533847c73a84a5f0efd60f07bbc6403032f9624/sherpa_onnx-1.13.4-cp312-cp312-win32.whl", hash = "sha256:d49928a3455bae1dd4e93f6b013cfbd2c3ccb5cde74aabae3710b656e7d79b6b", size = 1930647, upload-time = "2026-07-07T12:02:06.689Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/bb/1e723ab703a1e354f390de19981ec0c347576f87be01915d826dc6fc9f41/sherpa_onnx-1.13.4-cp312-cp312-win_amd64.whl", hash = "sha256:b8436ffe2763b3fd522fbac8fe53f47d611721c84819c241acfb65d122403d7d", size = 2244142, upload-time = "2026-07-07T13:01:42.293Z" },
+]
+
+[[package]]
+name = "sherpa-onnx-core"
+version = "1.13.4"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ad/69/ae33a8cb1ecc30e0c4638d76772e56161162d57bef748380790e1257841f/sherpa_onnx_core-1.13.4-py3-none-macosx_10_15_universal2.whl", hash = "sha256:737099a817998e4d74379dcd44d8d1b332a3fa1822780be174334c3d1d1e2451", size = 36025264, upload-time = "2026-07-07T11:41:37.506Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/8c/a1336beab226d228f62bdbe1cacf1439a2f6cf8714baac98f1f031dd2f60/sherpa_onnx_core-1.13.4-py3-none-macosx_10_15_x86_64.whl", hash = "sha256:674ea57eb6458002dab4e39749d21a7364b2f962f4a4958a3ee4c351b093cafd", size = 19325474, upload-time = "2026-07-07T11:31:03.394Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/26/d0d6bebea4ef8b7de6eed1a335235d1acce9197425c08eecb57ef107904d/sherpa_onnx_core-1.13.4-py3-none-macosx_11_0_arm64.whl", hash = "sha256:7820183581b711a68e30281a4fb36c0af8ef5615bfc789234fb259439824a014", size = 16897650, upload-time = "2026-07-07T11:42:28.755Z" },
+    { url = "https://files.pythonhosted.org/packages/81/29/15859e896574230d5377738ef27e8647cbd19fa325d75b1a00074791798d/sherpa_onnx_core-1.13.4-py3-none-manylinux2014_aarch64.whl", hash = "sha256:b4e4d17eb0d5c569bf4c9effcbc3daef57cf7e2b8418e07ae90f90c9b60b35d5", size = 13023017, upload-time = "2026-07-07T11:41:30.935Z" },
+    { url = "https://files.pythonhosted.org/packages/41/be/38c57721d71ee74d984b1ca21720a8ca8477d6d341026af24ff658866ef9/sherpa_onnx_core-1.13.4-py3-none-manylinux2014_x86_64.whl", hash = "sha256:367aa06cee90b3fd7959d4e071d6fc821710b859af399b4987e5c3119ee6ae2a", size = 10338839, upload-time = "2026-07-07T12:21:33.627Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/17/949ee6d5cff4ec9e2dcda014276a798b814e2eb80d35d820884e6e0614ff/sherpa_onnx_core-1.13.4-py3-none-manylinux_2_35_armv7l.whl", hash = "sha256:3b9cc7da5ce4a2333a9ae211f39c34dee981b13f2c9c8680fbf2d9636e87d617", size = 9889942, upload-time = "2026-07-07T14:25:04.94Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/71/e2fb4b965b86bd3ee6ca35d81999e9edad47c20d2c8fc4e03db8083494bc/sherpa_onnx_core-1.13.4-py3-none-win32.whl", hash = "sha256:ba9de2f463ae67ee2947f1bd9b981a1e39e6b831e281bf5088068251b8ec4dde", size = 13832564, upload-time = "2026-07-07T11:49:11.781Z" },
+    { url = "https://files.pythonhosted.org/packages/95/b0/c3d59ac76f3db873e41bd0cb4fc30b352a278da3289217985aaae3650211/sherpa_onnx_core-1.13.4-py3-none-win_amd64.whl", hash = "sha256:0a6949cf0fd83adb9fbcfdf5c27b8907a57f7b48626db703c7f6037be9b61764", size = 16450053, upload-time = "2026-07-07T12:03:05.196Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Adds loader: sherpa_onnx as a generic, in-process TTS loader backed by sherpa-onnx's kokoro models, with a curated model registry, driver-time bundle validation/fetch, and SSE streaming for /v1/audio/speech. Promotes the SSE framing helper out of the custom plugin's serving_speech.py into a shared modelship/openai/utils/audio.py so both paths use it.


