### PR TITLE
fix: account for MLA attention in vllm preflight sizing

### DIFF
--- a/modelship/preflight/vllm.py
+++ b/modelship/preflight/vllm.py
@@ -56,6 +56,14 @@ _CPU_KV_SEQUENCES = 4
 # max_position_embeddings.
 _UNKNOWN_CONTEXT_LENGTH_CAP = 32768
 
+# MLA's chunked-prefill decompression workspace row cap, mirrored from vLLM's
+# MLACommonMetadataBuilder.determine_chunked_prefill_workspace_size.
+_MLA_WORKSPACE_ROW_CAP = 65536
+
+# Safety margin on the MLA workspace's gpu_util reduction, covering PyTorch
+# CUDA allocator rounding/fragmentation on top of the raw tensor size.
+_MLA_WORKSPACE_SAFETY_MARGIN = 1.1
+
 
 class VllmPreflight:
     def recommend(self, config: ModelshipModelConfig, hw: HardwareProfile) -> dict[str, Any]:
@@ -145,6 +153,16 @@ class VllmPreflight:
         )
         # gpu_util already carries the fraction (set at config normalization).
         gpu_util = config.vllm_engine_kwargs.gpu_memory_utilization or default_gpu_memory_utilization(config)
+
+        # vLLM 0.26.0's CUDA-graph memory profiler is a no-op stub, and KV-block
+        # commitment isn't bounded by max_model_len — gpu_util is the only lever.
+        mla = _resolve_mla(text_cfg)
+        mla_workspace_bytes = 0
+        if mla is not None and not config.vllm_engine_kwargs.enforce_eager:
+            dtype_bytes = _resolve_compute_dtype_bytes(text_cfg, model_cfg)
+            mla_workspace_bytes = _mla_chunked_prefill_workspace_bytes(text_cfg, config, dtype_bytes, mla)
+            gpu_util = max(gpu_util - _MLA_WORKSPACE_SAFETY_MARGIN * mla_workspace_bytes / gpu_basis, 0.01)
+
         budget = (
             gpu_basis * gpu_util
             - weight_bytes_per_gpu
@@ -198,6 +216,9 @@ class VllmPreflight:
                 )
                 return {}
             rec = {"max_model_len": suggested}
