### PR TITLE
feat: deploy a single model from CLI flags instead of models.yaml

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,9 +191,30 @@ See [Monitoring & Logging](docs/monitoring.md) for full details.
 Modelship is actively used and designed for stability in multi-tenant setups. Key guarantees include:
 
 - **Mutex-backed deployments:** A cluster-wide deploy coordinator prevents VRAM exhaustion by ensuring models are never loaded concurrently if resources are tight.
-- **Comprehensive HTTP-level tests:** The `tests/test_*_integration.py` suites validate chat, reasoning, tool-calling, and streaming across all loaders using real (small) models.
+- **Comprehensive HTTP-level tests:** The `tests/test_*_integration.py` suites validate chat, reasoning, tool-calling, and streaming across all loaders using real (small) models — plus the cluster behaviour below.
 - **Security:** Gateway API-key auth, opt-in Ray cluster token auth, and payload/concurrency limits (`MSHIP_MAX_REQUEST_BODY_BYTES`) guard against unauthenticated or oversized requests.
 - **Observability:** Deep integration with Prometheus, OpenTelemetry, and structured logging, with a pre-built Grafana dashboard and Prometheus alerting rules included.
+
+### Verified cluster behaviour
+
+Every row below is asserted end-to-end against a **live cluster with real models over real HTTP** — no mocks, no stubs. Run them with `pytest tests/ -m integration` (or a single area via its marker, e.g. `-m blue_green`).
+
+| Capability | What the cluster guarantees | Proven by |
+|---|---|---|
+| **Zero-downtime model cutover** | Change a live model's config and the swap is atomic: traffic is hammered continuously through the cutover with **zero failed requests**, and the old deployment is fully torn down rather than left as a zombie | [`test_blue_green_integration.py`](tests/test_blue_green_integration.py) |
+| **Load-driven autoscaling** | Replicas scale out under sustained concurrency (bounded by `max_replicas`) and scale back to `min_replicas` once load stops — no errors on the way up or down | [`test_autoscaling_integration.py`](tests/test_autoscaling_integration.py) |
+| **Multi-replica gateway convergence** | With multiple gateway replicas, a deploy or removal converges on *every* replica — a removed model 404s on all of them instead of routing into a torn-down deployment | [`test_gateway_ha_integration.py`](tests/test_gateway_ha_integration.py) |
+| **Engine crash recovery** | `SIGKILL` the vLLM engine-core subprocess and the replica respawns and serves again on its own — no operator action, no cluster restart | [`test_crash_recovery_integration.py`](tests/test_crash_recovery_integration.py) |
+| **Authenticated node join / clean leave** | A node joining with a missing or wrong token is rejected; with the right token it joins, and `SIGTERM` removes only that node — the head and its other nodes are untouched | [`test_cluster_join.py`](tests/test_cluster_join.py) |
+| **Fractional GPU multi-tenancy** | Two *different* engines (vLLM at `num_gpus: 0.6`, llama-server at `0.3`) share one physical GPU and serve concurrent traffic without starving each other | [`test_fractional_gpu_sharing.py`](tests/test_fractional_gpu_sharing.py) |
+| **Cross-process disconnect cancellation** | A dropped client socket cancels in-flight inference across the Ray process boundary and frees the GPU; other requests on the same replica are unaffected | [`test_disconnect_integration.py`](tests/test_disconnect_integration.py) |
+| **Per-identity prefix-cache isolation** | An identical prompt from a different identity never hits another identity's KV-cache entry — the cross-tenant timing side channel is closed by construction | [`test_vllm_integration.py`](tests/test_vllm_integration.py) |
+| **Resumable background runs** | A client can disconnect mid-stream; the run continues server-side and the client reconnects with `starting_after` to replay from where it left off through to completion | [`test_responses_integration.py`](tests/test_responses_integration.py) |
+| **Durable conversation state** | Stored `/v1/responses` chains survive deletion of a parent turn, fan out into independent concurrent branches from one parent, and a cancel stays cancelled | [`test_responses_integration.py`](tests/test_responses_integration.py) |
+| **Server-side MCP tool loop** | Real MCP server, discovered and called by the model — including the `require_approval` round trip, background mode, mid-flight cancel that sticks, and an unreachable server surfacing as a `failed` response rather than a 5xx | [`test_mcp_integration.py`](tests/test_mcp_integration.py) |
+| **Real in-replica concurrency** | llama-server `parallel` slots serve concurrent requests genuinely in parallel — N at once complete in well under N× the single-request time, not serialized behind a lock | [`test_llama_server_integration.py`](tests/test_llama_server_integration.py) |
+| **Hot reconcile of the model set** | The entire integration suite swaps the deployed model set repeatedly via `--reconcile` against one long-lived gateway process that is never restarted | [`tests/conftest.py`](tests/conftest.py) |
+| **Cross-loader pipelines** | TTS audio generated by one deployment is fed straight back in as STT input to another, through the same gateway | [`test_audio_integration.py`](tests/test_audio_integration.py) |
 
 We are currently hardening the Kubernetes/KubeRay path (a Helm chart ships in [`helm/`](helm/modelship/); GPU-aware probes and gateway-level rate-limiting are next). See the full [Production Readiness Plan](docs/production-readiness.md) for the scorecard and roadmap.
 

--- a/README.md
+++ b/README.md
@@ -133,6 +133,15 @@ mship bootstrap --thin      # coordinator/head only, no capacity
 mship deploy --config models.yaml
 ```
 
+For a single model, skip the config file — the root-level fields have matching flags, validated by the same schema:
+
+```bash
+mship deploy --model "lmstudio-community/Qwen3-0.6B-GGUF:*Q4_K_M.gguf" \
+             --loader llama_server --usecase generate --num-cpus 3
+```
+
+It serves as `qwen3-0.6b`, inferred from the reference. Several models, or the nested tuning blocks, still need a `models.yaml` — see [Single-model deploys](docs/model-configuration.md#single-model-deploys-no-config-file).
+
 `mship bootstrap` installs a pinned Python 3.12.10 environment for that role and records it, so `deploy` afterwards needs no variant flag and installs nothing — it starts straight through. Nothing to pin and nothing to match across machines: every node lands on the same footing, so a new one joins the cluster by running the same two commands. After a `pip install -U mship`, re-run `mship bootstrap` to move the environment with it.
 
 Platform prerequisites still apply: Xcode Command Line Tools on macOS, `build-essential`/`cmake` on Linux, plus `ninja-build` and NVIDIA's `nvcc` for `--cuda`. Alpine and other musl distros are unsupported. See [docs/install-native.md](docs/install-native.md) for the full list.

--- a/docs/model-configuration.md
+++ b/docs/model-configuration.md
@@ -38,6 +38,49 @@ Reference for `models.yaml` (default: `config/models.yaml`). Each entry under `m
 | `--responses-ttl-s` | `MSHIP_RESPONSES_TTL_S` | `2592000` | TTL in seconds for stored `/v1/responses` conversation state; `<=0` disables expiry |
 | `--state-sweep-interval-s` | `MSHIP_STATE_SWEEP_INTERVAL_S` | `300` | Interval in seconds between expired-key sweeps in the in-memory state store |
 
