### PR TITLE
feat: split provisioning into `mship bootstrap`

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -157,7 +157,8 @@ jobs:
             ## Native install (Apple Silicon / homelab)
 
             ```bash
-            uv tool install "mship[metal]"
+            uv tool install mship
+            mship bootstrap --metal
             mship deploy --config models.yaml
             ```
 

--- a/README.md
+++ b/README.md
@@ -120,18 +120,20 @@ The response includes both `output_text` and a first-class `reasoning` output it
 
 ### Native install (no Docker)
 
-One install command everywhere, then pick the node's role at run time:
+One install command everywhere. Pick the node's role once, when you bootstrap it:
 
 ```bash
 pipx install mship          # or: uv tool install mship / pip install mship
 
-mship deploy --cuda  --config models.yaml   # NVIDIA GPU node
-mship deploy --cpu   --config models.yaml   # CPU node (includes vLLM CPU)
-mship deploy --metal --config models.yaml   # Apple Silicon
-mship deploy --thin  --config models.yaml   # coordinator/head only, no capacity
+mship bootstrap --cuda      # NVIDIA GPU node
+mship bootstrap --cpu       # CPU node (includes vLLM CPU)
+mship bootstrap --metal     # Apple Silicon
+mship bootstrap --thin      # coordinator/head only, no capacity
+
+mship deploy --config models.yaml
 ```
 
-Nothing to pin and nothing to match across machines. The first run of a variant sets itself up; after that it starts straight through. Every node lands on the same footing, so a new one joins the cluster by running the same command.
+`mship bootstrap` installs a pinned Python 3.12.10 environment for that role and records it, so `deploy` afterwards needs no variant flag and installs nothing — it starts straight through. Nothing to pin and nothing to match across machines: every node lands on the same footing, so a new one joins the cluster by running the same two commands. After a `pip install -U mship`, re-run `mship bootstrap` to move the environment with it.
 
 Platform prerequisites still apply: Xcode Command Line Tools on macOS, `build-essential`/`cmake` on Linux, plus `ninja-build` and NVIDIA's `nvcc` for `--cuda`. Alpine and other musl distros are unsupported. See [docs/installation.md](docs/installation.md) for the full list.
 

--- a/bootstrap/README.md
+++ b/bootstrap/README.md
@@ -7,18 +7,22 @@ production backend for self-hosted agents.
 pipx install mship          # or: uv tool install mship / pip install mship
 ```
 
-Then pick the node's role — the install command is the same on every machine:
+Then pick the node's role once — the install command is the same on every machine:
 
 ```bash
