### PR TITLE
Fix/preflight auto fit sentinel

### DIFF
--- a/docs/model-configuration.md
+++ b/docs/model-configuration.md
@@ -233,7 +233,7 @@ Two vLLM settings are **not** keys here, because modelship derives them and sett
 |---|---|---|---|
 | `tensor_parallel_size` | int | `1` | GPUs for tensor parallelism |
 | `pipeline_parallel_size` | int | `1` | GPUs for pipeline parallelism |
-| `max_model_len` | int | auto | Max sequence length. On GPU, preflight passes `-1` and vLLM fits the largest context its own post-profiling memory allows (the min across workers, so TP/PP are covered). On `num_gpus: 0`, preflight sizes it from host RAM instead, falling back to vLLM's own default when it declines (missing `config.json`, unreadable KV-cache geometry, etc.). Setting it explicitly overrides both |
+| `max_model_len` | int | auto | Max sequence length; must be positive if set. Left unset on GPU, vLLM fits the largest context its own post-profiling memory allows (the min across workers, so TP/PP are covered). On `num_gpus: 0`, preflight sizes it from host RAM instead, falling back to that same auto-fit when it declines (missing `config.json`, unreadable KV-cache geometry, etc.). Setting it explicitly overrides both |
 | `dtype` | string | `auto` | `auto`, `float16`, `bfloat16` |
 | `tokenizer` | string | model default | Custom tokenizer path |
 | `trust_remote_code` | bool | `false` | Allow remote code execution |

--- a/modelship/infer/vllm/vllm_infer.py
+++ b/modelship/infer/vllm/vllm_infer.py
@@ -112,6 +112,14 @@ from modelship.utils import base_request_id
 
 logger = get_logger("infer.vllm")
 