+
+        if mla_workspace_bytes:
+            rec["gpu_memory_utilization"] = round(gpu_util, 4)
 
         logger.info(
             "preflight vllm '%s': gpu_%s=%.2f GiB util=%.2f tp=%d pp=%d "
@@ -437,10 +458,45 @@ def _resolve_text_config(model_cfg: dict) -> dict:
     return model_cfg
 
 
+class MLAInfo(NamedTuple):
+    """DeepSeek-style MLA geometry: one shared compressed latent per token,
+    not per-head K/V."""
+
+    kv_lora_rank: int
+    qk_rope_head_dim: int
+    qk_nope_head_dim: int
+    v_head_dim: int
+    num_heads: int
+
+
+def _resolve_mla(text_cfg: dict) -> MLAInfo | None:
+    """None for ordinary MHA/GQA models."""
+    kv_lora_rank = text_cfg.get("kv_lora_rank")
+    qk_rope_head_dim = text_cfg.get("qk_rope_head_dim")
+    num_heads = text_cfg.get("num_attention_heads")
+    if not (kv_lora_rank and qk_rope_head_dim and num_heads):
+        return None
+    qk_nope_head_dim = text_cfg.get("qk_nope_head_dim") or 0
+    v_head_dim = text_cfg.get("v_head_dim") or qk_nope_head_dim
+    return MLAInfo(kv_lora_rank, qk_rope_head_dim, qk_nope_head_dim, v_head_dim, num_heads)
+
+
 def _kv_bytes_per_token(text_cfg: dict, model_cfg: dict, config: ModelshipModelConfig) -> tuple[int | None, int | None]:
     """Returns (bytes-per-token-across-all-TP-ranks, max_position_embeddings).
     Reads geometry from `text_cfg`, falling back to `model_cfg`."""
     num_layers = text_cfg.get("num_hidden_layers") or text_cfg.get("num_layers")
+    if not num_layers:
+        return None, None
+    kv_dtype_bytes = _resolve_kv_dtype_bytes(text_cfg, model_cfg, config)
+    max_position_embeddings = text_cfg.get("max_position_embeddings") or model_cfg.get("max_position_embeddings")
+    max_position_embeddings = int(max_position_embeddings) if max_position_embeddings else None
+
+    mla = _resolve_mla(text_cfg)
+    if mla is not None:
+        # One shared latent per token per layer: no per-head factor, no x2 for K/V.
+        per_token = (mla.kv_lora_rank + mla.qk_rope_head_dim) * kv_dtype_bytes * num_layers
+        return int(per_token), max_position_embeddings
+
     num_attention_heads = text_cfg.get("num_attention_heads")
     num_kv_heads = text_cfg.get("num_key_value_heads") or num_attention_heads
     hidden_size = text_cfg.get("hidden_size")
@@ -448,14 +504,12 @@ def _kv_bytes_per_token(text_cfg: dict, model_cfg: dict, config: ModelshipModelC
     if head_dim is None and hidden_size and num_attention_heads:
         head_dim = hidden_size // num_attention_heads
 
-    if not (num_layers and num_kv_heads and head_dim):
+    if not (num_kv_heads and head_dim):
         return None, None
 
-    kv_dtype_bytes = _resolve_kv_dtype_bytes(text_cfg, model_cfg, config)
     # Each token stores both K and V (factor of 2) for every layer.
     per_token = 2 * num_kv_heads * head_dim * kv_dtype_bytes * num_layers
-    max_position_embeddings = text_cfg.get("max_position_embeddings") or model_cfg.get("max_position_embeddings")
-    return int(per_token), int(max_position_embeddings) if max_position_embeddings else None
+    return int(per_token), max_position_embeddings
 
 
 def _resolve_kv_dtype_bytes(text_cfg: dict, model_cfg: dict, config: ModelshipModelConfig) -> int:
@@ -503,8 +557,23 @@ def _estimate_cudagraph_bytes_per_gpu(
     return int(hidden * layers * dtype_bytes * max_num_batched_tokens // divisor)
 
 
+def _mla_chunked_prefill_workspace_bytes(
+    text_cfg: dict, config: ModelshipModelConfig, dtype_bytes: int, mla: MLAInfo
+) -> int:
+    """MLA's decompressed-K/V scratch buffer, sized by context length —
+    mirrors vLLM's `determine_chunked_prefill_workspace_size`."""
+    max_model_len = (
+        config.vllm_engine_kwargs.max_model_len
+        or text_cfg.get("max_position_embeddings")
+        or _UNKNOWN_CONTEXT_LENGTH_CAP
+    )
+    rows = min(8 * max_model_len, _MLA_WORKSPACE_ROW_CAP)
+    return int(rows * mla.num_heads * (mla.qk_nope_head_dim + mla.v_head_dim) * dtype_bytes)
+
+
 def _divide_kv_by_tp(kv_per_token: int, model_cfg: dict, tp_size: int) -> float:
-    if tp_size <= 1:
+    if tp_size <= 1 or _resolve_mla(model_cfg) is not None:
+        # MLA's compressed latent is replicated per TP rank, not head-sharded.
         return float(kv_per_token)
     num_kv_heads = model_cfg.get("num_key_value_heads") or model_cfg.get("num_attention_heads") or 0
     if num_kv_heads and num_kv_heads % tp_size == 0:

--- a/tests/test_preflight.py
+++ b/tests/test_preflight.py
@@ -1076,6 +1076,94 @@ class TestCudagraphEstimation:
         rec_eager = VllmPreflight().recommend(cfg_eager, hw)
         assert rec_eager["max_model_len"] > rec_graphs["max_model_len"]
 
+    def test_mla_chunked_prefill_workspace_matches_deepseek_v2_lite_oom(self):
+        # Anchored against a real DeepSeek-V2-Lite-AWQ OOM: PyTorch reported
+        # "Tried to allocate 512.00 MiB" for exactly this buffer.
+        from modelship.preflight.vllm import _mla_chunked_prefill_workspace_bytes, _resolve_mla
+
+        mla = _resolve_mla(_MLA_CFG)
+        assert mla is not None
+        workspace = _mla_chunked_prefill_workspace_bytes(_MLA_CFG, _make_config(), 2, mla)
+        assert workspace == 512 * 1024**2
+
+
+# DeepSeek-V2-Lite's real config.json fields (deepseek-ai/DeepSeek-V2-Lite).
+_MLA_CFG: dict = {
+    "num_hidden_layers": 27,
+    "num_attention_heads": 16,
+    "num_key_value_heads": 16,
+    "hidden_size": 2048,
+    "kv_lora_rank": 512,
+    "qk_rope_head_dim": 64,
+    "qk_nope_head_dim": 128,
+    "v_head_dim": 128,
+    "torch_dtype": "bfloat16",
+    "max_position_embeddings": 163840,
+}
+
+
+class TestMlaKvCache:
+    """MLA stores one shared compressed latent per token, not per-head K/V —
+    both the KV-bytes formula and TP sharding need a different rule."""
+
+    def test_resolve_mla_detects_deepseek_v2_lite(self):
+        from modelship.preflight.vllm import MLAInfo, _resolve_mla
+
+        assert _resolve_mla(_MLA_CFG) == MLAInfo(
+            kv_lora_rank=512, qk_rope_head_dim=64, qk_nope_head_dim=128, v_head_dim=128, num_heads=16
+        )
+
+    def test_resolve_mla_none_for_ordinary_gqa(self):
+        from modelship.preflight.vllm import _resolve_mla
+
+        assert _resolve_mla(_HYBRID_CFG) is None
+
+    def test_kv_bytes_per_token_matches_deepseek_v2_lite(self):
+        from modelship.preflight.vllm import _kv_bytes_per_token
+
+        per_token, max_pos = _kv_bytes_per_token(_MLA_CFG, _MLA_CFG, _make_config())
+        # (kv_lora_rank + qk_rope_head_dim) * dtype_bytes * num_layers = 576 * 2 * 27.
+        assert per_token == 31104
+        assert max_pos == 163840
+
+    def test_kv_bytes_far_below_generic_per_head_formula(self):
+        from modelship.preflight.vllm import _kv_bytes_per_token
+
+        mla_per_token, _ = _kv_bytes_per_token(_MLA_CFG, _MLA_CFG, _make_config())
+        generic_cfg = dict(_MLA_CFG)
+        del generic_cfg["kv_lora_rank"]
+        generic_per_token, _ = _kv_bytes_per_token(generic_cfg, generic_cfg, _make_config())
+        assert mla_per_token is not None and generic_per_token is not None
+        assert mla_per_token * 7 < generic_per_token
+
+    def test_divide_kv_by_tp_does_not_shard_mla(self):
+        # num_key_value_heads=16 divides tp_size=2 cleanly, but MLA's latent
+        # is replicated per rank, not head-sharded — must not shrink.
+        from modelship.preflight.vllm import _divide_kv_by_tp
+
+        assert _divide_kv_by_tp(31104, _MLA_CFG, 2) == 31104
+
+    def test_recommend_lowers_gpu_memory_utilization_with_cudagraphs(self, tmp_path):
+        # vLLM's own CUDA-graph memory profiler doesn't reserve room for this
+        # workspace; preflight must shrink gpu_memory_utilization to compensate.
+        snapshot = _write_model_snapshot(tmp_path, config_json=_MLA_CFG, weight_bytes=5 * 1024**3)
+        hw = HardwareProfile(gpus=[GPUInfo(0, 16 * 1024**3, "test")])
+        rec = VllmPreflight().recommend(_make_config(resolved_path=str(snapshot)), hw)
+        assert "gpu_memory_utilization" in rec
+        assert rec["gpu_memory_utilization"] < default_gpu_memory_utilization(_make_config())
+
+    def test_recommend_leaves_gpu_memory_utilization_unset_when_eager(self, tmp_path):
+        snapshot = _write_model_snapshot(tmp_path, config_json=_MLA_CFG, weight_bytes=5 * 1024**3)
+        hw = HardwareProfile(gpus=[GPUInfo(0, 16 * 1024**3, "test")])
+        cfg = _make_config(resolved_path=str(snapshot), vllm_kwargs={"enforce_eager": True})
+        assert "gpu_memory_utilization" not in VllmPreflight().recommend(cfg, hw)
+
+    def test_recommend_leaves_gpu_memory_utilization_unset_for_ordinary_model(self, tmp_path):
+        snapshot = _write_model_snapshot(tmp_path, config_json=_HYBRID_CFG, weight_bytes=5 * 1024**3)
+        hw = HardwareProfile(gpus=[GPUInfo(0, 16 * 1024**3, "test")])
+        rec = VllmPreflight().recommend(_make_config(resolved_path=str(snapshot)), hw)
+        assert "gpu_memory_utilization" not in rec
+
 
 # Hybrid config mirroring Qwen3.5-4B: 32 layers, 8 full-attention + 24 linear.
 _HYBRID_CFG: dict = {


### PR DESCRIPTION
DeepSeek-style MLA (kv_lora_rank present) caches one shared compressed latent per token, not per-head K/V — the generic GQA/MHA formula overestimated KV cost 7x on DeepSeek-V2-Lite-AWQ, verified against vLLM's own MLAAttentionSpec. Also stop sharding MLA's KV bytes across TP ranks (the latent is replicated, not head-split).

Separately, vLLM 0.26.0's CUDA-graph memory profiler is a no-op stub, so nothing reserves room for MLA's chunked-prefill decompression workspace before KV-cache blocks commit the full gpu_memory_utilization budget — reproduced as a real OOM on deploy. Preflight now shrinks gpu_memory_utilization (with a safety margin for allocator rounding) to leave that headroom, since max_model_len doesn't bound the actual KV-block commitment.

Verified end-to-end against a real DeepSeek-V2-Lite-AWQ deploy with CUDA graphs enabled.