-mship deploy --cuda  --config models.yaml   # NVIDIA GPU node
-mship deploy --cpu   --config models.yaml   # CPU node (includes vLLM CPU)
-mship deploy --metal --config models.yaml   # Apple Silicon
-mship deploy --thin  --config models.yaml   # coordinator/head only, no capacity
+mship bootstrap --cuda      # NVIDIA GPU node
+mship bootstrap --cpu       # CPU node (includes vLLM CPU)
+mship bootstrap --metal     # Apple Silicon
+mship bootstrap --thin      # coordinator/head only, no capacity
+
+mship deploy --config models.yaml
 ```
 
-Nothing to pin and nothing to match across machines. The first run of a variant
-sets itself up; after that it starts straight through. Every node lands on the
-same footing, so a new one joins the cluster by running the same command.
+`bootstrap` installs a pinned Python 3.12.10 environment for that role and records
+it, so `deploy` needs no variant flag afterwards and installs nothing. Nothing to
+pin and nothing to match across machines: every node lands on the same footing, so
+a new one joins the cluster by running the same two commands. After upgrading
+`mship`, re-run `mship bootstrap` to move the environment with it.
 
 Alpine and other musl distros are unsupported — use a glibc distro or the Docker
 images.

--- a/bootstrap/mship_bootstrap/cli.py
+++ b/bootstrap/mship_bootstrap/cli.py
@@ -1,20 +1,22 @@
-"""Entry point. Resolves a variant, provisions its environment, execs the engine."""
+"""Entry point. `bootstrap` provisions a variant's environment; everything else
+resolves one, checks it is current, and execs the engine inside it."""
 
 from __future__ import annotations
 
 import os
 import sys
 
-from . import __version__, engine, gates, llama_cpp, paths, uv_binary
+from . import __version__, engine, gates, llama_cpp, paths, uv_binary, variants
 from .variants import VariantError, split_variant_flag
 from .variants import resolve as resolve_variant
 
-_COMMANDS = ("deploy", "info")
+_COMMANDS = ("bootstrap", "deploy", "info")
 
-_USAGE = """usage: mship {deploy,info} [--cuda|--cpu|--metal|--thin] [args]
+_USAGE = """usage: mship {bootstrap,deploy,info} [--cuda|--cpu|--metal|--thin] [args]
 
-  deploy   provision the node and serve models (requires a variant)
-  info     report bootstrapper state, or the engine's own report with a variant
+  bootstrap   install the engine environment for a variant (run once)
+  deploy      serve models, using the bootstrapped environment
+  info        report bootstrapper state, or the engine's own report with a variant
 """
 
 
@@ -31,28 +33,47 @@ def main(argv: list[str] | None = None) -> None:
         sys.exit(str(e))
 
     # Answerable before any variant exists.
-    if command == "info" and flag is None and not os.environ.get("MSHIP_VARIANT"):
+    if command == "info" and flag is None and not (os.environ.get("MSHIP_VARIANT") or "").strip():
         engine.print_info(__version__)
         return
 
     try:
-        variant = resolve_variant(flag)
+        variant = resolve_variant(flag, recorded=variants.read_recorded(paths.env_file()))
         gates.check_platform()
         gates.check_hardware(variant.requires_accelerator)
-        uv = uv_binary.ensure_uv()
-        python = engine.provision(variant, uv, __version__)
+        if command == "bootstrap":
+            _bootstrap(variant, rest)
+            return
+        if not engine.is_current(variant, __version__):
+            sys.exit(engine.describe_staleness(variant, __version__))
     except (VariantError, gates.GateError, uv_binary.UvError, engine.EngineError) as e:
         sys.exit(str(e))
 
+    python = paths.venv_python(variant.name)
     env = _engine_env(variant)
     os.execve(python, [python, "-m", "modelship.launcher", command, *rest], env)
+
+
+def _bootstrap(variant, rest: list[str]) -> None:
+    # Nothing here is forwarded to the engine.
+    if rest:
+        sys.exit(f"error: mship bootstrap takes no arguments besides the variant, got {' '.join(rest)}")
+
+    uv = uv_binary.ensure_uv()
+    engine.provision(variant, uv, __version__)
+    if variant.serves_models:
+        llama_cpp.provision(variant)
+    variants.write_recorded(paths.env_file(), variant.name)
+
+    print(f"\nmship {__version__} bootstrapped for --{variant.name} in {paths.env_dir(variant.name)}")
+    print(f"Recorded in {paths.env_file()}; `mship deploy` now needs no variant flag.")
 
 
 def _engine_env(variant) -> dict[str, str]:
     env = dict(os.environ)
     env.setdefault("MSHIP_CACHE_DIR", os.path.join(paths.home(), "cache"))
 
-    if variant.serves_models and (wrapper := llama_cpp.provision(variant)):
+    if variant.serves_models and (wrapper := llama_cpp.locate(variant)):
         env["MSHIP_LLAMA_SERVER_BIN"] = wrapper
         if variant.name == "cuda":
             llama_cpp.warn_if_no_cuda_device(wrapper)

--- a/bootstrap/mship_bootstrap/engine.py
+++ b/bootstrap/mship_bootstrap/engine.py
@@ -13,7 +13,7 @@ import sys
 from importlib import resources
 
 from . import paths
-from .variants import Variant, engine_requirement
+from .variants import VARIANTS, Variant, engine_requirement, read_recorded
 
 PYTHON_VERSION = "3.12.10"
 
@@ -44,26 +44,50 @@ def provision(variant: Variant, uv: str, version: str) -> str:
         [uv, "pip", "sync", "--python", venv, *variant.index_args, requirements],
         f"install the {variant.name} engine environment",
     )
+    # Only now — a failed sync must not leave the stamp is_current reads.
+    os.replace(requirements, paths.pins_copy(variant.name))
     return paths.venv_python(variant.name)
+
+
+def is_current(variant: Variant, version: str) -> bool:
+    """Whether this environment was built by this mship, for this variant. pins.txt's
+    last line is the engine requirement, carrying both the extras and the version."""
+    if not os.path.isfile(paths.venv_python(variant.name)):
+        return False
+    return _recorded_engine_requirement(variant) == engine_requirement(variant, version)
+
+
+def _recorded_engine_requirement(variant: Variant) -> str | None:
+    try:
+        with open(paths.pins_copy(variant.name)) as f:
+            lines = f.read().splitlines()
+    except OSError:
+        return None
+    return lines[-1].strip() if lines else None
+
+
+def describe_staleness(variant: Variant, version: str) -> str:
+    """Why `is_current` said no, and how to fix it."""
+    fix = f"\n\nRun: mship bootstrap --{variant.name}"
+    if not os.path.isfile(paths.venv_python(variant.name)):
+        others = [n for n in provisioned_variants() if n != variant.name]
+        also = f"\nProvisioned: {', '.join(others)}" if others else ""
+        return f"error: the {variant.name} environment has not been bootstrapped.{also}{fix}"
+    recorded = _recorded_engine_requirement(variant) or ""
+    built_for = recorded.partition("==")[2] or "an unknown version"
+    return f"error: the {variant.name} environment was built for mship {built_for}, but this is {version}.{fix}"
 
 
 def _write_requirements(variant: Variant, version: str) -> str:
     """The shipped pins plus the engine line, which `uv export --no-emit-project`
-    omits."""
+    omits. Staged: promoted to pins.txt once the sync succeeds."""
     body = read_pins(variant)
-    if wheel := os.environ.get("MSHIP_ENGINE_WHEEL"):
-        if not os.path.isfile(wheel):
-            raise EngineError(f"error: MSHIP_ENGINE_WHEEL={wheel!r} is not a file")
-        engine = f"{os.path.abspath(wheel)}[{','.join(variant.extras)}]"
-    else:
-        engine = engine_requirement(variant, version)
-
-    target = paths.pins_copy(variant.name)
+    target = paths.pins_staging(variant.name)
     with open(target, "w") as f:
         f.write(body)
         if not body.endswith("\n"):
             f.write("\n")
-        f.write(f"{engine}\n")
+        f.write(f"{engine_requirement(variant, version)}\n")
     return target
 
 
@@ -76,16 +100,20 @@ def _run(cmd: list[str], what: str) -> None:
         raise EngineError(f"error: failed to {what} (uv exited {e.returncode})") from e
 
 
-def describe_envs() -> list[tuple[str, str]]:
-    """(variant, human-readable size) for every provisioned environment."""
+def provisioned_variants() -> list[str]:
+    """Variants with a usable interpreter on disk. Cheap — no tree walk."""
     root = os.path.join(paths.home(), "envs")
-    if not os.path.isdir(root):
+    try:
+        names = os.listdir(root)
+    except OSError:
         return []
-    out = []
-    for name in sorted(os.listdir(root)):
-        if os.path.isfile(paths.venv_python(name)):
-            out.append((name, _human_size(_tree_size(paths.env_dir(name)))))
-    return out
+    return sorted(n for n in names if n in VARIANTS and os.path.isfile(paths.venv_python(n)))
+
+
+def describe_envs() -> list[tuple[str, str]]:
+    """(variant, human-readable size) for every provisioned environment. Sizing
+    walks the whole tree, so this stays confined to `mship info`."""
+    return [(name, _human_size(_tree_size(paths.env_dir(name)))) for name in provisioned_variants()]
 
 
 def _tree_size(path: str) -> int:
@@ -113,10 +141,12 @@ def print_info(version: str) -> None:
     print(f"python:               {sys.version.split()[0]} ({sys.executable})")
     print(f"MSHIP_HOME:           {paths.home()}")
     print(f"uv:                   {shutil.which('uv') or os.path.join(paths.bin_dir(), 'uv')}")
+    print(f"variant:              {read_recorded(paths.env_file()) or 'none recorded'}")
     envs = describe_envs()
     if not envs:
         print("environments:         none provisioned")
         return
     print("environments:")
     for name, size in envs:
-        print(f"  {name:<6} {size:>8}  {paths.env_dir(name)}")
+        stale = "" if is_current(VARIANTS[name], version) else "  (stale — re-run bootstrap)"
+        print(f"  {name:<6} {size:>8}  {paths.env_dir(name)}{stale}")

--- a/bootstrap/mship_bootstrap/llama_cpp.py
+++ b/bootstrap/mship_bootstrap/llama_cpp.py
@@ -66,8 +66,18 @@ _ASSETS: dict[tuple[str, str], _Asset] = {
 
 
 def provision(variant: Variant) -> str | None:
-    """Returns the wrapper path, or None when there is no prebuilt asset for this
-    platform. Never fatal — only the llama_server loader needs it."""
+    """Downloads the build if needed. Returns the wrapper path, or None when there
+    is no prebuilt asset for this platform. Never fatal — only the llama_server
+    loader needs it."""
+    return _resolve_or_warn(variant, fetch=True)
+
+
+def locate(variant: Variant) -> str | None:
+    """Same, but never downloads: for `deploy`, which installs nothing."""
+    return _resolve_or_warn(variant, fetch=False)
+
+
+def _resolve_or_warn(variant: Variant, *, fetch: bool) -> str | None:
     if explicit := os.environ.get("MSHIP_LLAMA_SERVER_BIN"):
         return explicit
 
@@ -76,13 +86,13 @@ def provision(variant: Variant) -> str | None:
         return None
 
     try:
-        return _resolve(variant, asset)
+        return _resolve(variant, asset, fetch=fetch)
     except Exception as e:
         print(f"warning: llama-server provisioning failed: {e}", file=sys.stderr)
         return None
 
 
-def _resolve(variant: Variant, asset: _Asset) -> str:
+def _resolve(variant: Variant, asset: _Asset, *, fetch: bool) -> str | None:
     tag_dir = os.path.join(paths.builds_dir(variant.name), "llama.cpp", _LLAMA_CPP_TAG)
     archive_path = os.path.join(tag_dir, "archive.tar.gz")
     extract_dir = os.path.join(tag_dir, "extracted")
@@ -92,6 +102,13 @@ def _resolve(variant: Variant, asset: _Asset) -> str:
     cuda = variant.name == "cuda" and (platform.system(), platform.machine()) == ("Linux", "x86_64")
 
     if not os.path.isfile(binary) or (cuda and not os.path.isfile(os.path.join(extract_dir, _CUDA_BACKEND_SO))):
+        if not fetch:
+            print(
+                f"warning: no llama.cpp {_LLAMA_CPP_TAG} build under {tag_dir}; "
+                f"the llama_server loader will not work. Run: mship bootstrap --{variant.name}",
+                file=sys.stderr,
+            )
+            return None
         if os.path.isdir(extract_dir):
             shutil.rmtree(extract_dir, ignore_errors=True)
         print(f"mship: fetching llama.cpp {_LLAMA_CPP_TAG}", flush=True)
@@ -100,6 +117,7 @@ def _resolve(variant: Variant, asset: _Asset) -> str:
         if cuda:
             _install_cuda_backend(tag_dir, extract_dir)
 
+    # Cheap, and rewritten on both paths: it bakes in a venv-specific library path.
     _write_wrapper(wrapper_path, extract_dir, asset.lib_env, variant, cuda=cuda)
     return wrapper_path
 

--- a/bootstrap/mship_bootstrap/paths.py
+++ b/bootstrap/mship_bootstrap/paths.py
@@ -31,9 +31,19 @@ def venv_python(variant: str) -> str:
     return os.path.join(venv_dir(variant), "bin", "python")
 
 
+def env_file() -> str:
+    """Where `mship bootstrap` records the variant it built."""
+    return os.path.join(home(), "env")
+
+
 def pins_copy(variant: str) -> str:
-    """Copy of the pins that built this environment."""
+    """Copy of the pins that built this environment; written only after a
+    successful sync."""
     return os.path.join(env_dir(variant), "pins.txt")
+
+
+def pins_staging(variant: str) -> str:
+    return os.path.join(env_dir(variant), "pins.txt.partial")
 
 
 def builds_dir(variant: str) -> str:

--- a/bootstrap/mship_bootstrap/variants.py
+++ b/bootstrap/mship_bootstrap/variants.py
@@ -6,6 +6,8 @@ from __future__ import annotations
 import os
 from typing import NamedTuple
 
+from . import paths
+
 _PYPI_INDEX = "https://pypi.org/simple"
 _PYTORCH_CPU_INDEX = "https://download.pytorch.org/whl/cpu"
 _PYTORCH_CU130_INDEX = "https://download.pytorch.org/whl/cu130"
@@ -72,9 +74,14 @@ VARIANT_ORDER = ("cuda", "cpu", "metal", "thin")
 
 NO_VARIANT_ERROR = (
     "error: no variant selected\n\n"
-    + "".join(f"  mship deploy --{n:<8} {VARIANTS[n].summary}\n" for n in VARIANT_ORDER)
-    + ("\nFirst use of a variant provisions a pinned Python 3.12.10 environment for it\n(several GB for --cuda).\n")
+    + "".join(f"  mship bootstrap --{n:<8} {VARIANTS[n].summary}\n" for n in VARIANT_ORDER)
+    + (
+        "\nBootstrapping provisions a pinned Python 3.12.10 environment for the variant\n"
+        "(several GB for --cuda). `mship deploy` then needs no variant flag.\n"
+    )
 )
+
+_RECORDED_HEADER = "# Written by mship bootstrap — do not edit; run 'mship bootstrap --<variant>' instead.\n"
 
 
 class VariantError(Exception):
@@ -96,10 +103,39 @@ def split_variant_flag(argv: list[str]) -> tuple[str | None, list[str]]:
     return (found[0] if found else None), rest
 
 
-def resolve(flag: str | None, env: dict[str, str] | None = None) -> Variant:
-    """Flag wins over MSHIP_VARIANT; disagreement is an error."""
+def read_recorded(path: str) -> str | None:
+    """MSHIP_VARIANT out of an env file, or None if there is none to read. No other
+    key is consumed and the file never reaches os.environ."""
+    try:
+        with open(path) as f:
+            lines = f.read().splitlines()
+    except OSError:
+        return None
+    for line in lines:
+        line = line.strip()
+        if not line or line.startswith("#") or "=" not in line:
+            continue
+        key, _, value = line.partition("=")
+        if key.strip() == "MSHIP_VARIANT":
+            return value.strip().strip("'\"").strip() or None
+    return None
+
+
+def write_recorded(path: str, name: str) -> None:
+    """Last bootstrap wins. Read-only so an editor warns first."""
+    tmp = f"{path}.partial"
+    with open(tmp, "w") as f:
+        f.write(f"{_RECORDED_HEADER}MSHIP_VARIANT={name}\n")
+    os.chmod(tmp, 0o444)
+    os.replace(tmp, path)
+
+
+def resolve(flag: str | None, env: dict[str, str] | None = None, recorded: str | None = None) -> Variant:
+    """Flag wins over MSHIP_VARIANT; disagreement between those two is an error.
+    `recorded` is only a default, so either overrides it silently."""
     env = os.environ if env is None else env
     from_env = (env.get("MSHIP_VARIANT") or "").strip() or None
+    recorded = (recorded or "").strip() or None
 
     if from_env is not None and from_env not in VARIANTS:
         raise VariantError(
@@ -109,6 +145,13 @@ def resolve(flag: str | None, env: dict[str, str] | None = None) -> Variant:
         raise VariantError(f"error: --{flag} conflicts with MSHIP_VARIANT={from_env}")
 
     chosen = flag or from_env
+    if chosen is None and recorded is not None:
+        if recorded not in VARIANTS:
+            raise VariantError(
+                f"error: MSHIP_VARIANT={recorded!r} in {paths.env_file()} is not a variant; "
+                f"expected one of {', '.join(VARIANT_ORDER)}"
+            )
+        chosen = recorded
     if chosen is None:
         raise VariantError(NO_VARIANT_ERROR)
     return VARIANTS[chosen]

--- a/bootstrap/tests/test_cli.py
+++ b/bootstrap/tests/test_cli.py
@@ -3,7 +3,7 @@ from unittest.mock import patch
 
 import pytest
 
-from mship_bootstrap import cli, paths
+from mship_bootstrap import cli, paths, variants
 from mship_bootstrap.variants import VARIANTS
 
 
@@ -18,7 +18,9 @@ def provisioned(tmp_path, monkeypatch):
         patch.object(cli.gates, "check_hardware"),
         patch.object(cli.uv_binary, "ensure_uv", return_value="/usr/bin/uv"),
         patch.object(cli.engine, "provision", return_value="/env/bin/python"),
+        patch.object(cli.engine, "is_current", return_value=True),
         patch.object(cli.llama_cpp, "provision", return_value="/builds/llama-server.sh"),
+        patch.object(cli.llama_cpp, "locate", return_value="/builds/llama-server.sh"),
         patch.object(cli.llama_cpp, "warn_if_no_cuda_device"),
         patch("os.execve") as execve,
     ):
@@ -50,11 +52,11 @@ class TestVariantRequired:
 
 
 class TestExec:
-    def test_execs_the_engine_via_module(self, provisioned):
+    def test_execs_the_engine_via_module(self, provisioned, tmp_path):
         cli.main(["deploy", "--cpu", "--config", "models.yaml"])
         python, args, _env = provisioned.call_args[0]
-        assert python == "/env/bin/python"
-        assert args == ["/env/bin/python", "-m", "modelship.launcher", "deploy", "--config", "models.yaml"]
+        assert python == paths.venv_python("cpu")
+        assert args == [python, "-m", "modelship.launcher", "deploy", "--config", "models.yaml"]
 
     def test_variant_flag_is_not_passed_to_the_engine(self, provisioned):
         cli.main(["deploy", "--cuda", "--reconcile"])
@@ -119,6 +121,15 @@ class TestInfo:
         cli.main(["info", "--cpu"])
         assert provisioned.call_args[0][1][-1] == "info"
 
+    def test_whitespace_only_env_var_still_answers_locally(self, tmp_path, monkeypatch, capsys):
+        """Matches resolve()'s own whitespace-as-unset handling."""
+        monkeypatch.setenv("MSHIP_HOME", str(tmp_path))
+        monkeypatch.setenv("MSHIP_VARIANT", "  ")
+        cli.main(["info"])
+        out = capsys.readouterr().out
+        assert "MSHIP_HOME" in out
+        assert "none provisioned" in out
+
 
 class TestPaths:
     def test_mship_home_relocates_everything(self, monkeypatch, tmp_path):
@@ -142,10 +153,85 @@ class TestPaths:
 
 class TestThinSkipsLlamaServer:
     def test_thin_does_not_provision_a_binary_it_cannot_use(self, provisioned):
-        cli.main(["deploy", "--thin"])
+        cli.main(["bootstrap", "--thin"])
         cli.llama_cpp.provision.assert_not_called()
-        assert "MSHIP_LLAMA_SERVER_BIN" not in provisioned.call_args[0][2]
 
     def test_serving_variants_still_provision(self, provisioned):
-        cli.main(["deploy", "--cpu"])
+        cli.main(["bootstrap", "--cpu"])
         cli.llama_cpp.provision.assert_called_once()
+
+    def test_thin_deploys_without_looking_for_one(self, provisioned):
+        cli.main(["deploy", "--thin"])
+        cli.llama_cpp.locate.assert_not_called()
+        assert "MSHIP_LLAMA_SERVER_BIN" not in provisioned.call_args[0][2]
+
+
+class TestBootstrap:
+    def test_provisions_and_does_not_exec(self, provisioned):
+        cli.main(["bootstrap", "--cpu"])
+        cli.engine.provision.assert_called_once()
+        assert not provisioned.called
+
+    def test_records_the_variant(self, provisioned, tmp_path):
+        cli.main(["bootstrap", "--metal"])
+        assert variants.read_recorded(paths.env_file()) == "metal"
+
+    def test_requires_a_variant(self):
+        with pytest.raises(SystemExit) as exc:
+            cli.main(["bootstrap"])
+        assert "no variant selected" in str(exc.value)
+
+    def test_rejects_trailing_arguments(self, provisioned):
+        with pytest.raises(SystemExit) as exc:
+            cli.main(["bootstrap", "--cpu", "--config", "models.yaml"])
+        assert "--config models.yaml" in str(exc.value)
+        cli.engine.provision.assert_not_called()
+
+    def test_a_failed_bootstrap_records_nothing(self, provisioned, tmp_path):
+        cli.engine.provision.side_effect = cli.engine.EngineError("error: boom")
+        with pytest.raises(SystemExit):
+            cli.main(["bootstrap", "--cpu"])
+        assert not os.path.exists(paths.env_file())
+
+
+class TestDeployInstallsNothing:
+    def test_deploy_never_provisions(self, provisioned):
+        cli.main(["deploy", "--cpu", "--config", "x"])
+        cli.uv_binary.ensure_uv.assert_not_called()
+        cli.engine.provision.assert_not_called()
+
+    def test_a_stale_environment_stops_the_deploy(self, provisioned):
+        cli.engine.is_current.return_value = False
+        with pytest.raises(SystemExit) as exc:
+            cli.main(["deploy", "--cpu", "--config", "x"])
+        assert "mship bootstrap --cpu" in str(exc.value)
+        assert not provisioned.called
+
+    def test_a_stale_environment_is_not_repaired(self, provisioned):
+        cli.engine.is_current.return_value = False
+        with pytest.raises(SystemExit):
+            cli.main(["deploy", "--cpu"])
+        cli.engine.provision.assert_not_called()
+
+
+class TestRecordedVariant:
+    def test_deploy_needs_no_flag_once_bootstrapped(self, provisioned):
+        cli.main(["bootstrap", "--cuda"])
+        cli.main(["deploy", "--config", "models.yaml"])
+        assert provisioned.call_args[0][0] == paths.venv_python("cuda")
+
+    def test_a_flag_overrides_the_record(self, provisioned):
+        cli.main(["bootstrap", "--cuda"])
+        cli.main(["deploy", "--thin"])
+        assert provisioned.call_args[0][0] == paths.venv_python("thin")
+
+    def test_bootstrapping_another_variant_moves_the_record(self, provisioned):
+        cli.main(["bootstrap", "--cuda"])
+        cli.main(["bootstrap", "--cpu"])
+        assert variants.read_recorded(paths.env_file()) == "cpu"
+
+    def test_an_unknown_recorded_value_is_an_error(self, provisioned, tmp_path):
+        (tmp_path / "env").write_text("MSHIP_VARIANT=gpu\n")
+        with pytest.raises(SystemExit) as exc:
+            cli.main(["deploy", "--config", "x"])
+        assert "not a variant" in str(exc.value)

--- a/bootstrap/tests/test_engine.py
+++ b/bootstrap/tests/test_engine.py
@@ -30,7 +30,6 @@ def _local_version_pins(variant) -> list[str]:
 @pytest.fixture
 def home(tmp_path, monkeypatch):
     monkeypatch.setenv("MSHIP_HOME", str(tmp_path))
-    monkeypatch.delenv("MSHIP_ENGINE_WHEEL", raising=False)
     return tmp_path
 
 
@@ -66,23 +65,10 @@ class TestWriteRequirements:
         target = engine._write_requirements(VARIANTS["thin"], "0.8.0")
         assert open(target).read().splitlines()[-1] == "mship-engine[thin]==0.8.0"
 
-    def test_writes_where_an_operator_will_find_it(self, home):
+    def test_stages_rather_than_overwriting_the_success_stamp(self, home):
         os.makedirs(paths.env_dir("cpu"), exist_ok=True)
-        assert engine._write_requirements(VARIANTS["cpu"], "0.8.0") == str(home / "envs" / "cpu" / "pins.txt")
-
-    def test_engine_wheel_override(self, home, monkeypatch, tmp_path):
-        wheel = tmp_path / "mship_engine-0.8.0-py3-none-any.whl"
-        wheel.write_text("")
-        monkeypatch.setenv("MSHIP_ENGINE_WHEEL", str(wheel))
-        os.makedirs(paths.env_dir("cuda"), exist_ok=True)
-        target = engine._write_requirements(VARIANTS["cuda"], "0.8.0")
-        assert open(target).read().splitlines()[-1] == f"{wheel}[cuda]"
-
-    def test_missing_engine_wheel_is_an_error(self, home, monkeypatch):
-        monkeypatch.setenv("MSHIP_ENGINE_WHEEL", "/does/not/exist.whl")
-        os.makedirs(paths.env_dir("cpu"), exist_ok=True)
-        with pytest.raises(engine.EngineError, match="not a file"):
-            engine._write_requirements(VARIANTS["cpu"], "0.8.0")
+        assert engine._write_requirements(VARIANTS["cpu"], "0.8.0") == paths.pins_staging("cpu")
+        assert not os.path.exists(paths.pins_copy("cpu"))
 
 
 class TestProvision:
@@ -120,15 +106,90 @@ class TestProvision:
             engine.provision(VARIANTS["cpu"], "/usr/bin/uv", "0.8.0")
         assert any(call[0][0][1] == "venv" for call in run.call_args_list)
 
+    def test_syncs_the_staged_file_then_promotes_it(self, home):
+        with patch.object(engine, "_run") as run:
+            engine.provision(VARIANTS["thin"], "/usr/bin/uv", "0.8.0")
+        assert run.call_args_list[-1][0][0][-1] == paths.pins_staging("thin")
+        assert open(paths.pins_copy("thin")).read().splitlines()[-1] == "mship-engine[thin]==0.8.0"
+        assert not os.path.exists(paths.pins_staging("thin"))
+
+    def test_a_failed_sync_leaves_no_success_stamp(self, home):
+        with patch.object(engine, "_run", side_effect=[None, engine.EngineError("boom")]):
+            with pytest.raises(engine.EngineError):
+                engine.provision(VARIANTS["thin"], "/usr/bin/uv", "0.8.0")
+        assert not os.path.exists(paths.pins_copy("thin"))
+
+
+def _provision_env(name: str, version: str | None = "0.8.0") -> None:
+    python = paths.venv_python(name)
+    os.makedirs(os.path.dirname(python), exist_ok=True)
+    open(python, "w").close()
+    if version is not None:
+        with open(paths.pins_copy(name), "w") as f:
+            f.write(f"idna==3.10\n{engine.engine_requirement(VARIANTS[name], version)}\n")
+
+
+class TestIsCurrent:
+    def test_matching_version(self, home):
+        _provision_env("cpu")
+        assert engine.is_current(VARIANTS["cpu"], "0.8.0")
+
+    def test_version_skew(self, home):
+        _provision_env("cpu", "0.7.12")
+        assert not engine.is_current(VARIANTS["cpu"], "0.8.0")
+
+    def test_missing_pins(self, home):
+        _provision_env("cpu", version=None)
+        assert not engine.is_current(VARIANTS["cpu"], "0.8.0")
+
+    def test_empty_pins(self, home):
+        _provision_env("cpu", version=None)
+        open(paths.pins_copy("cpu"), "w").close()
+        assert not engine.is_current(VARIANTS["cpu"], "0.8.0")
+
+    def test_missing_venv(self, home):
+        assert not engine.is_current(VARIANTS["cpu"], "0.8.0")
+
+
+class TestDescribeStaleness:
+    def test_not_bootstrapped_names_the_command(self, home):
+        message = engine.describe_staleness(VARIANTS["cuda"], "0.8.0")
+        assert "has not been bootstrapped" in message
+        assert "mship bootstrap --cuda" in message
+
+    def test_not_bootstrapped_points_at_what_is(self, home):
+        _provision_env("cpu")
+        assert "Provisioned: cpu" in engine.describe_staleness(VARIANTS["cuda"], "0.8.0")
+
+    def test_skew_names_both_versions(self, home):
+        _provision_env("cpu", "0.7.12")
+        message = engine.describe_staleness(VARIANTS["cpu"], "0.8.0")
+        assert "built for mship 0.7.12" in message
+        assert "but this is 0.8.0" in message
+
+
+class TestProvisionedVariants:
+    def test_empty_when_nothing_provisioned(self, home):
+        assert engine.provisioned_variants() == []
+
+    def test_lists_only_complete_envs(self, home):
+        os.makedirs(paths.env_dir("cuda"), exist_ok=True)
+        _provision_env("cpu")
+        assert engine.provisioned_variants() == ["cpu"]
+
+    def test_ignores_directories_that_are_not_variants(self, home):
+        _provision_env("cpu")
+        stray = paths.venv_python("scratch")
+        os.makedirs(os.path.dirname(stray), exist_ok=True)
+        open(stray, "w").close()
+        assert engine.provisioned_variants() == ["cpu"]
+
 
 class TestDescribeEnvs:
     def test_empty_when_nothing_provisioned(self, home):
         assert engine.describe_envs() == []
 
     def test_lists_only_complete_envs(self, home):
-        for name in ("cpu", "cuda"):
-            os.makedirs(paths.env_dir(name), exist_ok=True)
-        python = paths.venv_python("cpu")
-        os.makedirs(os.path.dirname(python), exist_ok=True)
-        open(python, "w").close()
+        os.makedirs(paths.env_dir("cuda"), exist_ok=True)
+        _provision_env("cpu")
         assert [name for name, _ in engine.describe_envs()] == ["cpu"]

--- a/bootstrap/tests/test_variants.py
+++ b/bootstrap/tests/test_variants.py
@@ -1,11 +1,16 @@
+import os
+import stat
+
 import pytest
 
 from mship_bootstrap.variants import (
     VARIANTS,
     VariantError,
     engine_requirement,
+    read_recorded,
     resolve,
     split_variant_flag,
+    write_recorded,
 )
 
 
@@ -61,6 +66,83 @@ class TestResolve:
     def test_empty_env_var_is_treated_as_unset(self):
         with pytest.raises(VariantError, match="no variant selected"):
             resolve(None, env={"MSHIP_VARIANT": "  "})
+
+
+class TestResolveRecorded:
+    def test_recorded_is_used_when_nothing_else_is_given(self):
+        assert resolve(None, env={}, recorded="metal").name == "metal"
+
+    def test_flag_overrides_it_silently(self):
+        assert resolve("cuda", env={}, recorded="thin").name == "cuda"
+
+    def test_env_var_overrides_it_silently(self):
+        assert resolve(None, env={"MSHIP_VARIANT": "cpu"}, recorded="thin").name == "cpu"
+
+    def test_unknown_recorded_value_is_an_error(self):
+        with pytest.raises(VariantError, match="not a variant"):
+            resolve(None, env={}, recorded="gpu")
+
+    def test_unknown_recorded_value_names_the_file(self):
+        with pytest.raises(VariantError, match="env"):
+            resolve(None, env={}, recorded="gpu")
+
+    @pytest.mark.parametrize("recorded", [None, "", "  "])
+    def test_absent_recorded_value_reads_as_unset(self, recorded):
+        with pytest.raises(VariantError, match="no variant selected"):
+            resolve(None, env={}, recorded=recorded)
+
+
+class TestRecordedFile:
+    def test_round_trip(self, tmp_path):
+        path = str(tmp_path / "env")
+        write_recorded(path, "cuda")
+        assert read_recorded(path) == "cuda"
+
+    def test_carries_a_do_not_edit_header(self, tmp_path):
+        path = str(tmp_path / "env")
+        write_recorded(path, "cpu")
+        body = open(path).read()
+        assert body.startswith("# ")
+        assert "do not edit" in body
+
+    def test_is_read_only(self, tmp_path):
+        path = str(tmp_path / "env")
+        write_recorded(path, "cpu")
+        assert not stat.S_IMODE(os.stat(path).st_mode) & stat.S_IWUSR
+
+    def test_last_bootstrap_wins(self, tmp_path):
+        path = str(tmp_path / "env")
+        write_recorded(path, "cpu")
+        write_recorded(path, "thin")
+        assert read_recorded(path) == "thin"
+
+    def test_missing_file(self, tmp_path):
+        assert read_recorded(str(tmp_path / "nope")) is None
+
+    def test_file_without_the_key(self, tmp_path):
+        path = tmp_path / "env"
+        path.write_text("# a comment\n\nHF_TOKEN=secret\n")
+        assert read_recorded(str(path)) is None
+
+    def test_other_keys_are_ignored(self, tmp_path):
+        path = tmp_path / "env"
+        path.write_text("MSHIP_RECORDED_TEST_KEY=secret\nMSHIP_VARIANT=metal\nMSHIP_HOME=/elsewhere\n")
+        before = dict(os.environ)
+        assert read_recorded(str(path)) == "metal"
+        assert os.environ == before
+
+    def test_empty_value_reads_as_unset(self, tmp_path):
+        path = tmp_path / "env"
+        path.write_text("MSHIP_VARIANT=\n")
+        assert read_recorded(str(path)) is None
+
+    def test_tolerates_quotes_and_whitespace(self, tmp_path):
+        path = tmp_path / "env"
+        path.write_text('  MSHIP_VARIANT = "cuda" \n')
+        assert read_recorded(str(path)) == "cuda"
+
+    def test_unreadable_file(self, tmp_path):
+        assert read_recorded(str(tmp_path)) is None
 
 
 class TestVariantDefinitions:

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -63,28 +63,33 @@ walkthrough.
 
 ## Native install
 
-One command on every platform — the node's role is chosen at run time, not at
-install time:
+One install command on every platform, then one bootstrap to pick the node's role:
 
 ```bash
 pipx install mship          # or: uv tool install mship / pip install mship
 ```
 
-| Command | Node role |
+| Bootstrap command | Node role |
 |---|---|
-| `mship deploy --cuda --config models.yaml` | NVIDIA GPU node (vLLM, Diffusers, llama.cpp GPU offload) |
-| `mship deploy --cpu --config models.yaml` | CPU node (vLLM CPU, llama.cpp, whisper.cpp, sherpa-onnx, stable-diffusion.cpp) |
-| `mship deploy --metal --config models.yaml` | Apple Silicon (Metal offload) |
-| `mship deploy --thin --config models.yaml` | Coordinator/head only — serves nothing itself |
+| `mship bootstrap --cuda` | NVIDIA GPU node (vLLM, Diffusers, llama.cpp GPU offload) |
+| `mship bootstrap --cpu` | CPU node (vLLM CPU, llama.cpp, whisper.cpp, sherpa-onnx, stable-diffusion.cpp) |
+| `mship bootstrap --metal` | Apple Silicon (Metal offload) |
+| `mship bootstrap --thin` | Coordinator/head only — serves nothing itself |
 
-`mship deploy` with no variant is an error that lists these options; there is no
+Then, with no variant flag:
+
+```bash
+mship deploy --config models.yaml
+```
+
+Bootstrapping with no variant is an error that lists these options; there is no
 default and no auto-detection, so a node's role is always something you stated.
-`MSHIP_VARIANT` is the environment-variable equivalent, for systemd units and CI.
+`MSHIP_VARIANT` is the environment-variable equivalent, for systemd units and CI,
+and overrides the recorded role for a single command.
 
-### What the first run does
+### What `mship bootstrap` does
 
-The `mship` package is a small installer that runs on any Python 3.10+. The first
-time you use a variant it:
+The `mship` package is a small installer that runs on any Python 3.10+. Bootstrapping:
 
 1. Refuses unsupported platforms (Windows, musl/Alpine) before downloading anything.
 2. Checks the hardware matches — `--cuda` needs `nvidia-smi` to list a device — so a
@@ -92,15 +97,28 @@ time you use a variant it:
 3. Provisions `~/.modelship/envs/<variant>/` on **CPython 3.12.10**, installing from a
    hash-pinned dependency list shipped inside the package.
 4. Fetches the pinned `llama-server` build for the platform.
-5. Runs the engine inside that environment.
+5. Records the variant in `~/.modelship/env`.
 
 Every node therefore lands on an identical interpreter and dependency set, which is
 what lets a native node join a cluster of Docker nodes — Ray refuses to form a
-cluster across mismatched Python versions. Later runs re-verify the environment in
-milliseconds and start straight away.
+cluster across mismatched Python versions.
 
 A copy of the exact pinned list that built each environment is left at
 `~/.modelship/envs/<variant>/pins.txt`. `mship info` reports what is provisioned.
+
+`deploy` itself installs nothing. It stops if the environment is missing or was
+built by a different `mship` version:
+
+```
+error: the cuda environment was built for mship 0.7.12, but this is 0.7.13.
+
+Run: mship bootstrap --cuda
+```
+
+So upgrading is `pip install -U mship` followed by `mship bootstrap`.
+
+To bootstrap more than one variant on a host, run `bootstrap` for each — the last
+one is the recorded default, and `mship deploy --thin` selects another explicitly.
 
 ### Platform prerequisites
 
@@ -142,16 +160,29 @@ deploy seems slow, check `"$MSHIP_LLAMA_SERVER_BIN" --list-devices` — it print
 
 ```
 ~/.modelship/