+### Single-model deploys (no config file)
+
+`--model` deploys one model straight from the command line, no `models.yaml` needed:
+
+```bash
+mship deploy --model lmstudio-community/Qwen3-8B-GGUF:'*Q4_K_M.gguf' \
+             --loader llama_server --usecase generate --num-cpus 4
+```
+
+These flags mirror the root-level fields of a `models:` entry one for one, and are validated by the same schema — anything rejected in the file is rejected here, with the same message:
+
+| Flag | Field |
+|---|---|
+| `--model` | `model` |
+| `--name` | `name` (inferred from `--model` when omitted) |
+| `--usecase` | `usecase` |
+| `--loader` | `loader` |
+| `--num-gpus` | `num_gpus` |
+| `--num-cpus` | `num_cpus` |
+| `--num-replicas` | `num_replicas` |
+| `--max-ongoing-requests` | `max_ongoing_requests` |
+
+Limits:
+
+- **One model per invocation.** Use `--config` for several. A second `mship deploy --model ...` against a running cluster adds to it (the default additive merge), so models can also be added one at a time.
+- **No nested blocks.** `vllm_engine_kwargs`, `llama_server_config`, `autoscaling_config`, `diffusers_config`, `stable_diffusion_cpp_config`, `whispercpp_config` and `chat_template_kwargs` have no flags — those need a config file. Preflight still auto-sizes the model, so most deploys don't need them.
+- **`--model` and `--config` are mutually exclusive.** With `--model`, the default `config/models.yaml` is ignored entirely.
+
+#### Inferred names
+
+With no `--name`, the name clients call the model by comes from the `model` reference — its basename (or the filename stem for a local weight file), minus GGUF and quantization decoration. The selector is ignored: it picks a quant, it doesn't identify the model.
+
+| `--model` | Inferred `name` |
+|---|---|
+| `lmstudio-community/Qwen3-8B-GGUF:*Q4_K_M.gguf` | `qwen3-8b` |
+| `bartowski/Llama-3.3-70B-Instruct-GGUF:*Q8_0*-of-*.gguf` | `llama-3.3-70b-instruct` |
+| `Qwen/Qwen3-8B` | `qwen3-8b` |
+| `/models/qwen3-8b-instruct.Q4_K_M.gguf` | `qwen3-8b-instruct` |
+| `~/models/Qwen3-8B/` | `qwen3-8b` |
+| `base.en` | `base.en` |
+
+Inference is deterministic, so re-running the same command is idempotent. It also means two different references can infer the same name — deploying `Qwen/Qwen3-8B` on `vllm` and then a `Qwen3-8B` GGUF on `llama_server` both resolve to `qwen3-8b`, and the second **replaces** the first, since a name maps to exactly one deployment. That is what you want when swapping a model's loader; pass `--name` to run both side by side.
+
 ### Cache directory structure
 
 Under `MSHIP_CACHE_DIR` (default `/.cache`):

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -26,6 +26,21 @@ docker run --rm --shm-size=8g \
 Images are multi-arch (amd64 + arm64), so this works on Apple Silicon and ARM
 Linux hosts too.
 
