### PR TITLE
fix: stop retrying a failing deploy forever

### DIFF
--- a/modelship/deploy/strategy.py
+++ b/modelship/deploy/strategy.py
@@ -15,8 +15,7 @@ from modelship.logging import get_logger
 logger = get_logger("startup")
 
 _DEPLOY_RETRY_SLEEP_S = 2.0
-# Attempts a model gets before the driver stops retrying it. Only a pass where the
-# deploy actually ran and raised consumes one; a capacity skip never does.
+# Only a pass that reached serve.run and raised consumes one; a skip never does.
 _MAX_TRANSIENT_FAILURES = 3
 _WAITING_LOG_EVERY_N_PASSES = 30  # with 2s sleep, log "still waiting" once per minute
 
@@ -35,10 +34,8 @@ class DeployPlan:
 
     models_to_add: list[ModelshipModelConfig]
     apps_to_remove: list[str]
-    # Previously-effective deployments that are no longer desired AND aren't live
-    # (no Serve app to delete) — e.g. reloaded from the durable registry after a
-    # cluster restart. They have no app to delete, but their stale coordinator
-    # registry entry must still be dropped or the gateway routes to a ghost.
+    # Dropped deployments with no live app to delete — only their stale coordinator
+    # registry entry needs clearing, or the gateway routes to a ghost.
     registry_only_drop: list[str]
 
 
@@ -48,18 +45,14 @@ def compute_deploy_plan(
     prev_effective_names: set[str],
     gateway_name: str,
 ) -> DeployPlan:
-    """Diff the desired effective set against what's live. The deploy ALWAYS
-    reconciles live -> desired (the merge verb already folded additive/reconcile
-    into `desired_conf`). Deployment names are `{model}-{fingerprint}`, so
-    a pure set comparison detects renames and config drift.
+    """Diff the desired effective set against what's live. The merge verb already
+    folded additive/reconcile into `desired_conf`, so this always reconciles
+    live -> desired. Deployment names are `{model}-{fingerprint}`, so a set
+    comparison detects renames and config drift.
 
-    Removal is scoped to `prev_effective_names` — the deployments that were under
-    THIS gateway's effective management before this run — intersected with what's
-    actually live. This is what keeps reconcile non-destructive: legacy/un-tracked
-    deployments (e.g. live models from before the effective config existed) and
-    other gateways' apps are never removed; only models the effective set itself
-    dropped are. An empty prev-effective set (migration / fresh install) therefore
-    removes nothing."""
+    Removal is `prev_effective_names & existing_apps`: only deployments THIS
+    gateway previously managed are removed, never untracked ones or another
+    gateway's. An empty prev-effective set removes nothing."""
 
     # Sort key: footprint desc, whole-GPU before fractional, larger fraction first.
     def _gpu_footprint(c: ModelshipModelConfig) -> tuple[int, bool, float]:
@@ -76,10 +69,8 @@ def compute_deploy_plan(
 
     desired_names = {c.deployment_name(gateway_name) for c in sorted_models}
 
-    # All previously-effective deployments this run drops, split by liveness:
-    # the live ones get serve.delete + registry drop; the rest (tracked but not
-    # live — typically resurrected from the durable registry onto a fresh cluster)
-    # get a registry-only drop so the gateway stops routing to a non-existent app.
+    # Split the dropped set by liveness: live ones get serve.delete + a registry
+    # drop, the rest a registry-only drop.
     dropped = prev_effective_names - desired_names
     apps_to_remove = sorted(dropped & existing_apps)
     registry_only_drop = sorted(dropped - existing_apps)
@@ -92,8 +83,8 @@ def compute_deploy_plan(
             registry_only_drop,
         )
 
-    # Skip configs already live under their fingerprint — makes re-runs idempotent
-    # and adopts a matching un-tracked deployment instead of redeploying it.
+    # Already live under its fingerprint -> skip, so re-runs are idempotent and a
+    # matching untracked deployment is adopted rather than redeployed.
     models_to_add = [c for c in sorted_models if c.deployment_name(gateway_name) not in existing_apps]
     if models_to_add:
         logger.info(
@@ -139,8 +130,7 @@ def try_reserve_and_deploy(config: ModelshipModelConfig, ctx: DeployContext) -> 
     if not reserved:
         return "skipped", None
 
-    # Replica sizing: autoscaling_config and a fixed num_replicas are mutually
-    # exclusive (enforced at config validation) — pass exactly one to Serve.
+    # Mutually exclusive, enforced at config validation — pass Serve exactly one.
     if config.autoscaling_config is not None:
         scaling_opts: dict = {"autoscaling_config": config.autoscaling_config.to_serve_dict()}
     else:
@@ -161,9 +151,8 @@ def try_reserve_and_deploy(config: ModelshipModelConfig, ctx: DeployContext) -> 
             route_prefix=None,
         )
         logger.info("Model ready: %s (deployment: %s)", config.name, deployment_name)
-        # Record ownership in the replica coordinator — the single source of truth.
-        # This bumps the gateway's generation, so every gateway replica's watch loop
-        # picks the new deployment up (the driver never pushes to replicas directly).
+        # Registering bumps the gateway's generation; replica watch loops pick the
+        # deployment up from there, so the driver never pushes to them.
         try:
             ray.get(ctx.replica_coordinator.register_deployment.remote(ctx.gateway_name, deployment_name, config.name))
         except Exception:
@@ -193,9 +182,8 @@ def try_reserve_and_deploy(config: ModelshipModelConfig, ctx: DeployContext) -> 
         )
         return "transient", f"{type(exc).__name__}: {exc}"
     finally:
-        # Ray may already be shut down (e.g. SIGINT cleanup ran shutdown_ray);
-        # the OperatorProbe death-detection will free the lock either way once
-        # the driver dies.
+        # Ray may already be shut down; OperatorProbe death-detection frees the
+        # lock either way once the driver dies.
         if ray.is_initialized():
             try:
                 ray.get(ctx.coordinator.release.remote(ctx.operator_id))
@@ -207,20 +195,16 @@ def run_deploy_loop(
     models: list[ModelshipModelConfig],
     ctx: DeployContext,
 ) -> tuple[int, list[tuple[ModelshipModelConfig, str]]]:
-    """Retry-pass loop: each pass tries every not-yet-deployed model. Models
-    whose resources don't currently fit (or whose reservation is rejected
-    because another operator holds the lock) are skipped and retried on the
-    next pass, indefinitely — waiting for a node to join is legitimate.
-    Placeable models deploy in configured order (TP>1 first).
+    """Retry-pass loop: each pass tries every not-yet-deployed model, in configured
+    order (TP>1 first). A model skipped for resources or a held lock is retried
+    indefinitely. One whose deploy raises gets `_MAX_TRANSIENT_FAILURES` attempts,
+    the pass sleep doubling each time, then is given up on as fatal — without the
+    cap it holds this loop, and the caller's removals and effective-config write,
+    forever.
 
-    A model whose deploy actually runs and raises gets `_MAX_TRANSIENT_FAILURES`
-    attempts, the pass sleep doubling each time, then is given up on as fatal.
-    Without that cap one crash-looping model holds this loop forever, and the
-    caller's app removals and effective-config write never run.
-
-    Returns (pass_count, fatally_failed) where fatally_failed pairs each
-    permanently-failed config with its error detail — the caller logs each one
-    and keeps it in the effective config, so a later deploy retries it."""
+    Returns (pass_count, fatally_failed), pairing each permanently-failed config
+    with its error detail. The caller logs them and keeps them in the effective
+    config, so a later deploy retries."""
     remaining = list(models)
     fatally_failed: list[tuple[ModelshipModelConfig, str]] = []
     failures: dict[str, int] = {}
@@ -268,8 +252,7 @@ def run_deploy_loop(
                 )
 
         if remaining:
-            # Back off only for models that have actually failed; a pure capacity
-            # wait keeps the base cadence.
+            # Back off only for models that failed; a capacity wait keeps the base cadence.
             worst = max(failures.get(c.deployment_name(ctx.gateway_name), 0) for c in remaining)
             time.sleep(_DEPLOY_RETRY_SLEEP_S * 2**worst)
 

