### PR TITLE
fix: stop subtracting a cudagraph estimate from the preflight budget

### DIFF
--- a/modelship/preflight/vllm.py
+++ b/modelship/preflight/vllm.py
@@ -27,10 +27,6 @@ _MIN_MAX_NUM_SEQS = 8
 # embedding tables, torch.compile artifacts not in safetensors `total_size`.
 _OVERHEAD_WEIGHT_FRACTION = 0.14
 
-# vLLM v1's default `max_num_batched_tokens` for text-only models; the
-# baseline batch size for the CUDA-graph memory estimate below.
-_DEFAULT_TEXT_BATCHED_TOKENS = 2048
-
 # torch_dtype string -> bytes per element. KV cache uses the compute dtype,
 # not storage dtype, so AWQ/GPTQ models are still 2 bytes per element.
 _DTYPE_BYTES = {
@@ -136,18 +132,8 @@ class VllmPreflight:
         weight_bytes = _estimate_weight_footprint(model_path)
         weight_bytes_per_gpu = weight_bytes / (tp_size * pp_size) if weight_bytes else 0.0
 
-        # Resolve multimodal status + the `max_num_batched_tokens` we expect
-        # vLLM to use — both are inputs to the CUDA-graph estimate.
         is_mm = _is_multimodal(model_cfg)
         mm_tokens_per_item = _estimate_mm_tokens_per_item(model_cfg) if is_mm else None
-        mm_recommended_mnbt = _recommended_mm_batched_tokens(mm_tokens_per_item) if is_mm else None
-        effective_mnbt = (
-            config.vllm_engine_kwargs.max_num_batched_tokens or mm_recommended_mnbt or _DEFAULT_TEXT_BATCHED_TOKENS
-        )
-
-        cudagraph_bytes_per_gpu = _estimate_cudagraph_bytes_per_gpu(
-            text_cfg, model_cfg, config, effective_mnbt, tp_size, pp_size
-        )
 
         # vLLM requires homogeneous GPUs for TP; take the smallest. Fractional
         # deploys size from total capacity (total_memory * gmu); whole-GPU
@@ -159,7 +145,7 @@ class VllmPreflight:
         # A fractional num_gpus is the fraction; anything else takes the default.
         gpu_util = resolve_gpu_memory_utilization(config)
 
-        # vLLM 0.26.0's CUDA-graph memory profiler is a no-op stub, and KV-block
+        # vLLM's cudagraph profiler returns 0 on the V2 runner, and KV-block
         # commitment isn't bounded by max_model_len — gpu_util is the only lever.
         mla = _resolve_mla(text_cfg)
         mla_workspace_bytes = 0
@@ -168,45 +154,18 @@ class VllmPreflight:
             mla_workspace_bytes = _mla_chunked_prefill_workspace_bytes(text_cfg, config, dtype_bytes, mla, tp_size)
             gpu_util = max(gpu_util - _MLA_WORKSPACE_SAFETY_MARGIN * mla_workspace_bytes / gpu_basis, 0.01)
 
-        budget = (
-            gpu_basis * gpu_util
-            - weight_bytes_per_gpu
-            - _OVERHEAD_WEIGHT_FRACTION * weight_bytes_per_gpu
-            - cudagraph_bytes_per_gpu
-        )
-        # Cudagraph capture is discretionary, the state/KV floor isn't. Skipped
-        # when eager is set: an explicit `false` wins the merge downstream.
-        force_eager = False
-        if cudagraph_bytes_per_gpu and config.vllm_engine_kwargs.enforce_eager is None:
-            floor_bytes = (
-                mamba.per_seq_state_bytes * (config.vllm_engine_kwargs.max_num_seqs or _MIN_MAX_NUM_SEQS)
-                if mamba is not None
-                else kv_per_token_per_gpu * _DEFAULT_BLOCK_SIZE
-            )
-            if budget < floor_bytes:
-                logger.info(
-                    "preflight '%s': cudagraph reservation (%.2f GiB/GPU) leaves %.2f GiB, under the %.2f GiB "
-                    "floor → recommending enforce_eager to reclaim it",
-                    config.name,
-                    cudagraph_bytes_per_gpu / 1024**3,
-                    budget / 1024**3,
-                    floor_bytes / 1024**3,
-                )
-                budget += cudagraph_bytes_per_gpu
-                cudagraph_bytes_per_gpu = 0
-                force_eager = True
+        budget = gpu_basis * gpu_util - weight_bytes_per_gpu - _OVERHEAD_WEIGHT_FRACTION * weight_bytes_per_gpu
 
         if budget <= 0:
             logger.warning(
                 "preflight: '%s' has no KV-cache budget on the assigned GPU "
-                "(%s=%.2f GiB, util=%.2f, est. weights/GPU=%.2f GiB, "
-                "cudagraph/GPU=%.2f GiB). Model likely won't fit; deploy will be attempted anyway.",
+                "(%s=%.2f GiB, util=%.2f, est. weights/GPU=%.2f GiB). "
+                "Model likely won't fit; deploy will be attempted anyway.",
                 config.name,
                 "share basis (total)" if fractional else "free",
                 gpu_basis / 1024**3,
                 gpu_util,
                 weight_bytes_per_gpu / 1024**3,
-                cudagraph_bytes_per_gpu / 1024**3,
             )
             return {}
 
@@ -244,15 +203,11 @@ class VllmPreflight:
                 return {}
             rec = {"max_model_len": suggested}
 
-        if force_eager:
-            rec["enforce_eager"] = True
-
         if mla_workspace_bytes:
             rec["gpu_memory_utilization"] = round(gpu_util, 4)
 
         logger.info(
-            "preflight vllm '%s': gpu_%s=%.2f GiB util=%.2f tp=%d pp=%d "
-            "weights/GPU≈%.2f GiB cudagraph/GPU≈%.2f GiB kv/token=%d B%s → %s",
+            "preflight vllm '%s': gpu_%s=%.2f GiB util=%.2f tp=%d pp=%d weights/GPU≈%.2f GiB kv/token=%d B%s → %s",
             config.name,
             "share" if fractional else "free",
             gpu_basis / 1024**3,
@@ -260,7 +215,6 @@ class VllmPreflight:
             tp_size,
             pp_size,
             weight_bytes_per_gpu / 1024**3,
-            cudagraph_bytes_per_gpu / 1024**3,
             int(kv_per_token_per_gpu),
             f" hybrid(state {mamba.per_seq_state_bytes / 1024**2:.1f} MiB/seq)"
             if mamba
@@ -273,15 +227,15 @@ class VllmPreflight:
         )
 
         # Multimodal: bump `max_num_batched_tokens` to fit one image/audio item
-        # per batch. Must equal `effective_mnbt`, or the cudagraph estimate
-        # above goes stale.
+        # per batch.
         if is_mm:
-            rec["max_num_batched_tokens"] = effective_mnbt
+            mnbt = _recommended_mm_batched_tokens(mm_tokens_per_item)
+            rec["max_num_batched_tokens"] = mnbt
             logger.info(
                 "preflight vllm '%s': multimodal detected → suggested max_num_batched_tokens=%d "
                 "(mm_tokens_per_item≈%s)",
                 config.name,
-                effective_mnbt,
+                mnbt,
                 mm_tokens_per_item if mm_tokens_per_item is not None else "unknown",
             )
 
@@ -550,28 +504,6 @@ def _recommended_mm_batched_tokens(mm_tokens_per_item: int | None) -> int:
     if mm_tokens_per_item is not None:
         floor = max(floor, mm_tokens_per_item * 2)
     return floor
-
-
-def _estimate_cudagraph_bytes_per_gpu(
-    text_cfg: dict,
-    model_cfg: dict,
-    config: ModelshipModelConfig,
-    max_num_batched_tokens: int,
-    tp_size: int,
-    pp_size: int,
-) -> int:
-    """Estimate the VRAM vLLM's memory profiler reserves for CUDA graphs:
-    `hidden * num_layers * dtype_bytes * max_num_batched_tokens`, divided by
-    `tp_size * pp_size`. Returns 0 when `enforce_eager=True`."""
-    if config.vllm_engine_kwargs.enforce_eager:
-        return 0
-    hidden = text_cfg.get("hidden_size")
-    layers = text_cfg.get("num_hidden_layers") or text_cfg.get("num_layers")
-    if not (hidden and layers):
-        return 0
-    dtype_bytes = _resolve_compute_dtype_bytes(text_cfg, model_cfg)
-    divisor = max(tp_size, 1) * max(pp_size, 1)
-    return int(hidden * layers * dtype_bytes * max_num_batched_tokens // divisor)
 
 
 def _mla_chunked_prefill_workspace_bytes(

--- a/tests/test_preflight.py
+++ b/tests/test_preflight.py
@@ -1034,74 +1034,11 @@ def test_kv_shrinks_per_gpu_only_when_tp_divides_heads(tp_size, num_kv_heads, ex
         assert result == kv_full
 
 
-class TestCudagraphEstimation:
-    """Unit-level tests for `_estimate_cudagraph_bytes_per_gpu`."""
+class TestCudagraphNotModelled:
+    """Cudagraph memory is deliberately not subtracted: preflight only sizes
+    `max_model_len`, which doesn't bound what vLLM allocates."""
 
-    def test_matches_formula_on_gemma4_measurement(self):
-        # Anchored against a measured 2.23 GiB CUDA graph run; the formula predicts
-        # 2.46 GiB (within ~10%, slight over-estimate is the safe direction).
-        from modelship.preflight.vllm import _estimate_cudagraph_bytes_per_gpu
-
-        text_cfg = {"hidden_size": 5376, "num_hidden_layers": 60, "torch_dtype": "bfloat16"}
-        cfg = _make_config()
-        estimate = _estimate_cudagraph_bytes_per_gpu(text_cfg, text_cfg, cfg, 8192, 2, 1)
-        measured = 2.23 * 1024**3
-        assert 0.9 * measured <= estimate <= 1.2 * measured
-
-    def test_zero_when_enforce_eager(self):
-        from modelship.preflight.vllm import _estimate_cudagraph_bytes_per_gpu
-
-        text_cfg = {"hidden_size": 4096, "num_hidden_layers": 32, "torch_dtype": "bfloat16"}
-        cfg = _make_config(vllm_kwargs={"enforce_eager": True})
-        assert _estimate_cudagraph_bytes_per_gpu(text_cfg, text_cfg, cfg, 8192, 1, 1) == 0
-
-    def test_nonzero_when_enforce_eager_unset(self):
-        # None and False both mean "CUDA graphs enabled"; estimator should run.
-        from modelship.preflight.vllm import _estimate_cudagraph_bytes_per_gpu
-
-        text_cfg = {"hidden_size": 4096, "num_hidden_layers": 32, "torch_dtype": "bfloat16"}
-        for eager in (None, False):
-            cfg = _make_config(vllm_kwargs={} if eager is None else {"enforce_eager": eager})
-            assert _estimate_cudagraph_bytes_per_gpu(text_cfg, text_cfg, cfg, 8192, 1, 1) > 0
-
-    def test_zero_when_geometry_missing(self):
-        # Without hidden_size / num_layers the formula can't run; return 0 rather than
-        # guessing — the caller already over-subtracts other overheads.
-        from modelship.preflight.vllm import _estimate_cudagraph_bytes_per_gpu
-
-        cfg = _make_config()
-        assert _estimate_cudagraph_bytes_per_gpu({}, {}, cfg, 8192, 1, 1) == 0
-
-    def test_scales_linearly_with_max_num_batched_tokens(self):
-        from modelship.preflight.vllm import _estimate_cudagraph_bytes_per_gpu
-
-        text_cfg = {"hidden_size": 4096, "num_hidden_layers": 32, "torch_dtype": "bfloat16"}
-        cfg = _make_config()
-        a = _estimate_cudagraph_bytes_per_gpu(text_cfg, text_cfg, cfg, 2048, 1, 1)
-        b = _estimate_cudagraph_bytes_per_gpu(text_cfg, text_cfg, cfg, 8192, 1, 1)
-        assert b == 4 * a
-
-    def test_divides_by_tp_size(self):
-        from modelship.preflight.vllm import _estimate_cudagraph_bytes_per_gpu
-
-        text_cfg = {"hidden_size": 4096, "num_hidden_layers": 32, "torch_dtype": "bfloat16"}
-        cfg = _make_config()
-        single = _estimate_cudagraph_bytes_per_gpu(text_cfg, text_cfg, cfg, 8192, 1, 1)
-        tp2 = _estimate_cudagraph_bytes_per_gpu(text_cfg, text_cfg, cfg, 8192, 2, 1)
-        assert tp2 == single // 2
-
-    def test_divides_by_pp_size(self):
-        from modelship.preflight.vllm import _estimate_cudagraph_bytes_per_gpu
-
-        text_cfg = {"hidden_size": 4096, "num_hidden_layers": 32, "torch_dtype": "bfloat16"}
-        cfg = _make_config()
-        single = _estimate_cudagraph_bytes_per_gpu(text_cfg, text_cfg, cfg, 8192, 1, 1)
-        pp2 = _estimate_cudagraph_bytes_per_gpu(text_cfg, text_cfg, cfg, 8192, 1, 2)
-        assert pp2 == single // 2
-
-    def test_enforce_eager_widens_max_model_len_recommendation(self, tmp_path):
-        """End-to-end: turning on enforce_eager should give a larger budget
-        (no CUDA-graph overhead subtracted) and therefore a higher max_model_len."""
+    def test_enforce_eager_does_not_change_max_model_len(self, tmp_path):
         snapshot = _write_model_snapshot(
             tmp_path,
             config_json={
@@ -1116,26 +1053,19 @@ class TestCudagraphEstimation:
             weight_bytes=15 * 1024**3,
         )
         hw = HardwareProfile(gpus=[GPUInfo(0, 24 * 1024**3, "test")])
-        cfg_graphs = _make_config(
-            resolved_path=str(snapshot),
+        rec_graphs = VllmPreflight().recommend(_make_config(resolved_path=str(snapshot)), hw)
+        rec_eager = VllmPreflight().recommend(
+            _make_config(resolved_path=str(snapshot), vllm_kwargs={"enforce_eager": True}), hw
         )
-        cfg_eager = _make_config(
-            resolved_path=str(snapshot),
-            vllm_kwargs={"enforce_eager": True},
-        )
-        rec_graphs = VllmPreflight().recommend(cfg_graphs, hw)
-        rec_eager = VllmPreflight().recommend(cfg_eager, hw)
-        assert rec_eager["max_model_len"] > rec_graphs["max_model_len"]
+        assert rec_eager["max_model_len"] == rec_graphs["max_model_len"]
 
-    def test_mla_chunked_prefill_workspace_matches_deepseek_v2_lite_oom(self):
-        # Anchored against a real DeepSeek-V2-Lite-AWQ OOM: PyTorch reported
-        # "Tried to allocate 512.00 MiB" for exactly this buffer.
-        from modelship.preflight.vllm import _mla_chunked_prefill_workspace_bytes, _resolve_mla
-
-        mla = _resolve_mla(_MLA_CFG)
-        assert mla is not None
-        workspace = _mla_chunked_prefill_workspace_bytes(_MLA_CFG, _make_config(), 2, mla, 1)
-        assert workspace == 512 * 1024**2
+    @pytest.mark.parametrize("gpu_gib", [10.8, 40])
+    def test_never_recommends_enforce_eager(self, tmp_path, gpu_gib):
+        # 10.8 GiB is where the old cudagraph reclaim used to fire.
+        snapshot = _write_model_snapshot(tmp_path, config_json=_HYBRID_CFG, weight_bytes=8 * 1024**3)
+        hw = HardwareProfile(gpus=[GPUInfo(0, int(gpu_gib * 1024**3), "test")])
+        with patch("modelship.preflight.vllm._resolve_mamba_state", return_value=_mamba_info()):
+            assert "enforce_eager" not in VllmPreflight().recommend(_make_config(resolved_path=str(snapshot)), hw)
 
 
 # DeepSeek-V2-Lite's real config.json fields (deepseek-ai/DeepSeek-V2-Lite).
@@ -1231,6 +1161,16 @@ class TestMlaKvCache:
         config = _make_config(vllm_kwargs={"max_model_len": 1024, "max_num_seqs": 8192})
         row_bytes = mla.num_heads * (mla.qk_nope_head_dim + mla.v_head_dim) * 2
         assert _mla_chunked_prefill_workspace_bytes(_MLA_CFG, config, 2, mla, 1) == 8192 * 16 * row_bytes
+
+    def test_mla_chunked_prefill_workspace_matches_deepseek_v2_lite_oom(self):
+        # Anchored against a real DeepSeek-V2-Lite-AWQ OOM: PyTorch reported
+        # "Tried to allocate 512.00 MiB" for exactly this buffer.
+        from modelship.preflight.vllm import _mla_chunked_prefill_workspace_bytes, _resolve_mla
+
+        mla = _resolve_mla(_MLA_CFG)
+        assert mla is not None
+        workspace = _mla_chunked_prefill_workspace_bytes(_MLA_CFG, _make_config(), 2, mla, 1)
+        assert workspace == 512 * 1024**2
 
     def test_recommend_lowers_gpu_memory_utilization_with_cudagraphs(self, tmp_path):
         # vLLM's own CUDA-graph memory profiler doesn't reserve room for this
@@ -1385,31 +1325,6 @@ class TestHybridIntegration:
             rec = VllmPreflight().recommend(cfg, hw)
         assert rec["max_model_len"] == _HYBRID_CFG["max_position_embeddings"]
         assert rec["max_num_seqs"] > 8
-
-    def test_cudagraph_starving_the_state_floor_recommends_eager(self, tmp_path):
-        snapshot = _write_model_snapshot(tmp_path, config_json=_HYBRID_CFG, weight_bytes=8 * 1024**3)
-        cfg = _make_config(resolved_path=str(snapshot))
-        # State floor fits only once the cudagraph bytes come back.
-        hw = HardwareProfile(gpus=[GPUInfo(0, int(10.8 * 1024**3), "test")])
-        with patch("modelship.preflight.vllm._resolve_mamba_state", return_value=_mamba_info()):
-            rec = VllmPreflight().recommend(cfg, hw)
-        assert rec["enforce_eager"] is True
-        assert rec["max_num_seqs"] == 8
-        assert rec["max_model_len"] >= 16
-
-    def test_explicit_eager_false_blocks_the_cudagraph_reclaim(self, tmp_path):
-        snapshot = _write_model_snapshot(tmp_path, config_json=_HYBRID_CFG, weight_bytes=8 * 1024**3)
-        cfg = _make_config(resolved_path=str(snapshot), vllm_kwargs={"enforce_eager": False})
-        hw = HardwareProfile(gpus=[GPUInfo(0, int(10.8 * 1024**3), "test")])
-        with patch("modelship.preflight.vllm._resolve_mamba_state", return_value=_mamba_info()):
-            assert VllmPreflight().recommend(cfg, hw) == {}
-
-    def test_roomy_gpu_leaves_enforce_eager_alone(self, tmp_path):
-        snapshot = _write_model_snapshot(tmp_path, config_json=_HYBRID_CFG, weight_bytes=8 * 1024**3)
-        cfg = _make_config(resolved_path=str(snapshot))
-        hw = HardwareProfile(gpus=[GPUInfo(0, 40 * 1024**3, "test")])
-        with patch("modelship.preflight.vllm._resolve_mamba_state", return_value=_mamba_info()):
-            assert "enforce_eager" not in VllmPreflight().recommend(cfg, hw)
 
     def test_cpu_auto_gmu_hybrid_folds_state_into_gmu(self, tmp_path):
         snapshot = _write_model_snapshot(tmp_path, config_json=_HYBRID_CFG, weight_bytes=8 * 1024**3)


### PR DESCRIPTION
`budget` feeds only the recommended max_model_len/max_num_seqs, and max_model_len does not bound what vLLM allocates -- gpu_memory_utilization does. Measured on Qwen3-0.6B at gmu 0.9: preflight subtracted 0.11 GiB and recommended a 40,960 context, while vLLM committed a 119,696-token KV pool, 2.9x more than one full-length request can use. The subtraction cannot prevent an OOM; it only advertises a smaller context than fits.

vLLM does subtract its own estimate from the KV pool, but profile_cudagraph_memory() returns 0 on the V2 model runner, and neither of the log lines gated on a non-zero estimate appeared on a dense or a hybrid deploy here -- so there was nothing to mirror either.

This removes the enforce_eager reclaim with it, since the estimate was its only trigger: it flipped a large performance switch off a number that was sized against the wrong lever. Preflight now never recommends enforce_eager; an explicit user setting is untouched, as is the MLA gpu_memory_utilization adjustment, which does move the lever that matters.

Verified live: dense and hybrid deploys are byte-identical before and after.