+!!! tip "No config file needed"
+    A single model can skip `models.yaml` entirely — the root-level fields have
+    matching flags, validated by the same schema:
+
+    ```bash
+    docker run --rm --shm-size=8g -v ./models-cache:/.cache -p 8000:8000 \
+      ghcr.io/modelship-ai/modelship:latest-cpu deploy \
+      --model "lmstudio-community/Qwen3-0.6B-GGUF:*Q4_K_M.gguf" \
+      --loader llama_server --usecase generate --num-cpus 3
+    ```
+
+    It serves as `qwen3-0.6b`, inferred from the reference. The nested tuning
+    blocks (`llama_server_config` above) still need a file — see
+    [Single-model deploys](model-configuration.md#single-model-deploys-no-config-file).
+
 Once the server is up (look for `Deployed app 'modelship' successfully`),
 call the **Responses API** and watch the model think:
 

--- a/modelship/deploy/config.py
+++ b/modelship/deploy/config.py
@@ -153,6 +153,7 @@ def resolve_input_models(args: argparse.Namespace) -> list[dict] | None:
 
     Ray-free, so the launcher can validate the result before importing ray.
     """
+    # parse_args rejects this first; kept for callers that build a Namespace directly.
     if args.model is not None and args.config is not None:
         raise ValueError(
             "--model and --config are mutually exclusive: --model deploys a single model, "

--- a/modelship/deploy/config.py
+++ b/modelship/deploy/config.py
@@ -1,3 +1,4 @@
+import argparse
 import os
 from pathlib import Path
 
@@ -6,6 +7,7 @@ from pydantic_yaml import parse_yaml_raw_as
 
 from modelship.logging import get_logger
 from modelship.utils import is_pathy
+from modelship.utils.cli import model_from_args
 from modelship.utils.config_schema import ModelLoader, ModelshipConfig
 
 logger = get_logger("startup")
@@ -134,6 +136,31 @@ def resolve_all_model_sources(yml_conf: ModelshipConfig) -> None:
 
 
 def config_absent(arg_path: str | None) -> bool:
-    """True when there's nothing to load: no ``--config`` and no default file.
+    """True when there's no file to load: no ``--config`` and no default file.
     An explicit ``--config`` that doesn't exist is still a hard error."""
     return arg_path is None and not default_config_path().exists()
+
+
+def validate_models(raw_models: list[dict]) -> ModelshipConfig:
+    """Validate raw model dicts into a ModelshipConfig. The single validation
+    entry point: models.yaml and the ``--model`` flags both land here."""
+    return ModelshipConfig.model_validate({"models": raw_models})
+
+
+def resolve_input_models(args: argparse.Namespace) -> list[dict] | None:
+    """The raw model dicts this invocation asks for, or None when it asks for
+    none. ``--model`` describes one entry; otherwise models.yaml supplies them.
+
+    Ray-free, so the launcher can validate the result before importing ray.
+    """
+    if args.model is not None and args.config is not None:
+        raise ValueError(
+            "--model and --config are mutually exclusive: --model deploys a single model, "
+            "--config deploys the set in a models.yaml. Add the model to the file instead."
+        )
+    cli_model = model_from_args(args)
+    if cli_model is not None:
+        return [cli_model]
+    if config_absent(args.config):
+        return None
+    return load_raw_models(args.config)

--- a/modelship/deploy/config.py
+++ b/modelship/deploy/config.py
@@ -142,8 +142,8 @@ def config_absent(arg_path: str | None) -> bool:
 
 
 def validate_models(raw_models: list[dict]) -> ModelshipConfig:
-    """Validate raw model dicts into a ModelshipConfig. The single validation
-    entry point: models.yaml and the ``--model`` flags both land here."""
+    """Validate raw model dicts into a ModelshipConfig. Both models.yaml and the
+    ``--model`` flags land here."""
     return ModelshipConfig.model_validate({"models": raw_models})
 
 

--- a/modelship/deploy/effective_config.py
+++ b/modelship/deploy/effective_config.py
@@ -17,6 +17,7 @@ This is the deploy-domain layer over the generic ``modelship.state`` store.
 
 from typing import Literal
 
+from modelship.deploy.config import validate_models
 from modelship.infer.infer_config import ModelshipConfig, ModelshipModelConfig
 from modelship.logging import get_logger
 from modelship.state import StateStore
@@ -91,11 +92,26 @@ def merge(
             continue
         prior_dep_name = dep_name_by_model_name.get(model_name)
         if prior_dep_name is not None:
-            del merged[prior_dep_name]
+            _log_replacement(model_name, merged.pop(prior_dep_name), d)
         merged[dep_name] = d
         dep_name_by_model_name[model_name] = dep_name
 
     return list(merged.values())
+
+
+def _log_replacement(model_name: str, prior: dict, incoming: dict) -> None:
+    """A name already in the effective set is replaced, not joined. Pointing it at
+    different weights is worth a warning; any other config change is routine."""
+    if prior.get("model") == incoming.get("model"):
+        logger.info("Model %r config changed; replacing the existing deployment.", model_name)
+        return
+    logger.warning(
+        "Model %r is already deployed from %r and will be REPLACED by %r — one model name maps to "
+        "exactly one deployment. Give one of them a distinct name to run both side by side.",
+        model_name,
+        prior.get("model"),
+        incoming.get("model"),
+    )
 
 
 def deployment_names(raw_models: list[dict], gateway_name: str) -> set[str]:
@@ -109,7 +125,7 @@ def deployment_names(raw_models: list[dict], gateway_name: str) -> set[str]:
 
 def to_config(raw_models: list[dict]) -> ModelshipConfig:
     """Validate raw model dicts into a ModelshipConfig for the deploy path."""
-    return ModelshipConfig.model_validate({"models": raw_models})
+    return validate_models(raw_models)
 
 
 def read_effective(store: StateStore, gateway_name: str) -> list[dict]:

--- a/modelship/driver.py
+++ b/modelship/driver.py
@@ -40,9 +40,8 @@ def main(argv: list[str] | None = None) -> None:
 
     from modelship.deploy.actor_options import build_deployment_options, total_gpu_reservation
     from modelship.deploy.config import (
-        config_absent,
-        load_raw_models,
         resolve_all_model_sources,
+        resolve_input_models,
     )
     from modelship.deploy.effective_config import (
         deployment_names,
@@ -194,23 +193,22 @@ def main(argv: list[str] | None = None) -> None:
     ensure_key_seeded(store)
     effective_raw = read_effective(store, gateway_name)
 
-    # No --config: self-heal (reconcile) reconciles live->effective; a join or a bare
-    # bootstrap do the same no-op merge and wait for a later --config/--reconcile/join.
-    if args.config is None and (mode == "reconcile" or joined_cluster):
+    # No input named: self-heal (reconcile) reconciles live->effective; a join or a
+    # bare bootstrap do the same no-op merge and wait for a later config/join.
+    if args.config is None and args.model is None and (mode == "reconcile" or joined_cluster):
         desired_raw = effective_raw
         logger.info(
-            "Self-heal: reconciling to persisted effective config (no --config given)."
+            "Self-heal: reconciling to persisted effective config (no --config/--model given)."
             if not joined_cluster
             else "Join: no config given — contributing resources, reconciling to effective set."
         )
-    elif config_absent(args.config):
+    elif (input_raw := resolve_input_models(args)) is None:
         desired_raw = effective_raw
         logger.info(
-            "No --config given and no default config/models.yaml found — bootstrapping an empty "
-            "coordinator; it will wait for capacity/models via a later --config, --reconcile, or join."
+            "No --config/--model given and no default config/models.yaml found — bootstrapping an "
+            "empty coordinator; it will wait for capacity/models via a later config or join."
         )
     else:
-        input_raw = load_raw_models(args.config)
         desired_raw = merge(effective_raw, input_raw, gateway_name, mode)
     yml_conf = to_config(desired_raw)
     logger.debug("Deploying effective config (%s mode, %d model(s)): %s", mode, len(desired_raw), yml_conf)

--- a/modelship/infer/model_resolver.py
+++ b/modelship/infer/model_resolver.py
@@ -1,5 +1,4 @@
 import fnmatch
-import os
 from pathlib import Path
 from typing import NamedTuple
 
@@ -7,7 +6,16 @@ from huggingface_hub import hf_hub_download, model_info, snapshot_download
 from tqdm.asyncio import tqdm_asyncio
 
 from modelship.logging import get_logger
-from modelship.utils import is_pathy
+from modelship.utils.model_ref import ResolvedSource, parse_model_ref
+
+__all__ = [
+    "ModelDownloadError",
+    "PinnedSource",
+    "ResolvedSource",
+    "check_model_source",
+    "download_model_source",
+    "parse_model_ref",
+]
 
 logger = get_logger("startup")
 
@@ -31,41 +39,6 @@ class ModelDownloadError(Exception):
     downloaded (network blip, transient HF error, disk full, ...). Kept
     distinct from `check_model_source`'s errors so `ModelDeployment` treats
     it as transient rather than fatal."""
-
-
-class ResolvedSource(NamedTuple):
-    """Result of parsing a model reference."""
-
-    source: str  # repo_id or local path
-    selector: str | None  # filename or glob pattern
-    is_local: bool
-
-
-def _expand(s: str) -> str:
-    """expanduser only for pathy strings — Path.resolve() never expands `~`,
-    so this must happen here or a valid `~/...` ref 404s downstream."""
-    return os.path.expanduser(s) if is_pathy(s) else s
-
-
-def parse_model_ref(model: str) -> ResolvedSource:
-    """Parses model string into (source, selector, is_local).
-
-    Path-first: if the literal full string is an existing local path, treat it
-    as one (covers the rare colon-in-filename case). Otherwise split on the
-    first ':' — the part before is the source, the part after is the selector.
-
-    A pathy source (starts with /, ./, or ~) is always local regardless of
-    whether it exists, so a missing path fails clearly downstream instead of
-    being misread as an HF repo id. `~` is expanded in the returned source."""
-    expanded = _expand(model)
-    if is_pathy(model) and Path(expanded).exists():
-        return ResolvedSource(source=expanded, selector=None, is_local=True)
-
-    if ":" in model:
-        source, selector = model.split(":", 1)
-        return ResolvedSource(source=_expand(source), selector=selector, is_local=is_pathy(source))
-
-    return ResolvedSource(source=expanded, selector=None, is_local=is_pathy(model))
 
 
 def _select_patterns(repo_files: list[str], trust_remote_code: bool = False) -> list[str] | None:

--- a/modelship/launcher.py
+++ b/modelship/launcher.py
@@ -5,9 +5,11 @@ Ray-free until it hands off to modelship.driver.
 
 from __future__ import annotations
 
+import argparse
 import importlib.util
 import os
 import platform
+import re
 import sys
 from typing import TYPE_CHECKING
 
@@ -18,6 +20,8 @@ from modelship.utils.accelerator import detect_accelerator
 from modelship.utils.cache import resolve_cache_root
 
 if TYPE_CHECKING:
+    from pydantic import ValidationError
+
     from modelship.utils.config_schema import ModelshipConfig
 
 _REQUIRED_PYTHON = (3, 12, 10)
@@ -44,7 +48,7 @@ def _cmd_deploy(argv: list[str]) -> None:
     os.environ.setdefault("MSHIP_CACHE_DIR", resolve_cache_root())
     _guard_python_version()
 
-    config = _validate_config(args.config)
+    config = _validate_config(args)
     if config is not None and _is_own_head_deploy():
         _check_loader_capabilities({m.loader.value for m in config.models})
 
@@ -98,20 +102,30 @@ def _advertises_no_capacity() -> bool:
     return not any(reserved)
 
 
-def _validate_config(config_path: str | None) -> ModelshipConfig | None:
-    """Validate models.yaml before the driver imports ray. None when there is
-    no config to load."""
+def _validate_config(args: argparse.Namespace) -> ModelshipConfig | None:
+    """Validate the requested models before the driver imports ray. None when
+    the invocation asks for none."""
     from pydantic import ValidationError
 
-    from modelship.deploy.config import config_absent, load_yaml_config
+    from modelship.deploy.config import resolve_input_models, validate_models
 
-    if config_absent(config_path):
-        return None
     try:
-        return load_yaml_config(config_path)
-    except (FileNotFoundError, ValidationError, yaml.YAMLError, ValueError) as e:
+        raw_models = resolve_input_models(args)
+        if raw_models is None:
+            return None
+        return validate_models(raw_models)
+    except ValidationError as e:
+        print(f"error: invalid config: {_flagged(e) if args.model else e}", file=sys.stderr)
+        sys.exit(1)
+    except (FileNotFoundError, yaml.YAMLError, ValueError) as e:
         print(f"error: invalid config: {e}", file=sys.stderr)
         sys.exit(1)
+
+
+def _flagged(error: ValidationError) -> str:
+    """Rewrite pydantic's `models.0.<field>` locations as `--<field>` so a
+    single-model deploy reports its own flags, not a models.yaml shape."""
+    return re.sub(r"\bmodels\.\d+\.([a-z_]+)", lambda m: f"--{m.group(1).replace('_', '-')}", str(error))
 
 
 def _check_loader_capabilities(loaders: set[str]) -> None:

--- a/modelship/utils/cli.py
+++ b/modelship/utils/cli.py
@@ -4,8 +4,34 @@ from __future__ import annotations
 
 import argparse
 import os
+import re
+from pathlib import Path
 
 from modelship.utils import parse_memory_bytes
+from modelship.utils.config_schema import ModelLoader, ModelUsecase
+from modelship.utils.model_ref import parse_model_ref
+
+# The models.yaml keys the model flags surface, in config-key form. Single
+# source of truth for what a --model deploy can express.
+MODEL_ARG_KEYS = (
+    "name",
+    "model",
+    "usecase",
+    "loader",
+    "num_gpus",
+    "num_cpus",
+    "num_replicas",
+    "max_ongoing_requests",
+)
+
+# Marks a `--model` path as a file rather than a directory when it doesn't
+# exist yet, so name inference can still take the stem.
+_WEIGHT_SUFFIXES = (".gguf", ".safetensors", ".bin")
+
+_GGUF_REPO_SUFFIX = "-gguf"
+
+# A trailing quant token in a weight filename: Q4_K_M, Q8_0, IQ4_XS, F16, BF16.
+_QUANT_SEGMENT = re.compile(r"^(?:i?q\d+|bf\d+|f\d+)(?:[_-]\w+)*$", re.IGNORECASE)
 
 # Maps argparse attribute names to the env vars they override. CLI flags take
 # precedence over env vars; downstream code (Ray init, logging, gateway start)
@@ -208,7 +234,89 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
             "stop_start: drop old first, then deploy new (brief unavailability, no overlap)."
         ),
     )
+    _add_model_args(parser)
     return parser.parse_args(argv)
+
+
+def _add_model_args(parser: argparse.ArgumentParser) -> None:
+    """The models.yaml root-level scalars, as flags for a single-model deploy.
+
+    None is `required`: unset flags are dropped from the raw dict, leaving the
+    schema to raise requiredness for both surfaces.
+    """
+    group = parser.add_argument_group(
+        "single-model deploy",
+        "Deploy one model with no config file. Use --config for several models, or for "
+        "the nested tuning blocks (vllm_engine_kwargs, llama_server_config, "
+        "autoscaling_config, ...), which have no flags.",
+    )
+    group.add_argument(
+        "--model",
+        help=(
+            "Model reference: an HF repo id, a repo id with a file selector "
+            "(repo:*Q4_K_M.gguf), or a local file/directory path. Mutually exclusive "
+            "with --config."
+        ),
+    )
+    group.add_argument("--name", help="Model name clients call it by (default: inferred from --model)")
+    group.add_argument("--usecase", choices=[u.value for u in ModelUsecase])
+    group.add_argument("--loader", choices=[loader.value for loader in ModelLoader])
+    group.add_argument("--num-gpus", type=float, help="GPUs to reserve; a fraction < 1 shares one GPU")
+    group.add_argument("--num-cpus", type=float, help="CPUs to reserve (default: 0.1)")
+    group.add_argument("--num-replicas", type=int, help="Fixed replica count (default: 1)")
+    group.add_argument("--max-ongoing-requests", type=int, help="Per-replica concurrency cap")
+
+
+def model_from_args(args: argparse.Namespace) -> dict | None:
+    """The raw models.yaml entry `--model` describes, or None when it's absent.
+
+    Unset flags are omitted, not defaulted — validators branch on
+    `model_fields_set`, so a materialized default validates differently.
+    """
+    if args.model is None:
+        return None
+
+    raw: dict = {"name": args.name if args.name is not None else infer_model_name(args.model)}
+    for key in MODEL_ARG_KEYS:
+        if key == "name":
+            continue
+        value = getattr(args, key, None)
+        if value is not None:
+            raw[key] = value
+    return raw
+
+
+def infer_model_name(model: str) -> str:
+    """Model name for a `--model` ref given no `--name`: the source's basename, or
+    its stem for a weight file, minus GGUF and quant decoration. The selector is
+    ignored; it picks a quant rather than identifying the model."""
+    ref = parse_model_ref(model)
+    base = os.path.basename(ref.source.rstrip("/"))
+
+    if ref.is_local and (Path(ref.source).is_file() or Path(base).suffix.lower() in _WEIGHT_SUFFIXES):
+        base = _strip_quant(Path(base).stem)
+    elif base.lower().endswith(_GGUF_REPO_SUFFIX):
+        base = base[: -len(_GGUF_REPO_SUFFIX)]
+
+    name = _sanitize_name(base)
+    if not name:
+        raise ValueError(f"cannot infer a model name from --model {model!r}; pass --name explicitly.")
+    return name
+
+
+def _strip_quant(stem: str) -> str:
+    """Drop trailing quant segments from a weight-file stem: qwen3-8b.Q4_K_M -> qwen3-8b."""
+    parts = stem.split(".")
+    while len(parts) > 1 and _QUANT_SEGMENT.match(parts[-1]):
+        parts.pop()
+    return ".".join(parts)
+
+
+def _sanitize_name(base: str) -> str:
+    """Lowercase and reduce to characters safe in a Serve app name and an OpenAI
+    `model` field. Capped short of the fingerprint the deployment name appends."""
+    name = re.sub(r"[^a-z0-9._-]+", "-", base.lower())
+    return re.sub(r"-{2,}", "-", name).strip("-._")[:63].strip("-._")
 
 
 def apply_args_to_env(args: argparse.Namespace) -> None:

--- a/modelship/utils/cli.py
+++ b/modelship/utils/cli.py
@@ -235,7 +235,15 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         ),
     )
     _add_model_args(parser)
-    return parser.parse_args(argv)
+    args = parser.parse_args(argv)
+    if args.model is not None and args.config is not None:
+        # Rejected here rather than in resolve_input_models so both entry points fail
+        # before the driver starts a Ray head.
+        parser.error(
+            "--model and --config are mutually exclusive: --model deploys a single model, "
+            "--config deploys the set in a models.yaml. Add the model to the file instead."
+        )
+    return args
 
 
 def _add_model_args(parser: argparse.ArgumentParser) -> None:

--- a/modelship/utils/model_ref.py
+++ b/modelship/utils/model_ref.py
@@ -1,0 +1,44 @@
+"""Model-reference parsing. Must stay ray-free and huggingface_hub-free — the
+pre-ray CLI path parses refs before the driver imports either.
+"""
+
+import os
+from pathlib import Path
+from typing import NamedTuple
+
+from modelship.utils import is_pathy
+
+
+class ResolvedSource(NamedTuple):
+    """Result of parsing a model reference."""
+
+    source: str  # repo_id or local path
+    selector: str | None  # filename or glob pattern
+    is_local: bool
+
+
+def expand(s: str) -> str:
+    """expanduser only for pathy strings — Path.resolve() never expands `~`,
+    so this must happen here or a valid `~/...` ref 404s downstream."""
+    return os.path.expanduser(s) if is_pathy(s) else s
+
+
+def parse_model_ref(model: str) -> ResolvedSource:
+    """Parses model string into (source, selector, is_local).
+
+    Path-first: if the literal full string is an existing local path, treat it
+    as one (covers the rare colon-in-filename case). Otherwise split on the
+    first ':' — the part before is the source, the part after is the selector.
+
+    A pathy source (starts with /, ./, or ~) is always local regardless of
+    whether it exists, so a missing path fails clearly downstream instead of
+    being misread as an HF repo id. `~` is expanded in the returned source."""
+    expanded = expand(model)
+    if is_pathy(model) and Path(expanded).exists():
+        return ResolvedSource(source=expanded, selector=None, is_local=True)
+
+    if ":" in model:
+        source, selector = model.split(":", 1)
+        return ResolvedSource(source=expand(source), selector=selector, is_local=is_pathy(source))
+
+    return ResolvedSource(source=expanded, selector=None, is_local=is_pathy(model))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,6 +12,7 @@ import pytest
 import yaml
 
 import modelship.infer.infer_config as infer_config
+from modelship.utils.cli import MODEL_ARG_KEYS
 from openai import OpenAI
 
 
@@ -214,9 +215,28 @@ MODEL_CONFIGS: dict[str, dict] = {
 }
 
 
+def cli_expressible(config: dict) -> bool:
+    """Whether `--model` and friends can express this entry. The CLI surfaces only
+    the root-level scalars, so anything with a nested tuning block deploys from a
+    file. `MODEL_ARG_KEYS` is the CLI's own list, so this can't drift from it."""
+    return set(config) <= set(MODEL_ARG_KEYS)
+
+
+def _model_flags(config: dict) -> list[str]:
+    flags: list[str] = []
+    for key, value in config.items():
+        flags += [f"--{key.replace('_', '-')}", str(value)]
+    return flags
+
+
 class _Deployer:
-    """Writes a one-shot models.yaml for the requested set and runs `mship_deploy.py
-    --reconcile` against the running gateway; re-deploying the same set is a no-op."""
+    """Runs `mship_deploy.py --reconcile` against the running gateway to swap the
+    deployed set; re-deploying the same set is a no-op.
+
+    Deploys a lone CLI-expressible model through the `--model` flags and everything
+    else through a one-shot models.yaml, so both input surfaces are exercised by the
+    same tests rather than by a separate CLI-only suite.
+    """
 
     def __init__(self, tmp_dir: Path) -> None:
         self._tmp = tmp_dir
@@ -228,22 +248,47 @@ class _Deployer:
             return
 
         slug = "+".join(sorted(wanted)) or "empty"
-        config_path = self._tmp / f"models-{slug}.yaml"
-        log_path = self._tmp / f"reconcile-{slug}.log"
-        with open(config_path, "w") as f:
-            yaml.dump({"models": [MODEL_CONFIGS[n] for n in sorted(wanted)]}, f)
+        configs = [MODEL_CONFIGS[n] for n in sorted(wanted)]
+        if len(configs) == 1 and cli_expressible(configs[0]):
+            input_args = _model_flags(configs[0])
+        else:
+            input_args = ["--config", str(self._write_config(f"models-{slug}.yaml", configs))]
 
+        self._run(input_args, slug, "stop_start")
+        self._current = wanted
+
+    def deploy_raw(self, models: list[dict], *, replace_strategy: str = "stop_start") -> None:
+        """Like deploy(), but takes raw model dicts directly and lets the caller pick
+        --replace-strategy; resets self._current since this bypasses the by-name cache."""
+        slug = "raw-" + ("+".join(sorted(m["name"] for m in models)) or "empty")
+        config_path = self._write_config(f"models-{slug}-{replace_strategy}.yaml", models)
+        self._current = frozenset()
+        self._run(["--config", str(config_path)], slug, replace_strategy)
+
+    def deploy_cli(self, *flags: str) -> None:
+        """Deploy straight from `--model` flags, for cases MODEL_CONFIGS can't name
+        (an inferred model name). Resets the by-name cache like deploy_raw."""
+        self._current = frozenset()
+        self._run(list(flags), "cli", "stop_start")
+
+    def _write_config(self, filename: str, models: list[dict]) -> Path:
+        config_path = self._tmp / filename
+        with open(config_path, "w") as f:
+            yaml.dump({"models": models}, f)
+        return config_path
+
+    def _run(self, input_args: list[str], slug: str, replace_strategy: str) -> None:
+        log_path = self._tmp / f"reconcile-{slug}-{replace_strategy}.log"
         with open(log_path, "w") as log_file:
             result = subprocess.run(
                 [
                     "uv",
                     "run",
                     "mship_deploy.py",
-                    "--config",
-                    str(config_path),
+                    *input_args,
                     "--reconcile",
                     "--replace-strategy",
-                    "stop_start",
+                    replace_strategy,
                     "--prune-ray-sessions",
                     "false",
                     # Attach to mship_cluster's already-running head instead of starting a second one.
@@ -254,44 +299,6 @@ class _Deployer:
                 check=False,
                 timeout=900,
             )
-        if result.returncode != 0:
-            tail = log_path.read_text()[-4000:]
-            pytest.fail(
-                f"mship_deploy --reconcile failed for {slug} (exit {result.returncode}).\n"
-                f"Log file: {log_path}\nLast 4KB:\n{tail}"
-            )
-        self._current = wanted
-
-    def deploy_raw(self, models: list[dict], *, replace_strategy: str = "stop_start") -> None:
-        """Like deploy(), but takes raw model dicts directly and lets the caller pick
-        --replace-strategy; resets self._current since this bypasses the by-name cache."""
-        slug = "+".join(sorted(m["name"] for m in models)) or "empty"
-        config_path = self._tmp / f"models-raw-{slug}-{replace_strategy}.yaml"
-        log_path = self._tmp / f"reconcile-raw-{slug}-{replace_strategy}.log"
-        with open(config_path, "w") as f:
-            yaml.dump({"models": models}, f)
-
-        with open(log_path, "w") as log_file:
-            result = subprocess.run(
-                [
-                    "uv",
-                    "run",
-                    "mship_deploy.py",
-                    "--config",
-                    str(config_path),
-                    "--reconcile",
-                    "--replace-strategy",
-                    replace_strategy,
-                    "--prune-ray-sessions",
-                    "false",
-                    "--use-existing-ray-cluster",
-                ],
-                stdout=log_file,
-                stderr=subprocess.STDOUT,
-                check=False,
-                timeout=900,
-            )
-        self._current = frozenset()
         if result.returncode != 0:
             tail = log_path.read_text()[-4000:]
             pytest.fail(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -216,9 +216,8 @@ MODEL_CONFIGS: dict[str, dict] = {
 
 
 def cli_expressible(config: dict) -> bool:
-    """Whether `--model` and friends can express this entry. The CLI surfaces only
-    the root-level scalars, so anything with a nested tuning block deploys from a
-    file. `MODEL_ARG_KEYS` is the CLI's own list, so this can't drift from it."""
+    """Whether the model flags can express this entry: they carry only the
+    root-level scalars, so a nested tuning block means a config file."""
     return set(config) <= set(MODEL_ARG_KEYS)
 
 
@@ -231,11 +230,8 @@ def _model_flags(config: dict) -> list[str]:
 
 class _Deployer:
     """Runs `mship_deploy.py --reconcile` against the running gateway to swap the
-    deployed set; re-deploying the same set is a no-op.
-
-    Deploys a lone CLI-expressible model through the `--model` flags and everything
-    else through a one-shot models.yaml, so both input surfaces are exercised by the
-    same tests rather than by a separate CLI-only suite.
+    deployed set; re-deploying the same set is a no-op. A lone CLI-expressible model
+    goes through the `--model` flags, everything else through a one-shot models.yaml.
     """
 
     def __init__(self, tmp_dir: Path) -> None:
@@ -266,8 +262,8 @@ class _Deployer:
         self._run(["--config", str(config_path)], slug, replace_strategy)
 
     def deploy_cli(self, *flags: str) -> None:
-        """Deploy straight from `--model` flags, for cases MODEL_CONFIGS can't name
-        (an inferred model name). Resets the by-name cache like deploy_raw."""
+        """Deploy straight from `--model` flags. Resets the by-name cache, as
+        deploy_raw does."""
         self._current = frozenset()
         self._run(list(flags), "cli", "stop_start")
 

--- a/tests/test_cli_model_args.py
+++ b/tests/test_cli_model_args.py
@@ -1,0 +1,181 @@
+"""The `--model` flags must produce a models.yaml entry indistinguishable from the
+hand-written one, so a single schema validates both surfaces."""
+
+import subprocess
+import sys
+from unittest.mock import patch
+
+import pytest
+from pydantic import ValidationError
+
+from modelship.deploy.config import resolve_input_models, validate_models
+from modelship.utils.cli import MODEL_ARG_KEYS, infer_model_name, model_from_args, parse_args
+
+
+def _args(*argv):
+    return parse_args(list(argv))
+
+
+def _raw(*argv):
+    return model_from_args(_args(*argv))
+
+
+class TestParityWithYaml:
+    def test_fingerprint_and_fields_set_match_the_yaml_entry(self):
+        yaml_entry = {
+            "name": "qwen",
+            "model": "lmstudio-community/Qwen3-8B-GGUF:*Q4_K_M.gguf",
+            "usecase": "generate",
+            "loader": "llama_server",
+            "num_cpus": 3.0,
+        }
+        cli_entry = _raw(
+            "--model",
+            "lmstudio-community/Qwen3-8B-GGUF:*Q4_K_M.gguf",
+            "--name",
+            "qwen",
+            "--usecase",
+            "generate",
+            "--loader",
+            "llama_server",
+            "--num-cpus",
+            "3",
+        )
+        assert cli_entry == yaml_entry
+
+        from_yaml = validate_models([yaml_entry]).models[0]
+        from_cli = validate_models([cli_entry]).models[0]
+        assert from_cli.fingerprint() == from_yaml.fingerprint()
+        assert from_cli.model_fields_set == from_yaml.model_fields_set
+
+    def test_unset_flags_are_omitted_not_defaulted(self):
+        raw = _raw("--model", "Qwen/Qwen3-8B", "--usecase", "generate", "--loader", "vllm")
+        assert raw == {"name": "qwen3-8b", "model": "Qwen/Qwen3-8B", "usecase": "generate", "loader": "vllm"}
+        assert validate_models([raw]).models[0].model_fields_set == {"name", "model", "usecase", "loader"}
+
+    def test_num_replicas_left_unset_does_not_block_autoscaling(self):
+        """The check rejects num_replicas alongside autoscaling_config via
+        model_fields_set — a materialized CLI default would trip it."""
+        raw = _raw("--model", "Qwen/Qwen3-8B", "--usecase", "generate", "--loader", "vllm")
+        merged = {**raw, "autoscaling_config": {"min_replicas": 1, "max_replicas": 3}}
+        validate_models([merged])  # no raise
+
+    def test_image_loader_still_defaults_usecase(self):
+        raw = _raw("--model", "stabilityai/sdxl-turbo", "--loader", "diffusers")
+        assert "usecase" not in raw
+        assert validate_models([raw]).models[0].usecase.value == "image"
+
+    def test_schema_rejects_missing_loader(self):
+        with pytest.raises(ValidationError, match="loader"):
+            validate_models([_raw("--model", "Qwen/Qwen3-8B", "--usecase", "generate")])
+
+    def test_model_arg_keys_covers_every_flag_the_builder_emits(self):
+        raw = _raw(
+            "--model", "Qwen/Qwen3-8B",
+            "--name", "n",
+            "--usecase", "generate",
+            "--loader", "vllm",
+            "--num-gpus", "0.5",
+            "--num-cpus", "2",
+            "--num-replicas", "2",
+            "--max-ongoing-requests", "8",
+        )  # fmt: skip
+        assert set(raw) == set(MODEL_ARG_KEYS)
+
+
+class TestInferModelName:
+    @pytest.mark.parametrize(
+        ("ref", "expected"),
+        [
+            ("lmstudio-community/Qwen3-8B-GGUF:*Q4_K_M.gguf", "qwen3-8b"),
+            ("bartowski/Llama-3.3-70B-Instruct-GGUF:*Q8_0*-of-*.gguf", "llama-3.3-70b-instruct"),
+            ("Qwen/Qwen3-8B", "qwen3-8b"),
+            ("nomic-ai/nomic-embed-text-v1.5-GGUF:nomic-embed-text-v1.5.Q4_K_M.gguf", "nomic-embed-text-v1.5"),
+            ("/models/qwen3-8b-instruct.Q4_K_M.gguf", "qwen3-8b-instruct"),
+            ("/models/Qwen2.5-0.5B-Instruct.IQ4_XS.gguf", "qwen2.5-0.5b-instruct"),
+            ("/models/Qwen3-8B/", "qwen3-8b"),
+            ("./weights/model.f16.gguf", "model"),
+            ("kokoro-en-v0_19", "kokoro-en-v0_19"),
+            ("base.en", "base.en"),
+        ],
+    )
+    def test_inference(self, ref, expected):
+        assert infer_model_name(ref) == expected
+
+    def test_explicit_name_wins(self):
+        assert _raw("--model", "Qwen/Qwen3-8B", "--name", "custom")["name"] == "custom"
+
+    def test_uninferrable_ref_raises(self):
+        with pytest.raises(ValueError, match="pass --name"):
+            infer_model_name("///")
+
+    def test_same_ref_infers_the_same_name(self):
+        """Re-running a deploy must be idempotent: the name is the additive
+        merge's replace-by-name key."""
+        ref = "lmstudio-community/Qwen3-8B-GGUF:*Q4_K_M.gguf"
+        assert infer_model_name(ref) == infer_model_name(ref)
+
+
+class TestResolveInputModels:
+    def test_model_flag_wins_over_the_default_config_file(self, tmp_path):
+        default = tmp_path / "models.yaml"
+        default.write_text("models:\n  - name: from-file\n    model: x.gguf\n    loader: llama_server\n")
+        with patch("modelship.deploy.config.default_config_path", return_value=default):
+            raw = resolve_input_models(_args("--model", "Qwen/Qwen3-8B", "--loader", "vllm", "--usecase", "generate"))
+        assert raw is not None
+        assert [m["name"] for m in raw] == ["qwen3-8b"]
+
+    def test_config_file_is_read_when_no_model_flag(self, tmp_path):
+        config = tmp_path / "models.yaml"
+        config.write_text("models:\n  - name: m\n    model: x.gguf\n    loader: llama_server\n    usecase: generate\n")
+        raw = resolve_input_models(_args("--config", str(config)))
+        assert raw == [{"name": "m", "model": "x.gguf", "loader": "llama_server", "usecase": "generate"}]
+
+    def test_neither_returns_none(self, tmp_path):
+        with patch("modelship.deploy.config.default_config_path", return_value=tmp_path / "nope.yaml"):
+            assert resolve_input_models(_args()) is None
+
+    def test_both_is_rejected(self, tmp_path):
+        config = tmp_path / "models.yaml"
+        config.write_text("models: []\n")
+        with pytest.raises(ValueError, match="mutually exclusive"):
+            resolve_input_models(_args("--model", "Qwen/Qwen3-8B", "--config", str(config)))
+
+
+class TestFailsBeforeRay:
+    def test_bad_model_flag_exits_without_importing_ray(self):
+        code = (
+            "import sys; from modelship.launcher import _cmd_deploy\n"
+            "try:\n"
+            "    _cmd_deploy(['--model', 'Qwen/Qwen3-8B'])\n"
+            "except SystemExit as e:\n"
+            "    print('exit', e.code, 'ray' in sys.modules)\n"
+        )
+        result = subprocess.run([sys.executable, "-c", code], capture_output=True, text=True, check=True)
+        assert result.stdout.strip() == "exit 1 False"
+
+
+class TestIntegrationCliRouting:
+    """The integration suite sends a lone CLI-expressible model through --model.
+    Pin the entries that actually take that route, so a later nested block added to
+    one of them shows up here instead of silently dropping CLI coverage."""
+
+    def test_single_model_call_sites_stay_cli_expressible(self):
+        from tests.conftest import MODEL_CONFIGS, cli_expressible
+
+        routed = {"chat-llama-server-plain", "chat-llama-server-gpu", "embed-model-llama-server"}
+        assert {name for name in routed if cli_expressible(MODEL_CONFIGS[name])} == routed
+
+    def test_nested_blocks_are_not_cli_expressible(self):
+        from tests.conftest import MODEL_CONFIGS, cli_expressible
+
+        assert not cli_expressible(MODEL_CONFIGS["chat-capable"])
+        assert not cli_expressible(MODEL_CONFIGS["autoscale-llama"])
+
+    def test_flags_round_trip_back_to_the_config(self):
+        """conftest builds argv from a MODEL_CONFIGS entry; parsing it back must
+        reproduce that entry, or the CLI-routed tests deploy something else."""
+        from tests.conftest import MODEL_CONFIGS, _model_flags
+
+        config = MODEL_CONFIGS["chat-llama-server-gpu"]
+        assert model_from_args(_args(*_model_flags(config))) == config

--- a/tests/test_cli_model_args.py
+++ b/tests/test_cli_model_args.py
@@ -1,5 +1,5 @@
 """The `--model` flags must produce a models.yaml entry indistinguishable from the
-hand-written one, so a single schema validates both surfaces."""
+hand-written one."""
 
 import subprocess
 import sys
@@ -156,9 +156,8 @@ class TestFailsBeforeRay:
 
 
 class TestIntegrationCliRouting:
-    """The integration suite sends a lone CLI-expressible model through --model.
-    Pin the entries that actually take that route, so a later nested block added to
-    one of them shows up here instead of silently dropping CLI coverage."""
+    """conftest sends a lone CLI-expressible model through --model. Pin the entries
+    that take that route: a nested block added to one fails here, not silently."""
 
     def test_single_model_call_sites_stay_cli_expressible(self):
         from tests.conftest import MODEL_CONFIGS, cli_expressible
@@ -174,7 +173,7 @@ class TestIntegrationCliRouting:
 
     def test_flags_round_trip_back_to_the_config(self):
         """conftest builds argv from a MODEL_CONFIGS entry; parsing it back must
-        reproduce that entry, or the CLI-routed tests deploy something else."""
+        reproduce that entry."""
         from tests.conftest import MODEL_CONFIGS, _model_flags
 
         config = MODEL_CONFIGS["chat-llama-server-gpu"]

--- a/tests/test_cli_model_args.py
+++ b/tests/test_cli_model_args.py
@@ -135,11 +135,19 @@ class TestResolveInputModels:
         with patch("modelship.deploy.config.default_config_path", return_value=tmp_path / "nope.yaml"):
             assert resolve_input_models(_args()) is None
 
-    def test_both_is_rejected(self, tmp_path):
+    def test_both_is_rejected_at_parse_time(self, tmp_path, capsys):
         config = tmp_path / "models.yaml"
         config.write_text("models: []\n")
+        with pytest.raises(SystemExit) as exc:
+            _args("--model", "Qwen/Qwen3-8B", "--config", str(config))
+        assert exc.value.code == 2
+        assert "mutually exclusive" in capsys.readouterr().err
+
+    def test_both_is_rejected_for_a_hand_built_namespace(self, tmp_path):
+        args = _args("--config", str(tmp_path / "models.yaml"))
+        args.model = "Qwen/Qwen3-8B"
         with pytest.raises(ValueError, match="mutually exclusive"):
-            resolve_input_models(_args("--model", "Qwen/Qwen3-8B", "--config", str(config)))
+            resolve_input_models(args)
 
 
 class TestFailsBeforeRay:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -665,18 +665,21 @@ class TestAutoscalingConfig:
 
 class TestPreRayImportChain:
     """These modules run before resolve_ray_auth_env(), and ray latches RAY_AUTH_MODE at
-    import; subprocess-based since ray is already in sys.modules by suite time."""
+    import; subprocess-based since ray is already in sys.modules by suite time.
+    huggingface_hub latches HF_HOME the same way."""
 
     @pytest.mark.parametrize(
         "module",
         [
+            "modelship.utils.model_ref",
             "modelship.utils.config_schema",
             "modelship.utils.cli",
             "modelship.deploy.config",
             "modelship.launcher",
         ],
     )
-    def test_import_does_not_pull_ray(self, module):
-        code = f"import sys; import {module}; print('ray' in sys.modules)"
+    @pytest.mark.parametrize("heavy", ["ray", "huggingface_hub"])
+    def test_import_stays_light(self, module, heavy):
+        code = f"import sys; import {module}; print({heavy!r} in sys.modules)"
         result = subprocess.run([sys.executable, "-c", code], capture_output=True, text=True, check=True)
-        assert result.stdout.strip() == "False", f"{module} imports ray"
+        assert result.stdout.strip() == "False", f"{module} imports {heavy}"

--- a/tests/test_effective_config.py
+++ b/tests/test_effective_config.py
@@ -50,6 +50,19 @@ class TestMerge:
         merged = merge([a1], [a2], "g", "additive")
         assert merged == [a2]
 
+    def test_replacing_a_name_with_different_weights_warns(self, caplog):
+        vllm = _model("qwen3-8b", model="Qwen/Qwen3-8B", loader="vllm")
+        gguf = _model("qwen3-8b", model="org/Qwen3-8B-GGUF:*Q4_K_M.gguf")
+        with caplog.at_level("WARNING"):
+            merged = merge([vllm], [gguf], "g", "additive")
+        assert merged == [gguf]
+        assert "REPLACED" in caplog.text
+
+    def test_replacing_a_name_with_the_same_weights_does_not_warn(self, caplog):
+        with caplog.at_level("WARNING"):
+            merge([_model("a", num_cpus=1)], [_model("a", num_cpus=2)], "g", "additive")
+        assert caplog.text == ""
+
     def test_additive_rejects_duplicate_name_within_input(self):
         a1 = _model("a", num_cpus=1)
         a2 = _model("a", num_cpus=2)

--- a/tests/test_launcher.py
+++ b/tests/test_launcher.py
@@ -5,6 +5,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from modelship import launcher
+from modelship.utils.cli import parse_args
 
 
 class TestGuardPythonVersion:
@@ -49,19 +50,22 @@ class TestValidateConfig:
         path.write_text(body)
         return str(path)
 
+    def _args(self, *argv):
+        return parse_args(list(argv))
+
     def test_absent_config_returns_none(self, tmp_path):
         with patch("modelship.deploy.config.default_config_path", return_value=tmp_path / "nope.yaml"):
-            assert launcher._validate_config(None) is None
+            assert launcher._validate_config(self._args()) is None
 
     def test_missing_explicit_config_exits(self, tmp_path):
         with pytest.raises(SystemExit) as exc:
-            launcher._validate_config(str(tmp_path / "nope.yaml"))
+            launcher._validate_config(self._args("--config", str(tmp_path / "nope.yaml")))
         assert exc.value.code == 1
 
     def test_unknown_loader_exits(self, tmp_path):
         config = self._write(tmp_path, "models:\n  - name: m\n    loader: nope\n    model: x\n")
         with pytest.raises(SystemExit) as exc:
-            launcher._validate_config(config)
+            launcher._validate_config(self._args("--config", config))
         assert exc.value.code == 1
 
     def test_duplicate_name_exits(self, tmp_path):
@@ -72,14 +76,14 @@ class TestValidateConfig:
             "  - name: m\n    loader: llama_server\n    model: b.gguf\n    usecase: generate\n",
         )
         with pytest.raises(SystemExit) as exc:
-            launcher._validate_config(config)
+            launcher._validate_config(self._args("--config", config))
         assert exc.value.code == 1
 
     def test_valid_config_returns_parsed_models(self, tmp_path):
         config = self._write(
             tmp_path, "models:\n  - name: m\n    loader: llama_server\n    model: x.gguf\n    usecase: generate\n"
         )
-        parsed = launcher._validate_config(config)
+        parsed = launcher._validate_config(self._args("--config", config))
         assert parsed is not None
         assert [m.loader.value for m in parsed.models] == ["llama_server"]
 
@@ -89,8 +93,59 @@ class TestValidateConfig:
         )
         with patch.dict(sys.modules):
             sys.modules.pop("ray", None)
-            launcher._validate_config(config)
+            launcher._validate_config(self._args("--config", config))
             assert "ray" not in sys.modules
+
+
+class TestValidateConfigFromModelFlag:
+    def _args(self, *argv):
+        return parse_args(list(argv))
+
+    def test_model_flag_returns_parsed_model(self):
+        parsed = launcher._validate_config(
+            self._args("--model", "x/y-GGUF:*Q4_K_M.gguf", "--loader", "llama_server", "--usecase", "generate")
+        )
+        assert parsed is not None
+        assert [(m.name, m.loader.value) for m in parsed.models] == [("y", "llama_server")]
+
+    def test_model_with_config_exits(self, tmp_path):
+        config = tmp_path / "models.yaml"
+        config.write_text("models: []\n")
+        with pytest.raises(SystemExit) as exc:
+            launcher._validate_config(self._args("--model", "x/y", "--config", str(config)))
+        assert exc.value.code == 1
+
+    def test_missing_loader_exits(self):
+        with pytest.raises(SystemExit) as exc:
+            launcher._validate_config(self._args("--model", "x/y", "--usecase", "generate"))
+        assert exc.value.code == 1
+
+    def test_fractional_num_gpus_with_whole_gpu_loader_exits(self):
+        with pytest.raises(SystemExit) as exc:
+            launcher._validate_config(
+                self._args(
+                    "--model", "x/y.gguf", "--loader", "llama_server", "--usecase", "generate", "--num-gpus", "1.5"
+                )
+            )
+        assert exc.value.code == 1
+
+
+class TestFlaggedErrors:
+    """Pydantic reports a models.yaml path; a --model deploy has no file to point at."""
+
+    def test_field_paths_become_flags(self, capsys):
+        with pytest.raises(SystemExit):
+            launcher._validate_config(parse_args(["--model", "x/y"]))
+        err = capsys.readouterr().err
+        assert "--usecase" in err and "--loader" in err
+        assert "models.0." not in err
+
+    def test_config_errors_keep_pydantic_paths(self, tmp_path, capsys):
+        config = tmp_path / "models.yaml"
+        config.write_text("models:\n  - name: m\n    model: x\n")
+        with pytest.raises(SystemExit):
+            launcher._validate_config(parse_args(["--config", str(config)]))
+        assert "models.0." in capsys.readouterr().err
 
 
 class TestIsOwnHeadDeploy:

--- a/tests/test_launcher.py
+++ b/tests/test_launcher.py
@@ -108,12 +108,12 @@ class TestValidateConfigFromModelFlag:
         assert parsed is not None
         assert [(m.name, m.loader.value) for m in parsed.models] == [("y", "llama_server")]
 
-    def test_model_with_config_exits(self, tmp_path):
+    def test_model_with_config_exits_at_parse_time(self, tmp_path):
         config = tmp_path / "models.yaml"
         config.write_text("models: []\n")
         with pytest.raises(SystemExit) as exc:
-            launcher._validate_config(self._args("--model", "x/y", "--config", str(config)))
-        assert exc.value.code == 1
+            self._args("--model", "x/y", "--config", str(config))
+        assert exc.value.code == 2
 
     def test_missing_loader_exits(self):
         with pytest.raises(SystemExit) as exc:

--- a/tests/test_llama_server_integration.py
+++ b/tests/test_llama_server_integration.py
@@ -494,7 +494,7 @@ def test_embeddings_llama_server(client, model_deployer):
 @pytest.mark.llama_server
 def test_deploy_with_inferred_model_name(client, model_deployer):
     """`--model` with no `--name`: the name inferred from the ref is what the
-    gateway serves under. Every other CLI-routed test passes --name explicitly."""
+    gateway serves under."""
     ref = MODEL_CONFIGS["chat-llama-server-plain"]["model"]
     model_deployer.deploy_cli("--model", ref, "--loader", "llama_server", "--usecase", "generate", "--num-cpus", "1")
 

--- a/tests/test_llama_server_integration.py
+++ b/tests/test_llama_server_integration.py
@@ -10,6 +10,9 @@ import time
 import httpx
 import pytest
 
+from modelship.utils.cli import infer_model_name
+from tests.conftest import MODEL_CONFIGS
+
 OPENAI_API_BASE = "http://localhost:8000/modelship/v1"
 
 _WEATHER_TOOL = {
@@ -485,3 +488,21 @@ def test_embeddings_llama_server(client, model_deployer):
     response = client.embeddings.create(model="embed-model-llama-server", input=["Hello world", "Modelship is great"])
     assert len(response.data) == 2
     assert len(response.data[0].embedding) > 0
+
+
+@pytest.mark.integration
+@pytest.mark.llama_server
+def test_deploy_with_inferred_model_name(client, model_deployer):
+    """`--model` with no `--name`: the name inferred from the ref is what the
+    gateway serves under. Every other CLI-routed test passes --name explicitly."""
+    ref = MODEL_CONFIGS["chat-llama-server-plain"]["model"]
+    model_deployer.deploy_cli("--model", ref, "--loader", "llama_server", "--usecase", "generate", "--num-cpus", "1")
+
+    inferred = infer_model_name(ref)
+    assert inferred in {m.id for m in client.models.list().data}
+    completion = client.chat.completions.create(
+        model=inferred,
+        messages=[{"role": "user", "content": "Say hi"}],
+        max_tokens=16,
+    )
+    assert completion.choices[0].message.content


### PR DESCRIPTION
`mship deploy --model <ref> --loader <l> --usecase <u>` deploys one model with no config file. The flags mirror the root-level scalars of a models: entry and assemble a raw dict that goes through the same ModelshipConfig validation, so neither surface can drift from the other. Nested tuning blocks and multi-model sets still need a config file.

None of the model flags are argparse-required: unset flags are dropped from the dict and the schema raises requiredness itself, which also keeps the image loaders' usecase defaulting working through the CLI.

With no --name, the name comes from the model reference. Two refs can infer the same name, and the second replaces the first — merge() now says so, warning when a name is repointed at different weights and logging an ordinary config change at info.

Model-ref parsing moves to modelship/utils/model_ref.py so the pre-ray path can parse a ref without pulling huggingface_hub; model_resolver re-exports it.


