### PR TITLE
fix: drop CoreML support from sherpa_onnx loader, CPU only

### DIFF
--- a/config/examples/README.md
+++ b/config/examples/README.md
@@ -10,7 +10,7 @@ Ready-to-run `models.yaml` configs for common scenarios. Mount one into the cont
 | [vllm-vision.yaml](vllm-vision.yaml) | Vision-language chat (image_url content parts) | NVIDIA GPU |
 | [diffusers.yaml](diffusers.yaml) | SDXL Turbo image generation | NVIDIA GPU |
 | [stable-diffusion-cpp.yaml](stable-diffusion-cpp.yaml) | GGUF-quantized image generation (SD 2.1, Flux-schnell) | CPU |
-| [sherpa-onnx.yaml](sherpa-onnx.yaml) | Kokoro TTS via sherpa-onnx | CPU or NVIDIA GPU (CoreML on Metal) |
+| [sherpa-onnx.yaml](sherpa-onnx.yaml) | Kokoro TTS via sherpa-onnx | CPU only |
 | [full-stack.yaml](full-stack.yaml) | LLM + TTS + STT + embeddings on one GPU | NVIDIA GPU |
 | [mini-pc.yaml](mini-pc.yaml) | Low-resource stack: llama-server chat + Kokoro TTS + whisper.cpp STT | CPU (e.g. Intel N100) |
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -7,7 +7,7 @@ Modelship is built on [Ray Serve](https://docs.ray.io/en/latest/serve/) for depl
 - **[vLLM](https://github.com/vllm-project/vllm)** — high-throughput inference with continuous batching and PagedAttention, on GPU or CPU
 - **llama-server** — a proxied `llama-server` subprocess for quantized GGUF chat, embeddings, and vision on CPU or GPU
 - **[HuggingFace Diffusers](https://github.com/huggingface/diffusers)** — image generation via `AutoPipelineForText2Image`
-- **sherpa-onnx** — TTS (Kokoro), on CPU or GPU (CoreML on Metal)
+- **sherpa-onnx** — TTS (Kokoro), CPU only
 - **whisper.cpp** — STT, via `pywhispercpp` bindings
 
 ## Request Lifecycle

--- a/docs/model-configuration.md
+++ b/docs/model-configuration.md
@@ -480,9 +480,9 @@ See `config/examples/whispercpp.yaml` for every `model:` form and a Metal exampl
 
 ## sherpa_onnx Loader
 
-The `sherpa_onnx` loader runs [sherpa-onnx](https://github.com/k2-fsa/sherpa-onnx) in-process via its Python bindings. Current scope: TTS only, kokoro family only, CPU (and CoreML on macOS) only — it never touches CUDA, so `num_gpus` is ignored entirely (any value is accepted at config time but forced to `0` at deploy time, with a warning if nonzero) and doesn't reserve GPU capacity another deploy could use.
+The `sherpa_onnx` loader runs [sherpa-onnx](https://github.com/k2-fsa/sherpa-onnx) in-process via its Python bindings. Current scope: TTS only, kokoro family only, CPU only — it never touches CUDA or CoreML, so `num_gpus` is ignored entirely (any value is accepted at config time but forced to `0` at deploy time, with a warning if nonzero) and doesn't reserve GPU capacity another deploy could use.
 
-`model:` is not an HF repo or path — it's a name from a curated, built-in registry (or a local directory whose basename matches one). Each name maps to a GitHub release tarball with a pinned sha256, downloaded and cached under `<cache_root>/sherpa_onnx/<name>/` on first use. There is no `sherpa_onnx_config` — `provider` (`cpu`/`coreml`) and thread count are derived from `num_gpus`/`num_cpus`, never user-supplied, since an invalid provider string silently falls back to CPU inside sherpa's own C++.
+`model:` is not an HF repo or path — it's a name from a curated, built-in registry (or a local directory whose basename matches one). Each name maps to a GitHub release tarball with a pinned sha256, downloaded and cached under `<cache_root>/sherpa_onnx/<name>/` on first use. There is no `sherpa_onnx_config` — `provider` is always `cpu`, thread count is derived from `num_cpus`, neither is user-supplied.
 
 Supported `model:` names:
 

--- a/modelship/deploy/actor_options.py
+++ b/modelship/deploy/actor_options.py
@@ -116,7 +116,7 @@ def build_deployment_options(config: ModelshipModelConfig) -> dict:
 
     capability_resources = deployment_capability_resources(config)
 
-    # sherpa_onnx never touches CUDA (CPU/CoreML only); ggml-backed loaders are
+    # sherpa_onnx never touches CUDA or CoreML (CPU only); ggml-backed loaders are
     # CPU-only off Darwin, where forcing 0 would mislead Ray into co-scheduling
     # another GPU actor onto the device Metal is actually using.
     force_zero_gpu = config.loader == ModelLoader.sherpa_onnx or (

--- a/modelship/infer/model_deployment.py
+++ b/modelship/infer/model_deployment.py
@@ -39,8 +39,8 @@ from modelship.openai.protocol import (
 
 logger = get_logger("infer.deployment")
 
-# llama_server, stable_diffusion_cpp, and whispercpp all have Metal backends; sherpa_onnx has
-# CoreML; vllm/diffusers don't.
+# llama_server, stable_diffusion_cpp, and whispercpp all have Metal backends; sherpa_onnx is
+# CPU-only; vllm/diffusers don't run on Darwin at all.
 _DARWIN_UNSUPPORTED_LOADERS = {ModelLoader.vllm, ModelLoader.diffusers}
 
 

--- a/modelship/infer/sherpa_onnx/sherpa_onnx_infer.py
+++ b/modelship/infer/sherpa_onnx/sherpa_onnx_infer.py
@@ -1,7 +1,6 @@
 import asyncio
 import contextlib
 import os
-import platform
 import threading
 from collections.abc import AsyncGenerator
 from typing import Any
@@ -24,7 +23,7 @@ logger = get_logger("infer.sherpa_onnx")
 
 class SherpaOnnxInfer(BaseInfer):
     """In-process sherpa-onnx TTS loader, generic across `OfflineTtsConfig`
-    families. v1 scope: the registry only curates kokoro, CPU/CoreML only."""
+    families. v1 scope: the registry only curates kokoro, CPU only."""
 
     def __init__(self, model_config: ModelshipModelConfig):
         super().__init__(model_config)
@@ -58,9 +57,9 @@ class SherpaOnnxInfer(BaseInfer):
             setattr(family_cfg, slot, os.path.join(bundle_dir, rel_path))
         if entry.lexicon:
             family_cfg.lexicon = ",".join(os.path.join(bundle_dir, rel_path) for rel_path in entry.lexicon)
-        # Never take provider from config: an unsupported/typo'd value silently
-        # falls back to CPU inside sherpa's C++ instead of raising.
-        cfg.model.provider = "coreml" if platform.system() == "Darwin" else "cpu"
+        # CPU only: CoreML fails under Ray's forked actor processes (macOS TCC
+        # check on the coremlcompiler XPC call).
+        cfg.model.provider = "cpu"
         cfg.model.num_threads = max(1, round(self.model_config.num_cpus))
 
         logger.info("loading sherpa_onnx model %r for '%s'", self.model_config.model, self.model_config.name)

--- a/tests/test_mship_deploy.py
+++ b/tests/test_mship_deploy.py
@@ -390,7 +390,7 @@ class TestBuildDeploymentOptions:
         assert opts["ray_actor_options"]["num_gpus"] == 0.5
 
     def test_sherpa_onnx_num_gpus_forced_to_zero(self):
-        # sherpa_onnx never touches CUDA (CPU/CoreML only); a nonzero num_gpus
+        # sherpa_onnx never touches CUDA or CoreML (CPU only); a nonzero num_gpus
         # here would just reserve GPU capacity the loader never uses.
         config = ModelshipModelConfig(
             name="test-model",

--- a/tests/test_sherpa_onnx_infer.py
+++ b/tests/test_sherpa_onnx_infer.py
@@ -117,7 +117,6 @@ class TestLoad:
                 "modelship.infer.sherpa_onnx.sherpa_onnx_infer.resolve_bundle_dir",
                 return_value=("/bundle", _ENTRY),
             ),
-            patch("modelship.infer.sherpa_onnx.sherpa_onnx_infer.platform.system", return_value="Linux"),
         ):
             tts, entry = infer._load()
         assert entry is _ENTRY
@@ -128,26 +127,12 @@ class TestLoad:
         assert tts.cfg.model.kokoro.tokens == "/bundle/tokens.txt"
         assert tts.cfg.model.kokoro.data_dir == "/bundle/espeak-ng-data"
 
-    def test_darwin_uses_coreml(self, monkeypatch):
-        monkeypatch.setitem(sys.modules, "sherpa_onnx", _fake_sherpa_onnx_module(len(_ENTRY.voice_names)))
-        infer = SherpaOnnxInfer(_config())
-        with (
-            patch(
-                "modelship.infer.sherpa_onnx.sherpa_onnx_infer.resolve_bundle_dir",
-                return_value=("/bundle", _ENTRY),
-            ),
-            patch("modelship.infer.sherpa_onnx.sherpa_onnx_infer.platform.system", return_value="Darwin"),
-        ):
-            tts, _entry = infer._load()
-        assert tts.cfg.model.provider == "coreml"
-
     def test_lexicon_joined_with_commas(self, monkeypatch):
         entry = REGISTRY["kokoro-multi-lang-v1_0"]
         monkeypatch.setitem(sys.modules, "sherpa_onnx", _fake_sherpa_onnx_module(len(entry.voice_names)))
         infer = SherpaOnnxInfer(_config(model="kokoro-multi-lang-v1_0"))
         with (
             patch("modelship.infer.sherpa_onnx.sherpa_onnx_infer.resolve_bundle_dir", return_value=("/bundle", entry)),
-            patch("modelship.infer.sherpa_onnx.sherpa_onnx_infer.platform.system", return_value="Linux"),
         ):
             tts, _entry2 = infer._load()
         assert tts.cfg.model.kokoro.lexicon == "/bundle/lexicon-us-en.txt,/bundle/lexicon-zh.txt"
@@ -160,7 +145,6 @@ class TestLoad:
                 "modelship.infer.sherpa_onnx.sherpa_onnx_infer.resolve_bundle_dir",
                 return_value=("/bundle", _ENTRY),
             ),
-            patch("modelship.infer.sherpa_onnx.sherpa_onnx_infer.platform.system", return_value="Linux"),
             pytest.raises(ValueError, match="999"),
         ):
             infer._load()


### PR DESCRIPTION
onnxruntime's CoreML EP fails under Ray's forked actor processes with an EPERM from Apple's coremlcompiler XPC service (TCC "responsible process" check), breaking kokoro TTS on macOS. sherpa_onnx now always uses provider="cpu".