--- a/modelship/deploy/strategy.py
+++ b/modelship/deploy/strategy.py
@@ -15,7 +15,18 @@ from modelship.logging import get_logger
 logger = get_logger("startup")
 
 _DEPLOY_RETRY_SLEEP_S = 2.0
+# Attempts a model gets before the driver stops retrying it. Only a pass where the
+# deploy actually ran and raised consumes one; a capacity skip never does.
+_MAX_TRANSIENT_FAILURES = 3
 _WAITING_LOG_EVERY_N_PASSES = 30  # with 2s sleep, log "still waiting" once per minute
+
+
+def _delete_failed_app(deployment_name: str) -> None:
+    """serve.run leaves the application behind when it raises."""
+    try:
+        serve.delete(deployment_name)
+    except Exception:
+        logger.exception("Failed to delete failed deployment: %s", deployment_name)
 
 
 @dataclass
@@ -110,8 +121,9 @@ class DeployContext:
 
 def try_reserve_and_deploy(config: ModelshipModelConfig, ctx: DeployContext) -> tuple[str, str | None]:
     """One attempt at deploying *config*. Returns (status, detail) where status is:
-    "skipped" (no progress, retry), "deployed", "transient" (deploy raised; retry),
-    "fatal" (deployment reported a permanent error; skip permanently)."""
+    "skipped" (no progress, retry), "deployed", "transient" (deploy raised; retry,
+    detail is the exception), "fatal" (deployment reported a permanent error; skip
+    permanently)."""
     deploy_opts = build_deployment_options(config)
     deployment_name = config.deployment_name(ctx.gateway_name)
 
@@ -157,7 +169,7 @@ def try_reserve_and_deploy(config: ModelshipModelConfig, ctx: DeployContext) -> 
         except Exception:
             logger.exception("Failed to record %s in deploy registry", deployment_name)
         return "deployed", None
-    except Exception:
+    except Exception as exc:
         # Did the deployment actively report a fatal init error before dying?
         try:
             fatal_err = ray.get(ctx.coordinator.pop_fatal_error.remote(deployment_name), timeout=2.0)
@@ -172,17 +184,14 @@ def try_reserve_and_deploy(config: ModelshipModelConfig, ctx: DeployContext) -> 
                 deployment_name,
                 fatal_err,
             )
-            try:
-                serve.delete(deployment_name)
-            except Exception:
-                logger.exception("Failed to delete failed deployment: %s", deployment_name)
+            _delete_failed_app(deployment_name)
             return "fatal", str(fatal_err)
         logger.exception(
             "Deploy failed for %s (deployment=%s); will retry next pass.",
             config.name,
             deployment_name,
         )
-        return "transient", None
+        return "transient", f"{type(exc).__name__}: {exc}"
     finally:
         # Ray may already be shut down (e.g. SIGINT cleanup ran shutdown_ray);
         # the OperatorProbe death-detection will free the lock either way once
@@ -201,14 +210,20 @@ def run_deploy_loop(
     """Retry-pass loop: each pass tries every not-yet-deployed model. Models
     whose resources don't currently fit (or whose reservation is rejected
     because another operator holds the lock) are skipped and retried on the
-    next pass. Placeable models deploy in configured order (TP>1 first).
+    next pass, indefinitely — waiting for a node to join is legitimate.
+    Placeable models deploy in configured order (TP>1 first).
+
+    A model whose deploy actually runs and raises gets `_MAX_TRANSIENT_FAILURES`
+    attempts, the pass sleep doubling each time, then is given up on as fatal.
+    Without that cap one crash-looping model holds this loop forever, and the
+    caller's app removals and effective-config write never run.
 
     Returns (pass_count, fatally_failed) where fatally_failed pairs each
