### PR TITLE
fix: emit an SSE error chunk on mid-stream failures instead of aborting

### DIFF
--- a/modelship/infer/vllm/vllm_infer.py
+++ b/modelship/infer/vllm/vllm_infer.py
@@ -721,12 +721,9 @@ class VllmInfer(BaseInfer[_VllmPrepared]):
                 chat_request, self.model_config.chat_template_kwargs, cache_salt=raw_request.identity
             )
         except ValidationError as exc:
-            # pydantic's .args is () here (str(exc) is the only useful message),
-            # matching api.py's _validation_error_from_cause for the same reason.
+            # Same 400 as the `responses_request_to_chat` failure above.
             logger.info("Validation error building vllm request: %s", exc)
-            return create_error_response(
-                message=str(exc), err_type="invalid_request_error", status_code=HTTPStatus.BAD_REQUEST
-            )
+            return responses_validation_error(exc)
         return await self._render_bundle(vllm_request)
 
     async def _create_response_no_stream(

--- a/modelship/infer/vllm/vllm_infer.py
+++ b/modelship/infer/vllm/vllm_infer.py
@@ -716,9 +716,17 @@ class VllmInfer(BaseInfer[_VllmPrepared]):
         except UnsupportedContentError as exc:
             return _to_error_response(exc)
         chat_request.stream = request.stream or False
-        vllm_request = engine_ops.build_vllm_request(
-            chat_request, self.model_config.chat_template_kwargs, cache_salt=raw_request.identity
-        )
+        try:
+            vllm_request = engine_ops.build_vllm_request(
+                chat_request, self.model_config.chat_template_kwargs, cache_salt=raw_request.identity
+            )
+        except ValidationError as exc:
+            # pydantic's .args is () here (str(exc) is the only useful message),
+            # matching api.py's _validation_error_from_cause for the same reason.
+            logger.info("Validation error building vllm request: %s", exc)
+            return create_error_response(
+                message=str(exc), err_type="invalid_request_error", status_code=HTTPStatus.BAD_REQUEST
+            )
         return await self._render_bundle(vllm_request)
 
     async def _create_response_no_stream(

--- a/modelship/openai/api.py
+++ b/modelship/openai/api.py
@@ -65,6 +65,7 @@ from modelship.openai.protocol import (
 from modelship.openai.protocol.responses.adapter import UnsupportedResponsesFeatureError
 from modelship.openai.state import responses as responses_state
 from modelship.openai.utils import responses as responses_utils
+from modelship.openai.utils.chat import encode_error_sse
 from modelship.state import get_state_store
 from modelship.utils import random_uuid
 
@@ -154,6 +155,21 @@ class OpenaiModelList(BaseModel):
 
 def _error_response(result: ErrorResponse) -> JSONResponse:
     return JSONResponse(content=result.model_dump(mode="json"), status_code=result._http_status)
+
+
+def _stream_error_chunk(endpoint: str) -> str:
+    """SSE-encode a failure between chunks, after headers are already committed to 200
+    — raising would just abort the connection with no body. Message is generic; details
+    go to the server log instead."""
+    if endpoint == "create_response":
+        event = {
+            "type": "response.failed",
+            "sequence_number": 0,
+            "response": {"status": "failed", "error": {"message": "Internal error during generation"}},
+        }
+        return f"event: {event['type']}\ndata: {json.dumps(event)}\n\n"
+    error = create_error_response(message="Internal error during generation", err_type="api_error", status_code=500)
+    return encode_error_sse(error)
 
 
 def _validation_error_from_cause(cause: BaseException) -> ErrorResponse:
@@ -499,7 +515,9 @@ class ModelshipAPI:
                 except Exception:
                     REQUEST_ERRORS_TOTAL.inc(tags={"model": model, "endpoint": endpoint, "error_type": "stream_error"})
                     REQUEST_TOTAL.inc(tags={"model": model, "endpoint": endpoint, "status": "error"})
-                    raise
+                    logger.exception("stream failed mid-response endpoint=%s model=%s", endpoint, model)
+                    yield _stream_error_chunk(endpoint)
+                    yield "data: [DONE]\n\n"
                 finally:
                     REQUEST_DURATION_SECONDS.observe(
                         time.monotonic() - start, tags={"model": model, "endpoint": endpoint}

--- a/modelship/openai/api.py
+++ b/modelship/openai/api.py
@@ -59,7 +59,9 @@ from modelship.openai.protocol import (
     TranslationResponse,
     TranslationResponseVerbose,
     create_error_response,
+    encode_sse_event,
     error_ws_frame,
+    failure_event_from_frames,
     frame_sse,
 )
 from modelship.openai.protocol.responses.adapter import UnsupportedResponsesFeatureError
@@ -157,18 +159,15 @@ def _error_response(result: ErrorResponse) -> JSONResponse:
     return JSONResponse(content=result.model_dump(mode="json"), status_code=result._http_status)
 
 
-def _stream_error_chunk(endpoint: str) -> str:
+def _stream_error_chunk(endpoint: str, model: str, created_frame: Any, last_frame: Any) -> str:
     """SSE-encode a failure between chunks, after headers are already committed to 200
     — raising would just abort the connection with no body. Message is generic; details
-    go to the server log instead."""
+    go to the server log instead. /v1/responses needs a typed terminal event rebuilt from
+    the frames already sent; every other endpoint takes the bare `data:` error object."""
+    message = "Internal error during generation"
     if endpoint == "create_response":
-        event = {
-            "type": "response.failed",
-            "sequence_number": 0,
-            "response": {"status": "failed", "error": {"message": "Internal error during generation"}},
-        }
-        return f"event: {event['type']}\ndata: {json.dumps(event)}\n\n"
-    error = create_error_response(message="Internal error during generation", err_type="api_error", status_code=500)
+        return encode_sse_event(failure_event_from_frames(created_frame, last_frame, message, model=model))
+    error = create_error_response(message=message, err_type="api_error", status_code=500)
     return encode_error_sse(error)
 
 
@@ -505,18 +504,22 @@ class ModelshipAPI:
 
             # streaming — first chunk already consumed, chain it back
             async def _stream():
+                # Held for _stream_error_chunk: opening frame carries the Responses
+                # envelope, last one the sequence number. Parsed only on the error path.
+                last = first
                 try:
                     STREAM_CHUNKS_TOTAL.inc(tags={"model": model})
                     yield first
                     async for chunk in response_gen:
                         STREAM_CHUNKS_TOTAL.inc(tags={"model": model})
+                        last = chunk
                         yield chunk
                     REQUEST_TOTAL.inc(tags={"model": model, "endpoint": endpoint, "status": "ok"})
                 except Exception:
                     REQUEST_ERRORS_TOTAL.inc(tags={"model": model, "endpoint": endpoint, "error_type": "stream_error"})
                     REQUEST_TOTAL.inc(tags={"model": model, "endpoint": endpoint, "status": "error"})
                     logger.exception("stream failed mid-response endpoint=%s model=%s", endpoint, model)
-                    yield _stream_error_chunk(endpoint)
+                    yield _stream_error_chunk(endpoint, model, first, last)
                     yield "data: [DONE]\n\n"
                 finally:
                     REQUEST_DURATION_SECONDS.observe(

--- a/modelship/openai/protocol/__init__.py
+++ b/modelship/openai/protocol/__init__.py
@@ -85,7 +85,9 @@ from modelship.openai.protocol.responses import (
     ResponseReasoningText,
     ResponsesRequest,
     ResponseUsage,
+    encode_sse_event,
     error_ws_frame,
+    failure_event_from_frames,
     frame_sse,
 )
 from modelship.openai.protocol.usage import CompletionTokenUsageInfo, PromptTokenUsageInfo, UsageInfo
@@ -157,7 +159,9 @@ __all__ = [
     "TranslationResponseVerbose",
     "UsageInfo",
     "create_error_response",
+    "encode_sse_event",
     "error_ws_frame",
+    "failure_event_from_frames",
     "frame_sse",
     "random_uuid",
 ]

--- a/modelship/openai/protocol/responses/__init__.py
+++ b/modelship/openai/protocol/responses/__init__.py
@@ -46,7 +46,9 @@ from modelship.openai.protocol.responses.schemas import (
 from modelship.openai.protocol.responses.streaming import (
     TERMINAL_EVENT_TYPES,
     ResponsesStreamTranslator,
+    encode_sse_event,
     error_ws_frame,
+    failure_event_from_frames,
     frame_sse,
     store_failure_event,
 )
@@ -75,7 +77,9 @@ __all__ = [
     "ResponsesRequest",
     "ResponsesStreamTranslator",
     "UnsupportedResponsesFeatureError",
+    "encode_sse_event",
     "error_ws_frame",
+    "failure_event_from_frames",
     "frame_sse",
     "parse_output_item",
     "responses_request_to_chat",

--- a/modelship/openai/protocol/responses/streaming.py
+++ b/modelship/openai/protocol/responses/streaming.py
@@ -79,7 +79,43 @@ def store_failure_event(terminal_payload: dict[str, Any], message: str) -> dict[
     }
 
 
-def _encode_sse_event(event: dict[str, Any]) -> str:
+def _frame_payload(frame: Any) -> dict[str, Any]:
+    """Best-effort decode of an SSE frame's ``data:`` JSON. ``{}`` for anything that
+    isn't one — a non-str chunk, the ``[DONE]`` terminator, malformed JSON."""
+    if not isinstance(frame, str):
+        return {}
+    for line in frame.splitlines():
+        if not line.startswith("data: "):
+            continue
+        try:
+            payload = json.loads(line[len("data: ") :])
+        except ValueError:
+            return {}
+        return payload if isinstance(payload, dict) else {}
+    return {}
+
+
+def failure_event_from_frames(created_frame: Any, last_frame: Any, message: str, *, model: str = "") -> dict[str, Any]:
+    """Terminal ``response.failed`` for a stream that died outside the loader, where no
+    translator survives to call :meth:`ResponsesStreamTranslator.fail`. Rebuilds the
+    envelope from the frames already sent: ``response.created`` carries id/created_at/
+    model, the last frame the sequence number this one must follow. Output is dropped —
+    the frames carry it as deltas, not items."""
+    response = dict(_frame_payload(created_frame).get("response") or {})
+    response.update(status="failed", error={"message": message}, output=[])
+    response.setdefault("object", "response")
+    response.setdefault("id", f"resp_{random_uuid()}")
+    response.setdefault("created_at", int(time.time()))
+    response.setdefault("model", model)
+    seq = _frame_payload(last_frame).get("sequence_number")
+    return {
+        "type": "response.failed",
+        "sequence_number": seq + 1 if isinstance(seq, int) else 0,
+        "response": response,
+    }
+
+
+def encode_sse_event(event: dict[str, Any]) -> str:
     """Wire-format one Responses event dict as an SSE frame (named event line + JSON data line)."""
     return f"event: {event['type']}\ndata: {json.dumps(event)}\n\n"
 
@@ -93,7 +129,7 @@ async def frame_sse(gen: AsyncIterator[Any]) -> AsyncGenerator[Any, None]:
     framed_any = False
     async for item in gen:
         if isinstance(item, dict):
-            yield _encode_sse_event(item)
+            yield encode_sse_event(item)
             framed_any = True
         else:
             yield item

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -624,3 +624,50 @@ class TestHandleResponse:
 
         assert isinstance(result, JSONResponse)
         assert result.status_code == 500
+
+    @pytest.mark.asyncio
+    async def test_stream_error_after_first_chunk_yields_sse_error_not_raise(self, api):
+        """Failure between chunks: raising after headers are committed just aborts the
+        connection with no body, so it must yield a parseable SSE error chunk instead."""
+        import json
+
+        from fastapi.responses import StreamingResponse
+
+        async def mock_gen():
+            yield "data: chunk1\n\n"
+            raise RuntimeError("boundary dropped")
+            yield  # pragma: no cover — unreachable, keeps this an async generator
+
+        watcher = MagicMock()
+        result = await api._handle_response(mock_gen(), watcher, "test-model", "create_chat_completion")
+        assert isinstance(result, StreamingResponse)
+
+        chunks = [chunk async for chunk in result.body_iterator]
+        assert chunks[0] == "data: chunk1\n\n"
+        assert chunks[-1] == "data: [DONE]\n\n"
+        error_chunk = chunks[-2]
+        assert error_chunk.startswith("data: ")
+        body = json.loads(error_chunk[len("data: ") :])
+        assert body["error"]["type"] == "api_error"
+        watcher.stop.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_stream_error_for_responses_endpoint_yields_response_failed_event(self, api):
+        """/v1/responses uses typed `event: <type>` framing, not bare `data:` lines —
+        the error chunk must match."""
+        from fastapi.responses import StreamingResponse
+
+        async def mock_gen():
+            yield 'event: response.output_text.delta\ndata: {"type": "response.output_text.delta"}\n\n'
+            raise RuntimeError("boundary dropped")
+            yield  # pragma: no cover — unreachable, keeps this an async generator
+
+        watcher = MagicMock()
+        result = await api._handle_response(mock_gen(), watcher, "test-model", "create_response")
+        assert isinstance(result, StreamingResponse)
+
+        chunks = [chunk async for chunk in result.body_iterator]
+        error_chunk = chunks[-2]
+        assert error_chunk.startswith("event: response.failed\n")
+        assert '"status": "failed"' in error_chunk
+        watcher.stop.assert_called_once()

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -653,12 +653,22 @@ class TestHandleResponse:
 
     @pytest.mark.asyncio
     async def test_stream_error_for_responses_endpoint_yields_response_failed_event(self, api):
-        """/v1/responses uses typed `event: <type>` framing, not bare `data:` lines —
-        the error chunk must match."""
+        """Typed `event:` framing, and the event must continue the stream it terminates:
+        same response id, next sequence number."""
+        import json
+
         from fastapi.responses import StreamingResponse
 
+        created = {
+            "type": "response.created",
+            "sequence_number": 0,
+            "response": {"id": "resp_abc", "object": "response", "created_at": 1, "model": "m", "output": []},
+        }
+        delta = {"type": "response.output_text.delta", "sequence_number": 7, "delta": "hi"}
+
         async def mock_gen():
-            yield 'event: response.output_text.delta\ndata: {"type": "response.output_text.delta"}\n\n'
+            yield f"event: {created['type']}\ndata: {json.dumps(created)}\n\n"
+            yield f"event: {delta['type']}\ndata: {json.dumps(delta)}\n\n"
             raise RuntimeError("boundary dropped")
             yield  # pragma: no cover — unreachable, keeps this an async generator
 
@@ -667,7 +677,38 @@ class TestHandleResponse:
         assert isinstance(result, StreamingResponse)
 
         chunks = [chunk async for chunk in result.body_iterator]
+        assert chunks[-1] == "data: [DONE]\n\n"
         error_chunk = chunks[-2]
         assert error_chunk.startswith("event: response.failed\n")
-        assert '"status": "failed"' in error_chunk
+        event = json.loads(error_chunk.split("data: ", 1)[1])
+        assert event["sequence_number"] == 8
+        assert event["response"]["id"] == "resp_abc"
+        assert event["response"]["model"] == "m"
+        assert event["response"]["created_at"] == 1
+        assert event["response"]["status"] == "failed"
+        assert event["response"]["error"]["message"]
         watcher.stop.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_stream_error_for_responses_endpoint_without_parseable_frames(self, api):
+        """Unparseable frames still have to produce a schema-complete event."""
+        import json
+
+        from fastapi.responses import StreamingResponse
+
+        async def mock_gen():
+            yield "data: [DONE]\n\n"
+            raise RuntimeError("boundary dropped")
+            yield  # pragma: no cover — unreachable, keeps this an async generator
+
+        watcher = MagicMock()
+        result = await api._handle_response(mock_gen(), watcher, "test-model", "create_response")
+        assert isinstance(result, StreamingResponse)
+
+        chunks = [chunk async for chunk in result.body_iterator]
+        event = json.loads(chunks[-2].split("data: ", 1)[1])
+        assert event["sequence_number"] == 0
+        assert event["response"]["model"] == "test-model"
+        assert event["response"]["id"].startswith("resp_")
+        assert event["response"]["output"] == []
+        assert event["response"]["status"] == "failed"


### PR DESCRIPTION
A Ray-boundary failure between chunks used to just re-raise after headers were already committed to 200, aborting the connection with no body — a fronting proxy sees that as a 502 with an empty response. Now it logs and terminates the stream with a real SSE error chunk instead, shaped per endpoint (bare `data:` for chat completions, `event: response.failed` for /v1/responses, which uses different SSE framing).

Also wraps _prepare_responses's build_vllm_request call in the same try/except ValidationError as its _prepare_chat sibling, closing the same unlogged-error gap there.


