### PR TITLE
ci: add Linux CUDA llama.cpp backend build workflow

### DIFF
--- a/.github/workflows/llama-cpp-cuda.yml
+++ b/.github/workflows/llama-cpp-cuda.yml
@@ -1,0 +1,110 @@
+name: Build llama.cpp (Linux CUDA)
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "llama.cpp tag to build (e.g. b10361)"
+        required: true
+
+permissions:
+  contents: read
+
+env:
+  LLAMA_CPP_BUILDS_REPO: modelship-ai/llama-cpp-builds
+  # CUDA major 13 pairs with torch cu130, which supplies libcudart/libcublas at
+  # run time (tests/test_cuda_abi_drift.py guards that pairing).
+  CUDA_VERSION_DASH: 13-0
+  CUDA_HOME: /usr/local/cuda-13.0
+
+jobs:
+  build:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout llama.cpp
+        uses: actions/checkout@v4
+        with:
+          repository: ggml-org/llama.cpp
+          ref: ${{ inputs.tag }}
+
+      - name: Install CUDA toolkit
+        run: |
+          curl -fsSL https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2404/x86_64/3bf863cc.pub \
+            | sudo gpg --dearmor -o /usr/share/keyrings/cuda-keyring.gpg
+          echo "deb [signed-by=/usr/share/keyrings/cuda-keyring.gpg] https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2404/x86_64/ /" \
+            | sudo tee /etc/apt/sources.list.d/cuda.list > /dev/null
+          sudo apt-get update -y
+          sudo apt-get install -y --no-install-recommends \
+            cuda-nvcc-${CUDA_VERSION_DASH} \
+            cuda-cudart-dev-${CUDA_VERSION_DASH} \
+            libcublas-dev-${CUDA_VERSION_DASH}
+          echo "${CUDA_HOME}/bin" >> "$GITHUB_PATH"
+
+      - name: ccache
+        uses: ggml-org/ccache-action@v1.2.21
+        with:
+          key: llama-cpp-cuda-${{ inputs.tag }}
+
+      - name: Build
+        run: |
+          cmake -B build \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DCMAKE_INSTALL_RPATH='$ORIGIN' \
+            -DCMAKE_BUILD_WITH_INSTALL_RPATH=ON \
+            -DGGML_BACKEND_DL=ON \
+            -DGGML_NATIVE=OFF \
+            -DGGML_CPU=OFF \
+            -DGGML_CUDA=ON \
+            -DLLAMA_BUILD_EXAMPLES=OFF \
+            -DLLAMA_BUILD_TESTS=OFF \
+            -DLLAMA_BUILD_TOOLS=OFF \
+            -DLLAMA_BUILD_SERVER=OFF
+          cmake --build build --config Release -j "$(nproc)" --target ggml-cuda
+          df -h /
+
+      - name: Verify ABI
+        run: |
+          SO=build/bin/libggml-cuda.so
+          test -f "$SO"
+          readelf -d "$SO"
+          readelf -d "$SO" | grep -q '(RUNPATH).*\$ORIGIN' \
+            || { echo "::error::missing \$ORIGIN runpath"; exit 1; }
+          BAD=$(readelf -d "$SO" \
+            | sed -n 's/.*Shared library: \[\(lib\(cudart\|cublas\|cublasLt\)\.so\.[0-9]*\)\].*/\1/p' \
+            | grep -v '\.so\.13$' || true)
+          if [ -n "$BAD" ]; then
+            echo "::error::non-CUDA-13 dependency: ${BAD}"
+            exit 1
+          fi
+
+      - name: Package
+        id: package
+        run: |
+          TAG=${{ inputs.tag }}
+          NAME="libggml-cuda-${TAG}-linux-x64-cuda13"
+          mkdir "$NAME"
+          cp build/bin/libggml-cuda.so "$NAME"/
+          cp LICENSE "$NAME"/
+          tar czf "${NAME}.tar.gz" "$NAME"
+          SHA=$(sha256sum "${NAME}.tar.gz" | awk '{print $1}')
+          echo "$SHA" > "${NAME}.tar.gz.sha256"
+          echo "sha256=$SHA" >> "$GITHUB_OUTPUT"
+          echo "name=$NAME" >> "$GITHUB_OUTPUT"
+          ls -lh "${NAME}.tar.gz"
+
+      - name: Publish release
+        env:
+          GH_TOKEN: ${{ secrets.LLAMA_CPP_BUILDS_TOKEN }}
+        run: |
+          TAG=${{ inputs.tag }}
+          NAME=${{ steps.package.outputs.name }}
+          gh release create "llamacpp-${TAG}-linux-cuda" \
+            --repo "${{ env.LLAMA_CPP_BUILDS_REPO }}" \
+            --title "llama.cpp ${TAG} (Linux x64 CUDA 13 backend)" \
+            --notes "Own-CI build of ggml-org/llama.cpp ${TAG}'s \`ggml-cuda\` target, from modelship's llama-cpp-cuda.yml.
+
+          Contains \`libggml-cuda.so\` only. Extract alongside upstream's \`llama-${TAG}-bin-ubuntu-x64.tar.gz\`, whose build it is ABI-matched to. At run time \`libcudart.so.13\`/\`libcublas.so.13\` must be on the loader path (torch cu130 bundles both under \`site-packages/nvidia/cu13/lib\`), plus \`libcuda.so.1\` from the NVIDIA driver.
+
+          sha256: ${{ steps.package.outputs.sha256 }}" \
+            --prerelease \
+            "${NAME}.tar.gz" "${NAME}.tar.gz.sha256"


### PR DESCRIPTION
Upstream ships no Linux CUDA binary in its GitHub Releases — only ubuntu-{x64,arm64,rocm,vulkan,sycl,openvino,s390x} tarballs plus win-cuda-*.zip. CUDA-on-Linux exists solely inside the server-cuda13 Docker image, which the Dockerfile consumes but a native install can't.

Build the ggml-cuda target alone and publish libggml-cuda.so as a tarball alongside the Metal builds. ggml dlopen()s its backends (GGML_BACKEND_DL), so the artifact drops into an extracted upstream ubuntu-x64 tarball of the same tag — the composition upstream already ships for Windows, where the CUDA zip contains only ggml-cuda.dll.

Nothing consumes the artifact yet; launcher.py is untouched.

Notes on the build flags:
- CMAKE_INSTALL_RPATH=$ORIGIN reproduces the release tarballs' runpath so the backend resolves libggml-base.so.0 from its own directory. The Docker image's copy instead carries a build-tree runpath, which is why that path needs a wrapper script.
- CMAKE_CUDA_ARCHITECTURES is left unset; ggml-cuda's CMakeLists derives a toolkit-version-aware list itself. GGML_NATIVE=OFF keeps that off "native", which would need a GPU the runner doesn't have.
- Only nvcc plus the cudart/cublas dev packages are installed, not the cuda-toolkit metapackage (~6-7 GB on a 14 GB runner). CUB and build-essential arrive as transitive deps.

The Verify ABI step fails the run before publishing if the build loses the $ORIGIN runpath or links a CUDA major other than 13, which must stay paired with torch cu130.