+# vLLM's sentinel for "fit the context to what memory profiling leaves".
+_AUTO_FIT_MAX_MODEL_LEN = -1
+
+
+def resolve_max_model_len(engine_kwargs: VllmEngineConfig) -> int:
+    """Derived, not a config key: the schema takes a real length or nothing."""
+    return engine_kwargs.max_model_len or _AUTO_FIT_MAX_MODEL_LEN
+
 
 def _to_error_response(
     err: VllmValidationError | VllmErrorResponse | Exception | str,
@@ -352,7 +360,7 @@ class VllmInfer(BaseInfer[_VllmPrepared]):
             model=self._model_path,
             tensor_parallel_size=self.vllm_engine_kwargs.tensor_parallel_size,
             pipeline_parallel_size=self.vllm_engine_kwargs.pipeline_parallel_size,
-            max_model_len=cast("int", self.vllm_engine_kwargs.max_model_len),
+            max_model_len=resolve_max_model_len(self.vllm_engine_kwargs),
             dtype=cast("VllmModelDType", self.vllm_engine_kwargs.dtype),
             tokenizer=self.vllm_engine_kwargs.tokenizer,
             trust_remote_code=self.vllm_engine_kwargs.trust_remote_code,

--- a/modelship/preflight/vllm.py
+++ b/modelship/preflight/vllm.py
@@ -13,6 +13,7 @@ from modelship.preflight._mla import MLAInfo
 from modelship.preflight._mla import kv_bytes_per_token as mla_kv_bytes_per_token
 from modelship.preflight._sliding_window import SlidingWindowInfo, fit_len_with_sliding, seq_kv_bytes
 from modelship.preflight.base import HardwareProfile
+from modelship.utils.config_schema import AUTO_FIT_MAX_MODEL_LEN
 
 logger = get_logger("preflight.vllm")
 
@@ -22,9 +23,6 @@ _DEFAULT_BLOCK_SIZE = 16
 # Concurrency floor for hybrid/SSM models: vLLM parks a fixed recurrent-state
 # buffer per sequence slot (sized by max_num_seqs, not max_model_len).
 _MIN_MAX_NUM_SEQS = 8
-
-# vLLM's sentinel for "fit the context to what memory profiling leaves".
-_AUTO_FIT_MAX_MODEL_LEN = -1
 
 # Overhead on top of weight bytes: AWQ/Marlin transposed packs, quant scales,
 # embedding tables, torch.compile artifacts not in safetensors `total_size`.
@@ -70,9 +68,9 @@ _MLA_WORKSPACE_SAFETY_MARGIN = 1.1
 
 
 def _user_context_length(config: ModelshipModelConfig) -> int | None:
-    """The user's max_model_len as a length — None for `_AUTO_FIT_MAX_MODEL_LEN`."""
+    """The user's max_model_len as a length — None for `AUTO_FIT_MAX_MODEL_LEN`."""
     value = config.vllm_engine_kwargs.max_model_len
-    return value if value is not None and value > 0 else None
+    return None if value == AUTO_FIT_MAX_MODEL_LEN else value
 
 
 class VllmPreflight:
@@ -89,7 +87,7 @@ class VllmPreflight:
         # vLLM binary-searches the largest context its post-profiling KV pool
         # holds, per worker. Skipped when set, so the merge has nothing to warn on.
         if config.vllm_engine_kwargs.max_model_len is None:
-            rec["max_model_len"] = _AUTO_FIT_MAX_MODEL_LEN
+            rec["max_model_len"] = AUTO_FIT_MAX_MODEL_LEN
 
         model_path = config._resolved_path
         if not model_path:

--- a/modelship/preflight/vllm.py
+++ b/modelship/preflight/vllm.py
@@ -13,7 +13,6 @@ from modelship.preflight._mla import MLAInfo
 from modelship.preflight._mla import kv_bytes_per_token as mla_kv_bytes_per_token
 from modelship.preflight._sliding_window import SlidingWindowInfo, fit_len_with_sliding, seq_kv_bytes
 from modelship.preflight.base import HardwareProfile
-from modelship.utils.config_schema import AUTO_FIT_MAX_MODEL_LEN
 
 logger = get_logger("preflight.vllm")
 
@@ -67,12 +66,6 @@ _VLLM_DEFAULT_MAX_NUM_SEQS = 128
 _MLA_WORKSPACE_SAFETY_MARGIN = 1.1
 
 
-def _user_context_length(config: ModelshipModelConfig) -> int | None:
-    """The user's max_model_len as a length — None for `AUTO_FIT_MAX_MODEL_LEN`."""
-    value = config.vllm_engine_kwargs.max_model_len
-    return None if value == AUTO_FIT_MAX_MODEL_LEN else value
-
-
 class VllmPreflight:
     def recommend(self, config: ModelshipModelConfig, hw: HardwareProfile) -> dict[str, Any]:
         # Branch on the reservation, not hardware discoverability —
@@ -84,11 +77,6 @@ class VllmPreflight:
 
     def _recommend_gpu(self, config: ModelshipModelConfig, hw: HardwareProfile) -> dict[str, Any]:
         rec: dict[str, Any] = {}
-        # vLLM binary-searches the largest context its post-profiling KV pool
-        # holds, per worker. Skipped when set, so the merge has nothing to warn on.
-        if config.vllm_engine_kwargs.max_model_len is None:
-            rec["max_model_len"] = AUTO_FIT_MAX_MODEL_LEN
-
         model_path = config._resolved_path
         if not model_path:
             logger.info("preflight '%s': no resolved model path; auto-fit only", config.name)
@@ -285,7 +273,7 @@ class VllmPreflight:
         """Hybrid on the auto-gmu path: splits kv_budget between mamba state and
         attention KV, then back-computes a gmu covering weights + state + KV
         (vLLM sizes CPU KV budget as gmu*RAM - RSS)."""
-        target_len = _user_context_length(config) or ctx_cap
+        target_len = config.vllm_engine_kwargs.max_model_len or ctx_cap
         rec = _apply_hybrid_fit(
             config.name,
             kv_budget,
@@ -424,7 +412,9 @@ def _mla_chunked_prefill_workspace_bytes(
     """MLA's decompressed-K/V scratch buffer, sized by context length —
     mirrors vLLM's `determine_chunked_prefill_workspace_size`."""
     max_model_len = (
-        _user_context_length(config) or text_cfg.get("max_position_embeddings") or _UNKNOWN_CONTEXT_LENGTH_CAP
+        config.vllm_engine_kwargs.max_model_len
+        or text_cfg.get("max_position_embeddings")
+        or _UNKNOWN_CONTEXT_LENGTH_CAP
     )
     # Larger of 8 full-length requests and 4 pages per slot, capped, then
     # re-floored at one page per slot — that floor is applied after the cap.

--- a/modelship/preflight/vllm.py
+++ b/modelship/preflight/vllm.py
@@ -69,6 +69,12 @@ _VLLM_DEFAULT_MAX_NUM_SEQS = 128
 _MLA_WORKSPACE_SAFETY_MARGIN = 1.1
 
 
+def _user_context_length(config: ModelshipModelConfig) -> int | None:
+    """The user's max_model_len as a length — None for `_AUTO_FIT_MAX_MODEL_LEN`."""
+    value = config.vllm_engine_kwargs.max_model_len
+    return value if value is not None and value > 0 else None
+
+
 class VllmPreflight:
     def recommend(self, config: ModelshipModelConfig, hw: HardwareProfile) -> dict[str, Any]:
         # Branch on the reservation, not hardware discoverability —
@@ -281,7 +287,7 @@ class VllmPreflight:
         """Hybrid on the auto-gmu path: splits kv_budget between mamba state and
         attention KV, then back-computes a gmu covering weights + state + KV
         (vLLM sizes CPU KV budget as gmu*RAM - RSS)."""
-        target_len = config.vllm_engine_kwargs.max_model_len or ctx_cap
+        target_len = _user_context_length(config) or ctx_cap
         rec = _apply_hybrid_fit(
             config.name,
             kv_budget,
@@ -420,9 +426,7 @@ def _mla_chunked_prefill_workspace_bytes(
     """MLA's decompressed-K/V scratch buffer, sized by context length —
     mirrors vLLM's `determine_chunked_prefill_workspace_size`."""
     max_model_len = (
-        config.vllm_engine_kwargs.max_model_len
-        or text_cfg.get("max_position_embeddings")
-        or _UNKNOWN_CONTEXT_LENGTH_CAP
+        _user_context_length(config) or text_cfg.get("max_position_embeddings") or _UNKNOWN_CONTEXT_LENGTH_CAP
     )
     # Larger of 8 full-length requests and 4 pages per slot, capped, then
     # re-floored at one page per slot — that floor is applied after the cap.

--- a/modelship/utils/config_schema.py
+++ b/modelship/utils/config_schema.py
@@ -7,7 +7,7 @@ import os
 from enum import StrEnum
 from typing import TYPE_CHECKING, Any, Literal
 
-from pydantic import BaseModel, ConfigDict, Field, PrivateAttr, field_validator, model_validator
+from pydantic import BaseModel, ConfigDict, Field, PrivateAttr, model_validator
 
 from modelship.logging import get_logger
 from modelship.utils import is_pathy
@@ -71,14 +71,11 @@ class _StrictModel(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
 
-# vLLM's sentinel for "fit the context to what memory profiling leaves".
-AUTO_FIT_MAX_MODEL_LEN = -1
-
-
 class VllmEngineConfig(_StrictModel):
     tensor_parallel_size: int = 1
     pipeline_parallel_size: int = 1
-    max_model_len: int | None = None
+    # Unset means vLLM fits the context to memory; the sentinel for that is derived.
+    max_model_len: int | None = Field(default=None, ge=1)
     dtype: str = "auto"
     tokenizer: str | None = None
     trust_remote_code: bool = False
@@ -106,16 +103,6 @@ class VllmEngineConfig(_StrictModel):
                 if key in data:
                     raise ValueError(f"vllm_engine_kwargs.{key} cannot be set: {reason}")
         return data
-
-    @field_validator("max_model_len")
-    @classmethod
-    def check_max_model_len(cls, value: int | None) -> int | None:
-        if value is not None and value < 1 and value != AUTO_FIT_MAX_MODEL_LEN:
-            raise ValueError(
-                f"vllm_engine_kwargs.max_model_len must be a positive context length or "
-                f"{AUTO_FIT_MAX_MODEL_LEN} (let vLLM fit it to available memory); got {value}."
-            )
-        return value
 
 
 class DiffusersConfig(_StrictModel):

--- a/modelship/utils/config_schema.py
+++ b/modelship/utils/config_schema.py
@@ -7,7 +7,7 @@ import os
 from enum import StrEnum
 from typing import TYPE_CHECKING, Any, Literal
 
-from pydantic import BaseModel, ConfigDict, Field, PrivateAttr, model_validator
+from pydantic import BaseModel, ConfigDict, Field, PrivateAttr, field_validator, model_validator
 
 from modelship.logging import get_logger
 from modelship.utils import is_pathy
@@ -71,6 +71,10 @@ class _StrictModel(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
 
+# vLLM's sentinel for "fit the context to what memory profiling leaves".
+AUTO_FIT_MAX_MODEL_LEN = -1
+
+
 class VllmEngineConfig(_StrictModel):
     tensor_parallel_size: int = 1
     pipeline_parallel_size: int = 1
@@ -102,6 +106,16 @@ class VllmEngineConfig(_StrictModel):
                 if key in data:
                     raise ValueError(f"vllm_engine_kwargs.{key} cannot be set: {reason}")
         return data
+
+    @field_validator("max_model_len")
+    @classmethod
+    def check_max_model_len(cls, value: int | None) -> int | None:
+        if value is not None and value < 1 and value != AUTO_FIT_MAX_MODEL_LEN:
+            raise ValueError(
+                f"vllm_engine_kwargs.max_model_len must be a positive context length or "
+                f"{AUTO_FIT_MAX_MODEL_LEN} (let vLLM fit it to available memory); got {value}."
+            )
+        return value
 
 
 class DiffusersConfig(_StrictModel):

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -718,3 +718,24 @@ class TestPreRayImportChain:
         code = f"import sys; import {module}; print({heavy!r} in sys.modules)"
         result = subprocess.run([sys.executable, "-c", code], capture_output=True, text=True, check=True)
         assert result.stdout.strip() == "False", f"{module} imports {heavy}"
+
+
+class TestMaxModelLenValidation:
+    def _cfg(self, value):
+        from modelship.utils.config_schema import VllmEngineConfig
+
+        return VllmEngineConfig(max_model_len=value)
+
+    def test_a_positive_context_length_is_accepted(self):
+        assert self._cfg(4096).max_model_len == 4096
+
+    def test_the_auto_fit_sentinel_is_accepted(self):
+        from modelship.utils.config_schema import AUTO_FIT_MAX_MODEL_LEN
+
+        assert self._cfg(AUTO_FIT_MAX_MODEL_LEN).max_model_len == AUTO_FIT_MAX_MODEL_LEN
+
+    @pytest.mark.parametrize("value", [0, -2, -7])
+    def test_other_non_positive_values_are_rejected(self, value):
+        # Without this they reach vLLM verbatim and preflight reads them as "unset".
+        with pytest.raises(ValidationError, match="positive context length"):
+            self._cfg(value)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -721,6 +721,9 @@ class TestPreRayImportChain:
 
 
 class TestMaxModelLenValidation:
+    """A context length or nothing. vLLM's -1 auto-fit sentinel is derived by the
+    actor, so preflight's `x or fallback` reads can never see a negative."""
+
     def _cfg(self, value):
         from modelship.utils.config_schema import VllmEngineConfig
 
@@ -729,13 +732,28 @@ class TestMaxModelLenValidation:
     def test_a_positive_context_length_is_accepted(self):
         assert self._cfg(4096).max_model_len == 4096
 
-    def test_the_auto_fit_sentinel_is_accepted(self):
-        from modelship.utils.config_schema import AUTO_FIT_MAX_MODEL_LEN
+    def test_unset_stays_none(self):
+        from modelship.utils.config_schema import VllmEngineConfig
 
-        assert self._cfg(AUTO_FIT_MAX_MODEL_LEN).max_model_len == AUTO_FIT_MAX_MODEL_LEN
+        assert VllmEngineConfig().max_model_len is None
 
-    @pytest.mark.parametrize("value", [0, -2, -7])
-    def test_other_non_positive_values_are_rejected(self, value):
-        # Without this they reach vLLM verbatim and preflight reads them as "unset".
-        with pytest.raises(ValidationError, match="positive context length"):
+    @pytest.mark.parametrize("value", [0, -1, -2, -7])
+    def test_non_positive_values_are_rejected(self, value):
+        with pytest.raises(ValidationError):
             self._cfg(value)
+
+
+class TestResolveMaxModelLen:
+    """The engine-side half of the split: unset becomes vLLM's auto-fit sentinel."""
+
+    def test_a_set_length_passes_through(self):
+        from modelship.infer.vllm.vllm_infer import resolve_max_model_len
+        from modelship.utils.config_schema import VllmEngineConfig
+
+        assert resolve_max_model_len(VllmEngineConfig(max_model_len=8192)) == 8192
+
+    def test_unset_becomes_the_auto_fit_sentinel(self):
+        from modelship.infer.vllm.vllm_infer import _AUTO_FIT_MAX_MODEL_LEN, resolve_max_model_len
+        from modelship.utils.config_schema import VllmEngineConfig
+
+        assert resolve_max_model_len(VllmEngineConfig()) == _AUTO_FIT_MAX_MODEL_LEN

--- a/tests/test_preflight.py
+++ b/tests/test_preflight.py
@@ -1099,6 +1099,17 @@ class TestMlaKvCache:
         row_bytes = mla.num_heads * (mla.qk_nope_head_dim + mla.v_head_dim) * 2
         assert _mla_chunked_prefill_workspace_bytes(_MLA_CFG, config, 2, mla, 1) == 8192 * 16 * row_bytes
 
+    def test_the_auto_fit_sentinel_is_not_read_as_a_context_length(self):
+        # -1 is truthy, so `max_model_len or max_position_embeddings` used to pick it
+        # and 8 * -1 lost to the pages term — an 8x under-sized workspace.
+        from modelship.preflight.vllm import _mla_chunked_prefill_workspace_bytes, _resolve_mla
+
+        mla = _resolve_mla(_MLA_CFG)
+        assert mla is not None
+        unset = _mla_chunked_prefill_workspace_bytes(_MLA_CFG, _make_config(), 2, mla, 1)
+        auto_fit = _make_config(vllm_kwargs={"max_model_len": -1})
+        assert _mla_chunked_prefill_workspace_bytes(_MLA_CFG, auto_fit, 2, mla, 1) == unset
+
     def test_mla_chunked_prefill_workspace_matches_deepseek_v2_lite_oom(self):
         # Anchored against a real DeepSeek-V2-Lite-AWQ OOM: PyTorch reported
         # "Tried to allocate 512.00 MiB" for exactly this buffer.
@@ -1269,6 +1280,19 @@ class TestHybridIntegration:
         assert rec["max_num_seqs"] == 8  # tight RAM → floor
         assert 0 < rec["max_model_len"] < _HYBRID_CFG["max_position_embeddings"]
         assert "gpu_memory_utilization" in rec  # auto path still sizes the fraction
+
+    def test_cpu_hybrid_auto_fit_sentinel_matches_an_unset_context(self, tmp_path):
+        # -1 used to reach _apply_hybrid_fit as the target, which skipped the fit
+        # ladder (budget >= negative target) and spent the whole budget on seqs.
+        snapshot = _write_model_snapshot(tmp_path, config_json=_HYBRID_CFG, weight_bytes=8 * 1024**3)
+        hw = HardwareProfile(ram_bytes=16 * 1024**3, available_ram_bytes=16 * 1024**3)
+        recs = []
+        for kwargs in ({}, {"max_model_len": -1}):
+            cfg = _make_config(resolved_path=str(snapshot), num_gpus=0, vllm_kwargs=kwargs)
+            with patch("modelship.preflight.vllm._resolve_mamba_state", return_value=_mamba_info()):
+                recs.append(VllmPreflight().recommend(cfg, hw))
+        assert recs[0] == recs[1]
+        assert recs[1]["max_num_seqs"] == 8
 
     def test_explicit_gpu_memory_utilization_rejected_on_cpu_hybrid_deploy(self, tmp_path):
         snapshot = _write_model_snapshot(tmp_path, config_json=_HYBRID_CFG, weight_bytes=8 * 1024**3)

--- a/tests/test_preflight.py
+++ b/tests/test_preflight.py
@@ -577,12 +577,10 @@ class TestVllmPreflight:
     _ACTOR_POPPED = frozenset({"gpu_memory_utilization"})
 
     def test_recommendation_survives_the_actor_merge(self, tmp_path):
-        """Every shape whose recommendation reaches VllmEngineConfig, including the
-        two that recommend a derived gpu_memory_utilization (MLA on GPU, and CPU) —
-        a dense GPU deploy is the only one that never emits it."""
+        """Whatever preflight emits must construct a VllmEngineConfig, since the
+        actor revalidates the merged dict. A dense GPU deploy emits nothing at all
+        (see test_context_recommendation_ignores_hardware)."""
         cases = (
-            ("dense/40GiB", _DENSE_CFG, 1, HardwareProfile(gpus=[GPUInfo(0, 40 * 1024**3, "test")])),
-            ("dense/80GiB", _DENSE_CFG, 1, HardwareProfile(gpus=[GPUInfo(0, 80 * 1024**3, "test")])),
             ("mla/40GiB", _MLA_CFG, 1, HardwareProfile(gpus=[GPUInfo(0, 40 * 1024**3, "test")])),
             ("dense/cpu", _DENSE_CFG, 0, HardwareProfile(ram_bytes=64 * 1024**3)),
         )
@@ -620,27 +618,26 @@ class TestVllmPreflight:
         assert "gpu_memory_utilization" not in recs["gpu"]
         assert "gpu_memory_utilization" in recs["cpu"]
 
-    def test_no_gpus_still_recommends_auto_fit(self):
+    def test_no_gpus_leaves_the_context_unset(self):
         # num_gpus > 0 means Ray reserved one, whatever discovery reports.
         cfg = _make_config(resolved_path="/nonexistent")
-        assert VllmPreflight().recommend(cfg, HardwareProfile()) == {"max_model_len": -1}
+        assert VllmPreflight().recommend(cfg, HardwareProfile()) == {}
 
-    def test_no_resolved_path_still_recommends_auto_fit(self):
+    def test_no_resolved_path_leaves_the_context_unset(self):
         cfg = _make_config()
         hw = HardwareProfile(gpus=[GPUInfo(0, 24 * 1024**3, "test")])
-        assert VllmPreflight().recommend(cfg, hw) == {"max_model_len": -1}
+        assert VllmPreflight().recommend(cfg, hw) == {}
 
-    def test_missing_config_json_still_recommends_auto_fit(self, tmp_path):
+    def test_missing_config_json_leaves_the_context_unset(self, tmp_path):
         cfg = _make_config(resolved_path=str(tmp_path))
         hw = HardwareProfile(gpus=[GPUInfo(0, 24 * 1024**3, "test")])
-        assert VllmPreflight().recommend(cfg, hw) == {"max_model_len": -1}
+        assert VllmPreflight().recommend(cfg, hw) == {}
 
-    def test_missing_geometry_still_recommends_auto_fit(self, tmp_path):
-        # Auto-fit reads no geometry.
+    def test_missing_geometry_leaves_the_context_unset(self, tmp_path):
         snapshot = _write_model_snapshot(tmp_path, config_json={"torch_dtype": "bfloat16"}, weight_bytes=1024)
         cfg = _make_config(resolved_path=str(snapshot))
         hw = HardwareProfile(gpus=[GPUInfo(0, 80 * 1024**3, "test")])
-        assert VllmPreflight().recommend(cfg, hw) == {"max_model_len": -1}
+        assert VllmPreflight().recommend(cfg, hw) == {}
 
     def test_context_recommendation_ignores_hardware(self, tmp_path):
         # A tight card, a roomy one and a half-share all get the same answer.
@@ -652,7 +649,7 @@ class TestVllmPreflight:
             )
             for num_gpus, free_gib in ((1, 16), (1, 80), (0.5, 80))
         ]
-        assert recs == [{"max_model_len": -1}] * 3
+        assert recs == [{}] * 3
 
     def test_user_set_max_model_len_is_left_alone(self, tmp_path):
         # The merge discards ours here, so emitting it would only log a warning.
@@ -954,8 +951,7 @@ class TestMultimodal:
         )
         hw = HardwareProfile(gpus=[GPUInfo(0, 24 * 1024**3, "test"), GPUInfo(1, 24 * 1024**3, "test")])
         rec = VllmPreflight().recommend(cfg, hw)
-        assert rec["max_model_len"] == -1
-        # Also recognised as multimodal → max_num_batched_tokens is set.
+        # Recognised as multimodal → max_num_batched_tokens is set.
         assert "max_num_batched_tokens" in rec
 
     @pytest.mark.parametrize(
@@ -1098,17 +1094,6 @@ class TestMlaKvCache:
         config = _make_config(vllm_kwargs={"max_model_len": 1024, "max_num_seqs": 8192})
         row_bytes = mla.num_heads * (mla.qk_nope_head_dim + mla.v_head_dim) * 2
         assert _mla_chunked_prefill_workspace_bytes(_MLA_CFG, config, 2, mla, 1) == 8192 * 16 * row_bytes
-
-    def test_the_auto_fit_sentinel_is_not_read_as_a_context_length(self):
-        # -1 is truthy, so `max_model_len or max_position_embeddings` used to pick it
-        # and 8 * -1 lost to the pages term — an 8x under-sized workspace.
-        from modelship.preflight.vllm import _mla_chunked_prefill_workspace_bytes, _resolve_mla
-
-        mla = _resolve_mla(_MLA_CFG)
-        assert mla is not None
-        unset = _mla_chunked_prefill_workspace_bytes(_MLA_CFG, _make_config(), 2, mla, 1)
-        auto_fit = _make_config(vllm_kwargs={"max_model_len": -1})
-        assert _mla_chunked_prefill_workspace_bytes(_MLA_CFG, auto_fit, 2, mla, 1) == unset
 
     def test_mla_chunked_prefill_workspace_matches_deepseek_v2_lite_oom(self):
         # Anchored against a real DeepSeek-V2-Lite-AWQ OOM: PyTorch reported
@@ -1259,7 +1244,7 @@ class TestHybridIntegration:
         # Same model/GPU but treated as a plain transformer (no state term).
         with patch("modelship.preflight.vllm._resolve_mamba_state", return_value=None):
             dense = VllmPreflight().recommend(cfg, hw)
-        assert hybrid == {"max_model_len": -1, "max_num_seqs": 8}
+        assert hybrid == {"max_num_seqs": 8}
         assert "max_num_seqs" not in dense  # non-hybrid never emits it
 
     def test_gpu_hybrid_seqs_stay_flat_on_a_roomy_card(self, tmp_path):
@@ -1269,7 +1254,7 @@ class TestHybridIntegration:
         hw = HardwareProfile(gpus=[GPUInfo(0, 40 * 1024**3, "test")])
         with patch("modelship.preflight.vllm._resolve_mamba_state", return_value=_mamba_info()):
             rec = VllmPreflight().recommend(cfg, hw)
-        assert rec == {"max_model_len": -1, "max_num_seqs": 8}
+        assert rec == {"max_num_seqs": 8}
 
     def test_cpu_auto_gmu_hybrid_folds_state_into_gmu(self, tmp_path):
         snapshot = _write_model_snapshot(tmp_path, config_json=_HYBRID_CFG, weight_bytes=8 * 1024**3)
@@ -1280,19 +1265,6 @@ class TestHybridIntegration:
         assert rec["max_num_seqs"] == 8  # tight RAM → floor
         assert 0 < rec["max_model_len"] < _HYBRID_CFG["max_position_embeddings"]
         assert "gpu_memory_utilization" in rec  # auto path still sizes the fraction
-
-    def test_cpu_hybrid_auto_fit_sentinel_matches_an_unset_context(self, tmp_path):
-        # -1 used to reach _apply_hybrid_fit as the target, which skipped the fit
-        # ladder (budget >= negative target) and spent the whole budget on seqs.
-        snapshot = _write_model_snapshot(tmp_path, config_json=_HYBRID_CFG, weight_bytes=8 * 1024**3)
-        hw = HardwareProfile(ram_bytes=16 * 1024**3, available_ram_bytes=16 * 1024**3)
-        recs = []
-        for kwargs in ({}, {"max_model_len": -1}):
-            cfg = _make_config(resolved_path=str(snapshot), num_gpus=0, vllm_kwargs=kwargs)
-            with patch("modelship.preflight.vllm._resolve_mamba_state", return_value=_mamba_info()):
-                recs.append(VllmPreflight().recommend(cfg, hw))
-        assert recs[0] == recs[1]
-        assert recs[1]["max_num_seqs"] == 8
 
     def test_explicit_gpu_memory_utilization_rejected_on_cpu_hybrid_deploy(self, tmp_path):
         snapshot = _write_model_snapshot(tmp_path, config_json=_HYBRID_CFG, weight_bytes=8 * 1024**3)


### PR DESCRIPTION
max_model_len: -1 asks vLLM to size the context itself, but two preflight sites read it through `x or fallback`, where -1 is truthy and then poisons arithmetic.

_mla_chunked_prefill_workspace_bytes (GPU): 8 * -1 loses to the 4-pages term, so a DeepSeek-V3-shaped 163840 context sized 8192 rows instead of 65536 — an 8x under-sized workspace, so the MLA gmu haircut is too small and the deploy can OOM. Reachable today: _recommend_gpu always calls _mla_gpu_memory_utilization.

_recommend_cpu_auto_gmu_hybrid: -1 reached _apply_hybrid_fit as the target, where `budget_at_floor >= target_len * kv_per_token` is trivially true for a negative target, so the fit ladder was skipped and the whole budget went to concurrency. On the test hybrid that is max_num_seqs 8 -> 35; a large enough budget reaches vLLM's default and hits the mamba-block ceiling E exists to avoid.

Both now go through _user_context_length, which returns None for the sentinel. _recommend_gpu's own `is None` check was already correct.