+  env                       the variant bootstrap recorded (MSHIP_VARIANT=…)
   cache/                    models and other downloads (MSHIP_CACHE_DIR)
   envs/<variant>/           one environment per variant
   builds/<variant>/         llama-server binaries
   bin/uv                    only if uv was not already installed
 ```
 
+`~/.modelship/env` is written read-only by `bootstrap` and holds a single
+`MSHIP_VARIANT=` line. Being an ordinary env file, it drops straight into a systemd
+unit:
+
+```ini
+[Service]
+EnvironmentFile=/home/youruser/.modelship/env
+ExecStart=/home/youruser/.local/bin/mship deploy --config /etc/modelship/models.yaml
+```
+
+Change it with `mship bootstrap`, not by hand.
+
 `MSHIP_CACHE_DIR` may point at shared storage — model weights are identical on every
 node. `MSHIP_HOME` (default `~/.modelship`) must stay node-local: environments and
 binaries are platform- and variant-specific. To reset a variant, delete
-`~/.modelship/envs/<variant>/`; the next run rebuilds it and leaves your models alone.
+`~/.modelship/envs/<variant>/` and bootstrap it again; your models are untouched.
 
 ## Local development
 


### PR DESCRIPTION
`mship deploy --cuda --config models.yaml` provisioned the environment and served models in one command, restating the variant every time. Provisioning now belongs to `mship bootstrap --cuda`, which installs the pinned environment and records the variant in `~/.modelship/env`; `mship deploy --config models.yaml` afterwards takes no variant flag and installs nothing.

BREAKING: `mship deploy` no longer provisions. A missing or version-skewed environment stops the deploy with the `mship bootstrap` command to run, so upgrading is `pip install -U mship` followed by `mship bootstrap`.

Variant resolution is `--flag` > `MSHIP_VARIANT` > the recorded file. The recorded value is a default rather than an assertion, so a flag or env var overrides it silently, but an unknown value errors. It only selects which environment to use — `is_current` independently checks that environment was built by this mship version, comparing pins.txt's trailing engine requirement.

Also:
- pins.txt is staged and promoted only after a successful sync, so a failed bootstrap no longer leaves a stamp claiming an install that never finished.
- Drop `MSHIP_ENGINE_WHEEL`, unused since it was added and the one case where the pins fingerprint held a path instead of a version.
- Split `llama_cpp.locate()` out of `provision()` so deploy never downloads; still non-fatal.
- `provisioned_variants()` filters non-variant directory names and skips the recursive size walk, which stays in `mship info`.