-    permanently-failed config with its error detail — the caller logs the name
-    and evicts the deployment from the effective config so a re-assert doesn't
-    retry it forever."""
+    permanently-failed config with its error detail — the caller logs each one
+    and keeps it in the effective config, so a later deploy retries it."""
     remaining = list(models)
     fatally_failed: list[tuple[ModelshipModelConfig, str]] = []
+    failures: dict[str, int] = {}
     pass_count = 0
     passes_with_no_progress = 0
 
@@ -216,6 +231,7 @@ def run_deploy_loop(
         pass_count += 1
         made_progress = False
         for config in list(remaining):
+            deployment_name = config.deployment_name(ctx.gateway_name)
             status, detail = try_reserve_and_deploy(config, ctx)
             if status == "deployed":
                 remaining.remove(config)
@@ -224,7 +240,21 @@ def run_deploy_loop(
                 fatally_failed.append((config, detail or ""))
                 remaining.remove(config)
                 made_progress = True
-            # "skipped" / "transient" -> stay in `remaining` for the next pass
+            elif status == "transient":
+                failures[deployment_name] = failures.get(deployment_name, 0) + 1
+                if failures[deployment_name] >= _MAX_TRANSIENT_FAILURES:
+                    logger.error(
+                        "Giving up on model '%s' after %d failed attempt(s) (deployment=%s): %s",
+                        config.name,
+                        failures[deployment_name],
+                        deployment_name,
+                        detail,
+                    )
+                    _delete_failed_app(deployment_name)
+                    fatally_failed.append((config, detail or ""))
+                    remaining.remove(config)
+                    made_progress = True
+            # "skipped" -> stays in `remaining` for the next pass
 
         if made_progress:
             passes_with_no_progress = 0
@@ -238,6 +268,9 @@ def run_deploy_loop(
                 )
 
         if remaining:
-            time.sleep(_DEPLOY_RETRY_SLEEP_S)
+            # Back off only for models that have actually failed; a pure capacity
+            # wait keeps the base cadence.
+            worst = max(failures.get(c.deployment_name(ctx.gateway_name), 0) for c in remaining)
+            time.sleep(_DEPLOY_RETRY_SLEEP_S * 2**worst)
 
     return pass_count, fatally_failed

--- a/tests/test_deploy_retry_limit.py
+++ b/tests/test_deploy_retry_limit.py
@@ -1,0 +1,113 @@
+"""`run_deploy_loop` must give up on a model that keeps failing to deploy, while
+still waiting indefinitely for one that is only short of capacity."""
+
+from unittest.mock import MagicMock
+
+import pytest
+from ray.serve.schema import LoggingConfig
+
+from modelship.deploy import strategy
+from modelship.infer.infer_config import ModelshipModelConfig
+
+
+def _model(name: str) -> ModelshipModelConfig:
+    return ModelshipModelConfig.model_validate(
+        {"name": name, "model": f"org/{name}", "usecase": "generate", "loader": "vllm", "num_gpus": 1}
+    )
+
+
+def _ctx() -> strategy.DeployContext:
+    return strategy.DeployContext(
+        coordinator=MagicMock(),
+        replica_coordinator=MagicMock(),
+        probe=MagicMock(),
+        operator_id="op-1",
+        gateway_name="g",
+        serve_logging_config=LoggingConfig(),
+        deployed_this_run={},
+    )
+
+
+@pytest.fixture
+def loop(monkeypatch):
+    """Drives run_deploy_loop off a per-model script of statuses, recording the
+    pass sleeps and any app deletion. The last entry of a script repeats."""
+    sleeps: list[float] = []
+    deleted: list[str] = []
+    monkeypatch.setattr(strategy.time, "sleep", lambda s: sleeps.append(s))
+    monkeypatch.setattr(strategy.serve, "delete", lambda name: deleted.append(name))
+
+    def run(scripts: dict[str, list[tuple[str, str | None]]]):
+        calls: dict[str, int] = {}
+
+        def fake_attempt(config, ctx):
+            script = scripts[config.name]
+            i = calls.get(config.name, 0)
+            calls[config.name] = i + 1
+            return script[min(i, len(script) - 1)]
+
+        monkeypatch.setattr(strategy, "try_reserve_and_deploy", fake_attempt)
+        models = [_model(name) for name in scripts]
+        passes, failed = strategy.run_deploy_loop(models, _ctx())
+        return {
+            "passes": passes,
+            "failed": {c.name: detail for c, detail in failed},
+            "attempts": calls,
+            "sleeps": sleeps,
+            "deleted": deleted,
+        }
+
+    return run
+
+
+TRANSIENT = ("transient", "RuntimeError: engine died")
+SKIPPED = ("skipped", None)
+DEPLOYED = ("deployed", None)
+
+
+class TestTransientCap:
+    def test_a_model_that_always_fails_is_given_up_on(self, loop):
+        r = loop({"a": [TRANSIENT]})
+        assert r["attempts"]["a"] == strategy._MAX_TRANSIENT_FAILURES
+        assert r["failed"] == {"a": "RuntimeError: engine died"}
+
+    def test_giving_up_deletes_the_failed_app(self, loop):
+        r = loop({"a": [TRANSIENT]})
+        assert r["deleted"] == [_model("a").deployment_name("g")]
+
+    def test_a_recovering_model_is_not_given_up_on(self, loop):
+        r = loop({"a": [TRANSIENT, TRANSIENT, DEPLOYED]})
+        assert r["failed"] == {}
+        assert r["attempts"]["a"] == 3
+
+    def test_a_fatal_report_still_wins_immediately(self, loop):
+        r = loop({"a": [("fatal", "bad config")]})
+        assert r["attempts"]["a"] == 1
+        assert r["failed"] == {"a": "bad config"}
+
+    def test_one_failing_model_does_not_strand_a_healthy_one(self, loop):
+        r = loop({"a": [TRANSIENT], "b": [DEPLOYED]})
+        assert r["failed"] == {"a": "RuntimeError: engine died"}
+        assert r["attempts"]["b"] == 1
+
+
+class TestCapacityWaitIsUncapped:
+    def test_skips_never_consume_an_attempt(self, loop):
+        r = loop({"a": [SKIPPED] * 20 + [DEPLOYED]})
+        assert r["failed"] == {}
+        assert r["attempts"]["a"] == 21
+
+    def test_a_skip_between_failures_does_not_reset_the_count(self, loop):
+        r = loop({"a": [TRANSIENT, SKIPPED, TRANSIENT, SKIPPED, TRANSIENT]})
+        assert r["failed"] == {"a": "RuntimeError: engine died"}
+
+
+class TestBackoff:
+    def test_the_pass_sleep_doubles_per_failure(self, loop):
+        r = loop({"a": [TRANSIENT]})
+        # No sleep after the pass that gives up — nothing is left to retry.
+        assert r["sleeps"] == [2 * strategy._DEPLOY_RETRY_SLEEP_S, 4 * strategy._DEPLOY_RETRY_SLEEP_S]
+
+    def test_a_pure_capacity_wait_keeps_the_base_cadence(self, loop):
+        r = loop({"a": [SKIPPED, SKIPPED, DEPLOYED]})
+        assert r["sleeps"] == [strategy._DEPLOY_RETRY_SLEEP_S] * 2


### PR DESCRIPTION
run_deploy_loop re-queued a "transient" model on every pass with no cap. A model whose deploy raises without the actor reporting a fatal error — both os._exit(1) paths, an OOM-kill, a lost node — retried indefinitely, and since the loop only returns once `remaining` empties, the caller's app removals and effective-config write never ran either.

A model now gets _MAX_TRANSIENT_FAILURES (3) attempts that actually reached serve.run and raised, with the pass sleep doubling between them, then is given up on as fatal — logged, app deleted, kept in the effective config so a later deploy retries it. A capacity skip consumes no attempt and keeps the base 2s cadence, so waiting for a node to join stays unbounded.

try_reserve_and_deploy now returns the exception as the transient detail, so the give-up log and fatally_failed carry a reason. Also corrects the docstring claim that the caller evicts fatally-failed models from the effective config — driver.py deliberately persists them.

