### PR TITLE
fix: stop whispercpp loader's native/download logs bleeding into console

### DIFF
--- a/modelship/infer/whispercpp/whispercpp_infer.py
+++ b/modelship/infer/whispercpp/whispercpp_infer.py
@@ -1,5 +1,6 @@
 import asyncio
 import json
+import logging
 import os
 import threading
 from collections.abc import AsyncGenerator
@@ -56,8 +57,21 @@ class WhispercppInfer(BaseInfer):
 
     def _load(self) -> Any:
         import _pywhispercpp as _pw
+        from pywhispercpp import utils as pywhispercpp_utils
         from pywhispercpp.constants import AVAILABLE_MODELS
         from pywhispercpp.model import Model
+        from tqdm import tqdm
+
+        class _ThrottledDownloadProgress(tqdm):
+            def __init__(self, *args: Any, **kwargs: Any) -> None:
+                kwargs.setdefault("mininterval", 60)
+                kwargs.setdefault(
+                    "bar_format", "{desc}: downloading {percentage:3.0f}% ({n_fmt}/{total_fmt}, {rate_fmt})"
+                )
+                super().__init__(*args, **kwargs)
+
+            def display(self, msg: str | None = None, pos: int | None = None) -> None:
+                logger.info("%s", self)
 
         use_gpu = self.model_config.num_gpus > 0
         context_params: dict[str, Any] = {"use_gpu": use_gpu}
@@ -86,7 +100,14 @@ class WhispercppInfer(BaseInfer):
                 kwargs["models_dir"] = models_dir
 
         logger.info("loading whisper.cpp model %r (gpu=%s) for '%s'", model_ref, use_gpu, self.model_config.name)
-        model: Any = Model(model_ref, **kwargs)
+        # raw stderr writes; redirecting into our own logger would deadlock (fd 2 -> our handlers' pipe)
+        kwargs["redirect_whispercpp_logs_to"] = False if logger.isEnabledFor(logging.DEBUG) else None
+        original_tqdm = pywhispercpp_utils.tqdm  # pyright: ignore[reportPrivateImportUsage]
+        pywhispercpp_utils.tqdm = _ThrottledDownloadProgress  # pyright: ignore[reportPrivateImportUsage]
+        try:
+            model: Any = Model(model_ref, **kwargs)
+        finally:
+            pywhispercpp_utils.tqdm = original_tqdm  # pyright: ignore[reportPrivateImportUsage]
         self._multilingual = bool(_pw.whisper_is_multilingual(model._ctx))
         return model
 

--- a/modelship/infer/whispercpp/whispercpp_infer.py
+++ b/modelship/infer/whispercpp/whispercpp_infer.py
@@ -71,7 +71,7 @@ class WhispercppInfer(BaseInfer):
                 super().__init__(*args, **kwargs)
 
             def display(self, msg: str | None = None, pos: int | None = None) -> None:
-                logger.info("%s", self)
+                logging.getLogger("pywhispercpp.download").info("%s", self)
 
         use_gpu = self.model_config.num_gpus > 0
         context_params: dict[str, Any] = {"use_gpu": use_gpu}

--- a/modelship/logging.py
+++ b/modelship/logging.py
@@ -72,6 +72,7 @@ _LIB_LOGGERS = (
     "diffusers",
     "flashinfer",
     "huggingface_hub",
+    "pywhispercpp",
 )
 
 # Env vars that libraries check internally when creating their own loggers.


### PR DESCRIPTION
pywhispercpp's own Python loggers weren't routed through modelship's handler/level config, and neither its download progress bar nor whisper.cpp's native model-load diagnostics went through logging at all - all three wrote raw, unprefixed output straight to stderr, regardless of MSHIP_LOG_LEVEL.

pywhispercpp is now a silenced-by-default lib logger like the others, and the download progress bar is routed through it via a throttled tqdm subclass. whisper.cpp's raw C stderr writes are silenced at INFO and passed through unredirected only at DEBUG/TRACE - piping them into our own logger would alias fd 2 to a pipe our handlers also write to, deadlocking.

