### PR TITLE
fix: normalize every image content-part shape to the nested chat form

### DIFF
--- a/modelship/openai/utils/chat.py
+++ b/modelship/openai/utils/chat.py
@@ -179,7 +179,6 @@ def _validate_part(
             )
         if ptype == "image_url" and isinstance(img, dict):
             return part
-        # Rewrite to the nested chat shape: backends reject a bare-string url.
         image_url: dict[str, Any] = {"url": url}
         if isinstance(detail, str):
             image_url["detail"] = detail

--- a/modelship/openai/utils/chat.py
+++ b/modelship/openai/utils/chat.py
@@ -83,7 +83,8 @@ def normalize_chat_messages(
         - Text-like parts (``text`` / ``input_text`` / ``output_text`` /
           ``refusal`` / ``thinking``) are normalized to ``{"type": "text", "text": ...}``.
         - Image parts (``image_url`` / ``input_image``) require ``supports_image``;
-          otherwise :class:`UnsupportedContentError` is raised.
+          otherwise :class:`UnsupportedContentError` is raised. Both are normalized
+          to ``{"type": "image_url", "image_url": {"url": ...}}``.
         - Audio parts (``input_audio`` / ``audio_url``) require ``supports_audio``;
           otherwise :class:`UnsupportedContentError` is raised.
         - Parts with empty / missing content are dropped with a warning
@@ -159,14 +160,15 @@ def _validate_part(
     if ptype in _IMAGE_TYPES:
         if not supports_image:
             raise UnsupportedContentError(f"messages[{msg_idx}].content: this model does not support image input")
-        img = part.get("image_url") if ptype == "image_url" else part.get("input_image")
+        # Both types carry the URL under `image_url`: bare string for input_image, {"url": ...} for image_url.
+        img = part.get("image_url")
         if img is None:
             logger.warning("messages[%d].content: skipping empty %r part", msg_idx, ptype)
             return None
         if isinstance(img, str):
-            url = img
+            url, detail = img, part.get("detail")
         elif isinstance(img, dict):
-            url = img.get("url")
+            url, detail = img.get("url"), img.get("detail")
         else:
             raise UnsupportedContentError(
                 f"messages[{msg_idx}].content: {ptype!r} must be a URL string or an object with a 'url' field"
@@ -175,7 +177,13 @@ def _validate_part(
             raise UnsupportedContentError(
                 f"messages[{msg_idx}].content: {ptype!r}.url must be a non-empty string (http(s) URL or data: URI)"
             )
-        return part
+        if ptype == "image_url" and isinstance(img, dict):
+            return part
+        # Rewrite to the nested chat shape: backends reject a bare-string url.
+        image_url: dict[str, Any] = {"url": url}
+        if isinstance(detail, str):
+            image_url["detail"] = detail
+        return {"type": "image_url", "image_url": image_url}
 
     if ptype in _AUDIO_TYPES:
         if not supports_audio:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -41,6 +41,14 @@ HEALTH_URL = "http://localhost:8000/modelship/health"
 
 # Per-model configs; Deployer.deploy(*names) writes a subset into a one-shot
 # models.yaml and runs `mship_deploy.py --reconcile` to swap the deployed set.
+# 64x64 solid red PNG — one unambiguous color, large enough to survive image preprocessing.
+RED_IMAGE_DATA_URI = (
+    "data:image/png;base64,"
+    "iVBORw0KGgoAAAANSUhEUgAAAEAAAABACAIAAAAlC+aJAAAAUElEQVR42u3PQREAAAQAMGTQP5kwUni42xos"
+    "pzs+q3hOQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBA4N4CQ5MBhMgt2OkA"
+    "AAAASUVORK5CYII="
+)
+
 MODEL_CONFIGS: dict[str, dict] = {
     "chat-capable": {
         "name": "chat-capable",
@@ -110,6 +118,18 @@ MODEL_CONFIGS: dict[str, dict] = {
         "llama_server_config": {
             "n_ctx": 4096,
             "parallel": 4,
+        },
+    },
+    "chat-vlm-llama-server": {
+        "name": "chat-vlm-llama-server",
+        # Smallest GGUF VLM that fits a CPU deploy; mmproj is what gates image input.
+        "model": "ggml-org/SmolVLM-256M-Instruct-GGUF:SmolVLM-256M-Instruct-Q8_0.gguf",
+        "usecase": "generate",
+        "loader": "llama_server",
+        "num_cpus": 2,
+        "llama_server_config": {
+            "mmproj": "ggml-org/SmolVLM-256M-Instruct-GGUF:mmproj-SmolVLM-256M-Instruct-Q8_0.gguf",
+            "n_ctx": 4096,
         },
     },
     "chat-llama-server-plain": {

--- a/tests/test_llama_server_integration.py
+++ b/tests/test_llama_server_integration.py
@@ -1,5 +1,5 @@
 """End-to-end coverage for the llama_server loader: chat, tool calling,
-reasoning, response_format, GPU offload, embeddings, and concurrency, all
+reasoning, response_format, vision, GPU offload, embeddings, and concurrency, all
 through a real `llama-server` subprocess proxied over its native
 OpenAI-compatible HTTP API."""
 
@@ -10,8 +10,9 @@ import time
 import httpx
 import pytest
 
+import openai
 from modelship.utils.cli import infer_model_name
-from tests.conftest import MODEL_CONFIGS
+from tests.conftest import MODEL_CONFIGS, RED_IMAGE_DATA_URI
 
 OPENAI_API_BASE = "http://localhost:8000/modelship/v1"
 
@@ -506,3 +507,107 @@ def test_deploy_with_inferred_model_name(client, model_deployer):
         max_tokens=16,
     )
     assert completion.choices[0].message.content
+
+
+@pytest.mark.integration
+@pytest.mark.llama_server
+class TestChatVlmLlamaServer:
+    """Vision through a real llama-server subprocess launched with `--mmproj`, over
+    every accepted image part shape. Asserted on `prompt_tokens`: a dropped image
+    still answers fluently, and only the token count falls back to the text baseline."""
+
+    _QUESTION = "What color is this image? Answer in one word."
+
+    @pytest.fixture(autouse=True, scope="class")
+    def _deploy(self, model_deployer):
+        # chat-llama-server rides along with no mmproj — the rejection case.
+        model_deployer.deploy("chat-vlm-llama-server", "chat-llama-server")
+
+    @pytest.fixture(scope="class")
+    def text_only_prompt_tokens(self, client) -> int:
+        completion = client.chat.completions.create(
+            model="chat-vlm-llama-server",
+            messages=[{"role": "user", "content": self._QUESTION}],
+            max_tokens=8,
+        )
+        return completion.usage.prompt_tokens
+
+    @pytest.mark.parametrize(
+        "part",
+        [
+            pytest.param({"type": "image_url", "image_url": {"url": RED_IMAGE_DATA_URI}}, id="image_url-object"),
+            pytest.param({"type": "image_url", "image_url": RED_IMAGE_DATA_URI}, id="image_url-bare-string"),
+            pytest.param({"type": "input_image", "image_url": RED_IMAGE_DATA_URI}, id="input_image"),
+        ],
+    )
+    def test_every_image_part_shape_reaches_the_backend(self, client, text_only_prompt_tokens, part):
+        completion = client.chat.completions.create(
+            model="chat-vlm-llama-server",
+            messages=[{"role": "user", "content": [{"type": "text", "text": self._QUESTION}, part]}],
+            max_tokens=16,
+            temperature=0.0,
+        )
+        assert completion.choices[0].message.content
+        assert completion.usage.prompt_tokens > text_only_prompt_tokens + 20
+        assert "red" in completion.choices[0].message.content.lower()
+
+    def test_image_url_streaming(self, client):
+        stream = client.chat.completions.create(
+            model="chat-vlm-llama-server",
+            messages=[
+                {
+                    "role": "user",
+                    "content": [
+                        {"type": "text", "text": self._QUESTION},
+                        {"type": "image_url", "image_url": {"url": RED_IMAGE_DATA_URI}},
+                    ],
+                }
+            ],
+            max_tokens=16,
+            temperature=0.0,
+            stream=True,
+        )
+        chunks = [c.choices[0].delta.content for c in stream if c.choices[0].delta.content]
+        assert "red" in "".join(chunks).lower()
+
+    def test_responses_input_image(self, client, text_only_prompt_tokens):
+        response = client.responses.create(
+            model="chat-vlm-llama-server",
+            input=[
+                {
+                    "role": "user",
+                    "content": [
+                        {"type": "input_text", "text": self._QUESTION},
+                        {"type": "input_image", "image_url": RED_IMAGE_DATA_URI},
+                    ],
+                }
+            ],
+            max_output_tokens=16,
+            temperature=0.0,
+        )
+        assert response.usage.input_tokens > text_only_prompt_tokens + 20
+        assert "red" in response.output_text.lower()
+
+    def test_text_only_request_still_works(self, client):
+        completion = client.chat.completions.create(
+            model="chat-vlm-llama-server",
+            messages=[{"role": "user", "content": "Say hi."}],
+            max_tokens=8,
+        )
+        assert completion.choices[0].message.content
+
+    def test_image_rejected_without_mmproj(self, client):
+        with pytest.raises(openai.BadRequestError, match="does not support image input"):
+            client.chat.completions.create(
+                model="chat-llama-server",
+                messages=[
+                    {
+                        "role": "user",
+                        "content": [
+                            {"type": "text", "text": self._QUESTION},
+                            {"type": "image_url", "image_url": {"url": RED_IMAGE_DATA_URI}},
+                        ],
+                    }
+                ],
+                max_tokens=16,
+            )

--- a/tests/test_openai_chat_utils.py
+++ b/tests/test_openai_chat_utils.py
@@ -91,7 +91,8 @@ def test_image_url_data_uri():
     assert result[0]["content"][0]["image_url"]["url"] == "data:image/png;base64,AAA"
 
 
-def test_image_url_as_bare_string_accepted():
+def test_image_url_as_bare_string_is_nested():
+    # llama-server rejects a bare-string url ("Invalid base64 value").
     messages = [
         {
             "role": "user",
@@ -102,7 +103,36 @@ def test_image_url_as_bare_string_accepted():
         }
     ]
     result = normalize_chat_messages(messages, supports_image=True)
-    assert result[0]["content"][0]["image_url"] == "https://example.com/x.png"
+    assert result[0]["content"][0] == {"type": "image_url", "image_url": {"url": "https://example.com/x.png"}}
+
+
+def test_input_image_normalized_to_image_url():
+    messages = [
+        {
+            "role": "user",
+            "content": [
+                {"type": "input_image", "image_url": "data:image/png;base64,AAA", "detail": "low"},
+                {"type": "input_text", "text": "what is this"},
+            ],
+        }
+    ]
+    result = normalize_chat_messages(messages, supports_image=True)
+    assert result[0]["content"][0] == {
+        "type": "image_url",
+        "image_url": {"url": "data:image/png;base64,AAA", "detail": "low"},
+    }
+
+
+def test_input_image_missing_url_rejected():
+    messages = [{"role": "user", "content": [{"type": "input_image", "image_url": {}}]}]
+    with pytest.raises(UnsupportedContentError, match="url"):
+        normalize_chat_messages(messages, supports_image=True)
+
+
+def test_image_url_detail_preserved():
+    part = {"type": "image_url", "image_url": {"url": "https://example.com/x.png", "detail": "high"}}
+    result = normalize_chat_messages([{"role": "user", "content": [part]}], supports_image=True)
+    assert result[0]["content"][0] == part
 
 
 def test_image_url_missing_url_field_rejected():

--- a/tests/test_openai_chat_utils.py
+++ b/tests/test_openai_chat_utils.py
@@ -92,7 +92,7 @@ def test_image_url_data_uri():
 
 
 def test_image_url_as_bare_string_is_nested():
-    # llama-server rejects a bare-string url ("Invalid base64 value").
+    # Both backends reject it: llama-server "Invalid base64 value", vllm a pydantic dict_type 400.
     messages = [
         {
             "role": "user",

--- a/tests/test_openai_chat_utils.py
+++ b/tests/test_openai_chat_utils.py
@@ -92,7 +92,6 @@ def test_image_url_data_uri():
 
 
 def test_image_url_as_bare_string_is_nested():
-    # Both backends reject it: llama-server "Invalid base64 value", vllm a pydantic dict_type 400.
     messages = [
         {
             "role": "user",

--- a/tests/test_vllm_integration.py
+++ b/tests/test_vllm_integration.py
@@ -7,6 +7,8 @@ import json
 import httpx
 import pytest
 
+from tests.conftest import RED_IMAGE_DATA_URI
+
 OPENAI_API_BASE = "http://localhost:8000/modelship/v1"
 
 
@@ -394,40 +396,48 @@ class TestChatReasoning:
         assert "<think>" not in "".join(content_parts)
 
 
-# 1x1 red pixel PNG
-_RED_PIXEL_DATA_URI = (
-    "data:image/png;base64,"
-    "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8/5+hHgAHggJ/PchI7wAAAABJRU5ErkJggg=="
-)
-
-
 @pytest.mark.integration
 @pytest.mark.vllm
 class TestChatVlm:
     """End-to-end vision: a real Qwen3-VL-2B deployment receiving an
     ``image_url`` content part through the modelship gateway."""
 
+    _QUESTION = "What color is this image? Answer in one word."
+
     @pytest.fixture(autouse=True, scope="class")
     def _deploy(self, model_deployer):
         model_deployer.deploy("chat-vlm")
 
-    def test_chat_with_image_url_returns_response(self, client):
+    @pytest.fixture(scope="class")
+    def text_only_prompt_tokens(self, client) -> int:
         completion = client.chat.completions.create(
             model="chat-vlm",
-            messages=[
-                {
-                    "role": "user",
-                    "content": [
-                        {"type": "text", "text": "What color is this image? Answer in one word."},
-                        {"type": "image_url", "image_url": {"url": _RED_PIXEL_DATA_URI}},
-                    ],
-                }
-            ],
+            messages=[{"role": "user", "content": self._QUESTION}],
+            max_tokens=8,
+        )
+        return completion.usage.prompt_tokens
+
+    @pytest.mark.parametrize(
+        "part",
+        [
+            pytest.param({"type": "image_url", "image_url": {"url": RED_IMAGE_DATA_URI}}, id="image_url-object"),
+            pytest.param({"type": "image_url", "image_url": RED_IMAGE_DATA_URI}, id="image_url-bare-string"),
+            pytest.param({"type": "input_image", "image_url": RED_IMAGE_DATA_URI}, id="input_image"),
+        ],
+    )
+    def test_every_image_part_shape_reaches_the_backend(self, client, text_only_prompt_tokens, part):
+        # prompt_tokens, not the text: a dropped image still answers fluently.
+        completion = client.chat.completions.create(
+            model="chat-vlm",
+            messages=[{"role": "user", "content": [{"type": "text", "text": self._QUESTION}, part]}],
             max_tokens=16,
+            temperature=0.0,
         )
         assert completion.choices[0].message.content
         assert completion.choices[0].finish_reason in {"stop", "length"}
         assert completion.model == "chat-vlm"
+        assert completion.usage.prompt_tokens > text_only_prompt_tokens + 20
+        assert "red" in completion.choices[0].message.content.lower()
 
     def test_text_only_request_still_works_on_vlm(self, client):
         completion = client.chat.completions.create(
@@ -445,7 +455,7 @@ class TestChatVlm:
                     "role": "user",
                     "content": [
                         {"type": "text", "text": "Describe the image briefly."},
-                        {"type": "image_url", "image_url": {"url": _RED_PIXEL_DATA_URI}},
+                        {"type": "image_url", "image_url": {"url": RED_IMAGE_DATA_URI}},
                     ],
                 }
             ],


### PR DESCRIPTION
`_validate_part` read a Responses-style `input_image` part's URL from `part["input_image"]`, but the spec shape carries it under `image_url`. The lookup always missed, so the part was dropped as empty and the content collapsed to text-only — the request succeeded and the model answered about an image it never received. A bare-string `image_url` was passed through untouched, which llama-server rejects with "Invalid base64 value".

Both shapes are now rewritten to `{"type": "image_url", "image_url": {"url": ...}}`, preserving `detail`; an already-nested `image_url` still passes through as-is. The helper is shared, so this covers vllm and llama_server alike.

Integration coverage: a CPU SmolVLM-256M + mmproj deploy for llama_server, and all three shapes parametrized on both loaders. Assertions read `prompt_tokens` rather than the answer text — a dropped image still answers fluently, which is why the existing vision tests never caught this.


