### PR TITLE
fix: log silent ErrorResponse paths and validate tool_choice at the s…

### DIFF
--- a/modelship/infer/vllm/vllm_infer.py
+++ b/modelship/infer/vllm/vllm_infer.py
@@ -487,8 +487,10 @@ class VllmInfer(BaseInfer[_VllmPrepared]):
         try:
             result = await engine_ops.render_and_params(self.openai_serving_render, vllm_request)
         except VllmValidationError as exc:
+            logger.info("Validation error rendering chat request: %s", exc)
             return _to_error_response(exc)
         if isinstance(result, VllmErrorResponse):
+            logger.info("Validation error rendering chat request: %s", result.error.message)
             return _to_error_response(result)
         engine_input, sampling_params = result
         return _VllmPrepared(vllm_request, engine_input, sampling_params)
@@ -561,9 +563,17 @@ class VllmInfer(BaseInfer[_VllmPrepared]):
             )
         except UnsupportedContentError as exc:
             return _to_error_response(exc)
-        vllm_request = engine_ops.build_vllm_request(
-            request, self.model_config.chat_template_kwargs, cache_salt=raw_request.identity
-        )
+        try:
+            vllm_request = engine_ops.build_vllm_request(
+                request, self.model_config.chat_template_kwargs, cache_salt=raw_request.identity
+            )
+        except ValidationError as exc:
+            # pydantic's .args is () here (str(exc) is the only useful message),
+            # matching api.py's _validation_error_from_cause for the same reason.
+            logger.info("Validation error building vllm request: %s", exc)
+            return create_error_response(
+                message=str(exc), err_type="invalid_request_error", status_code=HTTPStatus.BAD_REQUEST
+            )
         return await self._render_bundle(vllm_request)
 
     async def _create_chat_completion_stream(

--- a/modelship/openai/api.py
+++ b/modelship/openai/api.py
@@ -454,7 +454,15 @@ class ModelshipAPI:
             if isinstance(first, ErrorResponse):
                 REQUEST_ERRORS_TOTAL.inc(tags={"model": model, "endpoint": endpoint, "error_type": "inference_error"})
                 REQUEST_TOTAL.inc(tags={"model": model, "endpoint": endpoint, "status": "error"})
-                logger.info("Inference error for model=%s: %s", model, first.error.message)
+                logger.info(
+                    "Inference error endpoint=%s model=%s type=%s code=%s param=%s message=%.200s",
+                    endpoint,
+                    model,
+                    first.error.type,
+                    first.error.code,
+                    first.error.param,
+                    first.error.message,
+                )
                 return _error_response(first)
 
             if isinstance(first, Response):
@@ -997,7 +1005,15 @@ class ModelshipAPI:
             if isinstance(first, ErrorResponse):
                 REQUEST_ERRORS_TOTAL.inc(tags={"model": model, "endpoint": endpoint, "error_type": "inference_error"})
                 REQUEST_TOTAL.inc(tags={"model": model, "endpoint": endpoint, "status": "error"})
-                logger.info("Inference error for model=%s: %s", model, first.error.message)
+                logger.info(
+                    "Inference error endpoint=%s model=%s type=%s code=%s param=%s message=%.200s",
+                    endpoint,
+                    model,
+                    first.error.type,
+                    first.error.code,
+                    first.error.param,
+                    first.error.message,
+                )
                 return _error_response(first)
 
             assert isinstance(first, ChatCompletionResponse)

--- a/modelship/openai/api.py
+++ b/modelship/openai/api.py
@@ -454,6 +454,7 @@ class ModelshipAPI:
             if isinstance(first, ErrorResponse):
                 REQUEST_ERRORS_TOTAL.inc(tags={"model": model, "endpoint": endpoint, "error_type": "inference_error"})
                 REQUEST_TOTAL.inc(tags={"model": model, "endpoint": endpoint, "status": "error"})
+                logger.info("Inference error for model=%s: %s", model, first.error.message)
                 return _error_response(first)
 
             if isinstance(first, Response):
@@ -996,6 +997,7 @@ class ModelshipAPI:
             if isinstance(first, ErrorResponse):
                 REQUEST_ERRORS_TOTAL.inc(tags={"model": model, "endpoint": endpoint, "error_type": "inference_error"})
                 REQUEST_TOTAL.inc(tags={"model": model, "endpoint": endpoint, "status": "error"})
+                logger.info("Inference error for model=%s: %s", model, first.error.message)
                 return _error_response(first)
 
             assert isinstance(first, ChatCompletionResponse)


### PR DESCRIPTION
…ource

Requests that failed inside an actor (e.g. vLLM context-overflow or a render error) returned a clean 400 but left no trace in modelship's own logs, only visible via the Ray Serve access log's raw status code. Log the error message at both silent-swallow points (api.py's ErrorResponse branches, vllm_infer.py's _render_bundle).

Separately, a request with tool_choice set but no tools raised an uncaught pydantic ValidationError in _prepare_chat that blew through the whole Ray Serve actor stack as an ERROR-level traceback, even though the gateway already unwraps it into a correct 400 one layer up. Catch it at the source, same as the sibling UnsupportedContentError case, so it logs cleanly instead of looking like a service fault.

